### PR TITLE
fix: lack the rsdoctor types packages

### DIFF
--- a/.changeset/nervous-ducks-judge.md
+++ b/.changeset/nervous-ducks-judge.md
@@ -1,0 +1,8 @@
+---
+'@rsdoctor/graph': patch
+'@rsdoctor/utils': patch
+'@rsdoctor/core': patch
+'@rsdoctor/sdk': patch
+---
+
+fix: lack @rsdoctor/types dependency

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@rsdoctor/graph": "workspace:*",
+    "@rsdoctor/types": "workspace:*",
     "@rsdoctor/sdk": "workspace:*",
     "@rsdoctor/utils": "workspace:*",
     "@rspack/core": "0.3.14",
@@ -62,7 +63,6 @@
   },
   "devDependencies": {
     "@rsdoctor/test-helper": "workspace:*",
-    "@rsdoctor/types": "workspace:*",
     "@types/bytes": "3.1.1",
     "@types/loader-utils": "^2.0.5",
     "@types/lodash": "^4.14.200",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -20,13 +20,13 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@rsdoctor/types": "workspace:*",
     "@rsdoctor/utils": "workspace:*",
     "lodash": "^4.17.21",
     "socket.io": "4.7.2",
     "source-map": "^0.7.4"
   },
   "devDependencies": {
-    "@rsdoctor/types": "workspace:*",
     "@types/body-parser": "1.19.2",
     "@types/estree": "1.0.0",
     "@types/lodash": "^4.14.200",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -23,6 +23,7 @@
     "@rsdoctor/utils": "workspace:*",
     "@rsdoctor/graph": "workspace:*",
     "@rsdoctor/client": "workspace:*",
+    "@rsdoctor/types": "workspace:*",
     "body-parser": "1.20.1",
     "cors": "2.8.5",
     "dayjs": "1.11.6",
@@ -34,7 +35,6 @@
     "tapable": "2.2.1"
   },
   "devDependencies": {
-    "@rsdoctor/types": "workspace:*",
     "@types/body-parser": "1.19.2",
     "@types/cors": "2.8.13",
     "@types/ip": "1.1.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@babel/code-frame": "7.18.6",
+    "@rsdoctor/types": "workspace:*",
     "@types/estree": "1.0.0",
     "acorn": "^8.10.0",
     "acorn-import-assertions": "1.8.0",
@@ -70,7 +71,6 @@
   },
   "devDependencies": {
     "@types/deep-eql": "4.0.0",
-    "@rsdoctor/types": "workspace:*",
     "@types/babel__code-frame": "7.0.3",
     "@types/bytes": "3.1.1",
     "@types/connect": "3.4.35",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,9 @@ importers:
       '@rsdoctor/sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@rsdoctor/types':
+        specifier: workspace:*
+        version: link:../types
       '@rsdoctor/utils':
         specifier: workspace:*
         version: link:../utils
@@ -408,9 +411,6 @@ importers:
       '@rsdoctor/test-helper':
         specifier: workspace:*
         version: link:../test-helper
-      '@rsdoctor/types':
-        specifier: workspace:*
-        version: link:../types
       '@types/bytes':
         specifier: 3.1.1
         version: 3.1.1
@@ -459,6 +459,9 @@ importers:
 
   packages/graph:
     dependencies:
+      '@rsdoctor/types':
+        specifier: workspace:*
+        version: link:../types
       '@rsdoctor/utils':
         specifier: workspace:*
         version: link:../utils
@@ -472,9 +475,6 @@ importers:
         specifier: ^0.7.4
         version: 0.7.4
     devDependencies:
-      '@rsdoctor/types':
-        specifier: workspace:*
-        version: link:../types
       '@types/body-parser':
         specifier: 1.19.2
         version: 1.19.2
@@ -539,6 +539,9 @@ importers:
       '@rsdoctor/graph':
         specifier: workspace:*
         version: link:../graph
+      '@rsdoctor/types':
+        specifier: workspace:*
+        version: link:../types
       '@rsdoctor/utils':
         specifier: workspace:*
         version: link:../utils
@@ -570,9 +573,6 @@ importers:
         specifier: 2.2.1
         version: 2.2.1
     devDependencies:
-      '@rsdoctor/types':
-        specifier: workspace:*
-        version: link:../types
       '@types/body-parser':
         specifier: 1.19.2
         version: 1.19.2
@@ -661,6 +661,9 @@ importers:
       '@babel/code-frame':
         specifier: 7.18.6
         version: 7.18.6
+      '@rsdoctor/types':
+        specifier: workspace:*
+        version: link:../types
       '@types/estree':
         specifier: 1.0.0
         version: 1.0.0
@@ -707,9 +710,6 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
     devDependencies:
-      '@rsdoctor/types':
-        specifier: workspace:*
-        version: link:../types
       '@types/babel__code-frame':
         specifier: 7.0.3
         version: 7.0.3


### PR DESCRIPTION
## Summary
Fix: lack the @rsdoctor/types packages 

## Related Links
#73
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
