### PR TITLE
docs: integrate rsfamily nav icon

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -31,6 +31,7 @@
     "rebranded",
     "rsbuild",
     "rsdoctor",
+    "rsfamily",
     "rslog",
     "rspack",
     "rspress",

--- a/document/package.json
+++ b/document/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "framer-motion": "^10.17.6",
     "react-markdown": "^9.0.1",
+    "rsfamily-nav-icon": "^1.0.1",
     "rspress": "^1.9.2",
     "tailwindcss": "^3.4.0"
   }

--- a/document/theme/index.tsx
+++ b/document/theme/index.tsx
@@ -1,9 +1,9 @@
 import Theme from 'rspress/theme';
 import { HomeLayout } from './pages';
+import { RsfamilyNavIcon } from 'rsfamily-nav-icon';
+import 'rsfamily-nav-icon/dist/index.css';
 
-const Layout = () => (
-  <Theme.Layout />
-);
+const Layout = () => <Theme.Layout beforeNavTitle={<RsfamilyNavIcon />} />;
 
 // eslint-disable-next-line import/export
 export * from 'rspress/theme';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       react-markdown:
         specifier: ^9.0.1
         version: 9.0.1(@types/react@18.2.39)(react@18.2.0)
+      rsfamily-nav-icon:
+        specifier: ^1.0.1
+        version: 1.0.1
       rspress:
         specifier: ^1.9.2
         version: 1.9.2(typescript@5.3.3)(webpack@5.89.0)
@@ -16812,6 +16815,10 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
+
+  /rsfamily-nav-icon@1.0.1:
+    resolution: {integrity: sha512-TJdyzLpFfmEGfJiPAwZqn1TdXwoR7j/Y0j9ejovNk3zABzJ1FRQ6WZl7DVQQTHoJnABlRgXphMuxnAZ2UMePdQ==}
+    dev: false
 
   /rslog@1.1.1:
     resolution: {integrity: sha512-ncYfbtX17x9Irt3gowS8lPdbx6F9WaRpR+5M/OopoCvfUDFDyQGxUEG+cbnjzyZ7PTYmb07Fn+rdGBfWPN2b7w==}


### PR DESCRIPTION
## Summary

Integrate rsfamily nav icon.

![image](https://github.com/web-infra-dev/rsdoctor/assets/7237365/82156ebc-2148-494d-b45d-f97b08e126e2)

## Related Links

https://github.com/rspack-contrib/rsfamily-nav-icon

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
