### PR TITLE
fix(core): proxy-loader behavior is not correct when query is string

### DIFF
--- a/.changeset/tough-pumpkins-cry.md
+++ b/.changeset/tough-pumpkins-cry.md
@@ -1,0 +1,9 @@
+---
+'@rsdoctor/core': patch
+---
+
+fix(proxy-loader): proxy-loader behavior is not correct when query is string
+
+1. fix `this.query` hits `this.resourceQuery` in loader
+
+2. Special handling has been implemented for cases where `rule.use` is a function.

--- a/e2e/cases/doctor-webpack/fixtures/loaders/serialize-resource-query-to-comment.js
+++ b/e2e/cases/doctor-webpack/fixtures/loaders/serialize-resource-query-to-comment.js
@@ -1,0 +1,16 @@
+const { parseQuery } = require('loader-utils');
+
+/**
+ * @type {import("webpack").LoaderDefinitionFunction<{}, {}>}
+ */
+module.exports = function (input) {
+  const res = [input, `// ${JSON.stringify(this.resourceQuery)}`];
+
+  // Based on https://github.com/windicss/windicss-webpack-plugin/blob/main/src/loaders/windicss-template.ts#L42
+  // test the loader query
+  if (this.resourceQuery !== '') {
+    res.push(`// ${JSON.stringify(parseQuery(this.resourceQuery))}`);
+  }
+
+  return res.join('\n');
+};

--- a/e2e/cases/doctor-webpack/loaders/query.test.ts
+++ b/e2e/cases/doctor-webpack/loaders/query.test.ts
@@ -13,14 +13,14 @@ const loaderPath = path.resolve(
 );
 
 async function webpack5(query?: string) {
-  const res = await compileByWebpack5(query ? `${file}${query}` : file, {
+  const res = await compileByWebpack5(file, {
     module: {
       rules: [
         {
           test: /\.js$/,
           use: [
             {
-              loader: loaderPath,
+              loader: query ? `${loaderPath}${query}` : loaderPath,
             },
           ],
         },

--- a/e2e/cases/doctor-webpack/loaders/resourceQuery.test.ts
+++ b/e2e/cases/doctor-webpack/loaders/resourceQuery.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/test';
+import { getSDK } from '@rsdoctor/core/plugins';
+import { compileByWebpack5 } from '@rsbuild/test-helper';
+import os from 'os';
+import path from 'path';
+import qs from 'querystring';
+import { createRsdoctorPlugin } from '../test-utils';
+
+const file = path.resolve(__dirname, '../fixtures/a.js');
+const loaderPath = path.resolve(
+  __dirname,
+  '../fixtures/loaders/serialize-resource-query-to-comment.js',
+);
+
+async function webpack5(resourceQuery?: string) {
+  const res = await compileByWebpack5(
+    resourceQuery ? `${file}${resourceQuery}` : file,
+    {
+      module: {
+        rules: [
+          {
+            test: /\.js$/,
+            use: [
+              {
+                loader: loaderPath,
+              },
+            ],
+          },
+        ],
+      },
+      // @ts-ignore
+      plugins: [createRsdoctorPlugin()],
+    },
+  );
+  return res;
+}
+
+test('webpack5', async () => {
+  const codeTransformed =
+    os.EOL === '\n'
+      ? `console.log('a');\n\n// ${JSON.stringify('')}`
+      : `console.log('a');\r\n\n// ${JSON.stringify('')}`;
+
+  await webpack5();
+
+  const { loader } = getSDK().getStoreData();
+  expect(loader).toHaveLength(1);
+  os.EOL === '\n' &&
+    expect(loader[0].loaders[0].result).toEqual(codeTransformed);
+});
+
+test('this.resourceQuery exists', async () => {
+  // number are not parsed: https://github.com/webpack/loader-utils/tree/v2.0.0-branch#parsequery
+  const resourceQuery = { test: '111' };
+  const resourceQuerystring = `?${qs.stringify(resourceQuery)}`;
+  const codeTransformed =
+    os.EOL === '\n'
+      ? `console.log('a');\n\n// ${JSON.stringify(
+          resourceQuerystring,
+        )}\n// ${JSON.stringify(resourceQuery)}`
+      : `console.log('a');\r\n\n// ${JSON.stringify(
+          resourceQuerystring,
+        )}\n// ${JSON.stringify(resourceQuery)}`;
+
+  await webpack5(resourceQuerystring);
+
+  const { loader } = getSDK().getStoreData();
+  expect(loader).toHaveLength(1);
+  expect(loader[0].loaders[0].result).toEqual(codeTransformed);
+});

--- a/packages/core/tests/build/utils/loader/createLoaderContextTrap.test.ts
+++ b/packages/core/tests/build/utils/loader/createLoaderContextTrap.test.ts
@@ -66,14 +66,16 @@ describe('test utils/loader.ts createLoaderContextTrap()', () => {
       // @ts-ignore
       {
         query: {
-          [Loader.LoaderInternalPropertyName]: { hasOptions: false },
+          [Loader.LoaderInternalPropertyName]: {
+            hasOptions: false,
+            loader: './loader1?xyz=1!loader2!./resource?rrr',
+          },
           a: 1,
         },
-        resourceQuery: '?a=2',
       },
       final,
     );
-    expect(trap2.query).toEqual('?a=2');
+    expect(trap2.query).toEqual('?xyz=1!loader2!./resource?rrr');
   });
 
   it('this.query is neither string or object', () => {


### PR DESCRIPTION
## Summary

There are some problems in the implementation of two places.

1. in loader `this.query` hits `this.resourceQuery`

2. when `rule.use` is a function, rsdoctor cannot handle correctly


## Related Links

closes #155
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
