### PR TITLE
fix(docs): rules page dark mode

### DIFF
--- a/document/src/components/RuleIndex.module.scss
+++ b/document/src/components/RuleIndex.module.scss
@@ -9,9 +9,8 @@
   margin: 0;
   padding: 0;
   position: relative;
-  background: #ffffff;
   border-radius: 8px;
-  border: 1px solid #f0f0f0;
+  border: 1px solid var(--rp-c-divider-light);
   margin-right: 24px;
   font-size: 14px;
 }
@@ -21,7 +20,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 24px;
-  border-bottom: 1px solid #f0f0f0;
+  border-bottom: 1px solid var(--rp-c-divider-light);
   height: 55.5px;
   overflow: hidden;
   font-weight: bold;


### PR DESCRIPTION
## Summary
[Rules page](https://rsdoctor.dev/guide/more/rules) documentation is not accessible on dark mode, updated css to make the page accessible on dark mode(PFA)

**Summary**
Before
<img width="931" alt="Screenshot 2024-02-01 at 10 17 16 PM" src="https://github.com/web-infra-dev/rsdoctor/assets/38801162/d53740ad-53fd-4a37-bf2a-fb7c5903942f">
After
<img width="504" alt="Screenshot 2024-02-01 at 10 17 03 PM" src="https://github.com/web-infra-dev/rsdoctor/assets/38801162/e2ce0a32-d92f-4d62-9b20-92c613189d6c">


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
