### PR TITLE
Release v0.1.1

### DIFF
--- a/.changeset/calm-horses-travel.md
+++ b/.changeset/calm-horses-travel.md
@@ -1,5 +1,0 @@
----
-'@rsdoctor/sdk': patch
----
-
-reuse browser tab on OS X

--- a/.changeset/friendly-years-occur.md
+++ b/.changeset/friendly-years-occur.md
@@ -1,5 +1,0 @@
----
-'@rsdoctor/types': patch
----
-
-fix: rsdoctor types package change the dependency of @rspack/core

--- a/.changeset/light-news-report.md
+++ b/.changeset/light-news-report.md
@@ -1,5 +1,0 @@
----
-'@rsdoctor/utils': patch
----
-
-bundle overall support woff/woff2 files

--- a/.changeset/nine-cheetahs-happen.md
+++ b/.changeset/nine-cheetahs-happen.md
@@ -1,8 +1,0 @@
----
-'@rsdoctor/types': patch
-'@rsdoctor/utils': patch
-'@rsdoctor/core': patch
-'@rsdoctor/sdk': patch
----
-
-feat: integrate rslog as the logger

--- a/.changeset/polite-lamps-itch.md
+++ b/.changeset/polite-lamps-itch.md
@@ -1,7 +1,0 @@
----
-'@rsdoctor/rspack-plugin': patch
-'@rsdoctor/types': patch
-'@rsdoctor/core': patch
----
-
-fix(rspack):optimize the builtin:swc-loader matching calculation

--- a/.changeset/tough-pumpkins-cry.md
+++ b/.changeset/tough-pumpkins-cry.md
@@ -1,9 +1,0 @@
----
-'@rsdoctor/core': patch
----
-
-fix(proxy-loader): proxy-loader behavior is not correct when query is string
-
-1. fix `this.query` hits `this.resourceQuery` in loader
-
-2. Special handling has been implemented for cases where `rule.use` is a function.

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @rsdoctor/components
 
+## 0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/index.html",
   "repository": {
     "type": "git",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @rsdoctor/components
 
+## 0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/components",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "./dist/index.js",
   "license": "MIT",
   "module": "dist/index.js",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @rsdoctor/core
 
+## 0.1.1
+
+### Patch Changes
+
+- e64a428: feat: integrate rslog as the logger
+- 05737c1: fix(rspack):optimize the builtin:swc-loader matching calculation
+- 39e57a2: fix(proxy-loader): proxy-loader behavior is not correct when query is string
+
+  1. fix `this.query` hits `this.resourceQuery` in loader
+  2. Special handling has been implemented for cases where `rule.use` is a function.
+
+- Updated dependencies [da541be]
+- Updated dependencies [89d79bf]
+- Updated dependencies [85da1c2]
+- Updated dependencies [e64a428]
+- Updated dependencies [05737c1]
+  - @rsdoctor/sdk@0.1.1
+  - @rsdoctor/types@0.1.1
+  - @rsdoctor/utils@0.1.1
+  - @rsdoctor/graph@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/graph/CHANGELOG.md
+++ b/packages/graph/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @rsdoctor/graph
 
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies [89d79bf]
+- Updated dependencies [85da1c2]
+- Updated dependencies [e64a428]
+- Updated dependencies [05737c1]
+  - @rsdoctor/types@0.1.1
+  - @rsdoctor/utils@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/graph",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/rspack-plugin/CHANGELOG.md
+++ b/packages/rspack-plugin/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @rsdoctor/rspack-plugin
 
+## 0.1.1
+
+### Patch Changes
+
+- 05737c1: fix(rspack):optimize the builtin:swc-loader matching calculation
+- Updated dependencies [da541be]
+- Updated dependencies [e64a428]
+- Updated dependencies [05737c1]
+- Updated dependencies [39e57a2]
+  - @rsdoctor/sdk@0.1.1
+  - @rsdoctor/core@0.1.1
+  - @rsdoctor/graph@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/rspack-plugin/package.json
+++ b/packages/rspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/rspack-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @rsdoctor/sdk
 
+## 0.1.1
+
+### Patch Changes
+
+- da541be: reuse browser tab on OS X
+- e64a428: feat: integrate rslog as the logger
+- Updated dependencies [89d79bf]
+- Updated dependencies [85da1c2]
+- Updated dependencies [e64a428]
+- Updated dependencies [05737c1]
+  - @rsdoctor/types@0.1.1
+  - @rsdoctor/utils@0.1.1
+  - @rsdoctor/client@0.1.1
+  - @rsdoctor/graph@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/test-helper/CHANGELOG.md
+++ b/packages/test-helper/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @rsdoctor/test-helper
 
+## 0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/test-helper/package.json
+++ b/packages/test-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/test-helper",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The vitest helpers of Rsdoctor.",
   "repository": {
     "type": "git",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rsdoctor/types
 
+## 0.1.1
+
+### Patch Changes
+
+- 89d79bf: fix: rsdoctor types package change the dependency of @rspack/core
+- e64a428: feat: integrate rslog as the logger
+- 05737c1: fix(rspack):optimize the builtin:swc-loader matching calculation
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/types",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @rsdoctor/utils
 
+## 0.1.1
+
+### Patch Changes
+
+- 85da1c2: bundle overall support woff/woff2 files
+- e64a428: feat: integrate rslog as the logger
+- Updated dependencies [89d79bf]
+- Updated dependencies [e64a428]
+- Updated dependencies [05737c1]
+  - @rsdoctor/types@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/utils",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/webpack-plugin/CHANGELOG.md
+++ b/packages/webpack-plugin/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @rsdoctor/webpack-plugin
 
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies [da541be]
+- Updated dependencies [85da1c2]
+- Updated dependencies [e64a428]
+- Updated dependencies [05737c1]
+- Updated dependencies [39e57a2]
+  - @rsdoctor/sdk@0.1.1
+  - @rsdoctor/utils@0.1.1
+  - @rsdoctor/core@0.1.1
+  - @rsdoctor/graph@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/webpack-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",


### PR DESCRIPTION
## What's Changed
### New Features 🎉
- feat: integrate rslog as the logger
### Bug Fixes 🐞
- fix: rsdoctor types package change the dependency of @rspack/core
- fix(rspack):optimize the builtin:swc-loader matching calculation
- fix(proxy-loader): proxy-loader behavior is not correct when query is string
### Other Changes
- reuse browser tab on OS X
- bundle overall support woff/woff2 files