### PR TITLE
fix(graph): dependency has some error

### DIFF
--- a/.changeset/clean-comics-double.md
+++ b/.changeset/clean-comics-double.md
@@ -1,0 +1,5 @@
+---
+'@rsdoctor/graph': patch
+---
+
+fix(graph): dependency has some error

--- a/packages/graph/src/graph/package-graph/graph.ts
+++ b/packages/graph/src/graph/package-graph/graph.ts
@@ -94,9 +94,7 @@ export class PackageGraph implements SDK.PackageGraphInstance {
         }
         current = dirname(current);
         if (readFile) {
-          result =
-            readFile(join(current, 'package.json')) ||
-            PackageUtil.getPackageMetaFromModulePath(file);
+          result = readFile(join(current, 'package.json'));
         }
         if (!readFile) {
           result = PackageUtil.getPackageMetaFromModulePath(file);
@@ -194,10 +192,10 @@ export class PackageGraph implements SDK.PackageGraphInstance {
   getDuplicatePackages(): Package[][] {
     return unionBy(
       Array.from(this._pkgNameMap.values())
-      .map(pkgs => {
-        return unionBy(pkgs, 'version')
-      })
-      .filter((pkgs) => pkgs.length > 1),
+        .map((pkgs) => {
+          return unionBy(pkgs, 'version');
+        })
+        .filter((pkgs) => pkgs.length > 1),
       (pkgs) => pkgs[0].name,
     );
   }


### PR DESCRIPTION
## Summary
fix(graph): dependency has some error

错误原因：
- path 为 `node_modules/.pnpm/@rspack+plugin-react-refresh@0.5.1_react-refresh@0.14.0/node_modules/@rspack/plugin-react-refresh/client` 时，当下是没有 package.json 的，就会走到下面代码的 `PackageUtil.getPackageMetaFromModulePath(file);` 逻辑：
```code
readFile(join(current, 'package.json')) ||
            PackageUtil.getPackageMetaFromModulePath(file);
```
但其实这时应该继续向上一层文件夹去继续递归查找 package.json, 如果没有 readFile 时，才应该使用 `PackageUtil.getPackageMetaFromModulePath(file);` 来获取 npm package 的 name & version。

## Related Links
closes: #136 
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
