### PR TITLE
chore(nx): enable inputs of dependencies

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,17 +1,21 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "namedInputs": {
+    "default": ["{projectRoot}/src/**/*"],
+    "build": [
+      "default",
+      "!{projectRoot}/**/*.{md,mdx}",
+      "{projectRoot}/tsconfig.json",
+      "{projectRoot}/package.json",
+      "{projectRoot}/modern.config.*",
+      "{projectRoot}/scripts/**/*"
+    ]
+  },
   "targetDefaults": {
     "build": {
       "cache": true,
       "dependsOn": ["^build"],
-      "inputs": [
-        "{projectRoot}/src/**/*",
-        "!{projectRoot}/**/*.{md,mdx}",
-        "{projectRoot}/tsconfig.json",
-        "{projectRoot}/package.json",
-        "{projectRoot}/modern.config.*",
-        "{projectRoot}/scripts/**/*"
-      ]
+      "inputs": ["build", "^build"]
     }
   },
   "affected": {


### PR DESCRIPTION
## Summary

enable inputs of a dependencies to ensure the correctness of cache key calculations when topological dependencies exist between packages.

配置 dependencies 的 inputs 以确保包之间存在拓扑依赖关系时缓存影响面计算的正确性

## Related Links

https://nx.dev/recipes/running-tasks/configure-inputs#configure-inputs-for-task-caching

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
