### PR TITLE
docs: use Open Sans as the default font

### DIFF
--- a/document/docs/en/index.md
+++ b/document/docs/en/index.md
@@ -3,8 +3,8 @@ pageType: home
 
 hero:
   name: Rsdoctor
-  text: Analyzer for Rspack and Webpack.
-  tagline: Visualize building behavior
+  text: Analyzer for Rspack & Webpack
+  tagline: Visualize the building process
   actions:
     - theme: brand
       text: Introduction

--- a/document/docs/zh/index.md
+++ b/document/docs/zh/index.md
@@ -3,8 +3,8 @@ pageType: home
 
 hero:
   name: Rsdoctor
-  text: Rspack 和 Webpack 构建分析器
-  tagline: 让构建行为可视化
+  text: Rspack & Webpack 构建分析工具
+  tagline: 让构建过程可视化
   actions:
     - theme: brand
       text: 介绍

--- a/document/package.json
+++ b/document/package.json
@@ -14,13 +14,14 @@
     "@types/react-dom": "^18.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "rspress-plugin-font-open-sans": "^1.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
   },
   "dependencies": {
     "framer-motion": "^10.17.6",
     "react-markdown": "^9.0.1",
-    "rsfamily-nav-icon": "^1.0.1",
+    "rsfamily-nav-icon": "^1.0.2",
     "rspress": "^1.15.0",
     "tailwindcss": "^3.4.0"
   }

--- a/document/rspress.config.ts
+++ b/document/rspress.config.ts
@@ -1,7 +1,9 @@
 import * as path from 'path';
 import { defineConfig } from 'rspress/config';
+import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
 
 export default defineConfig({
+  plugins: [pluginFontOpenSans()],
   root: path.join(__dirname, 'docs'),
   title: 'Rsdoctor',
   description: 'A one-stop build analyzer for Rspack and Webpack.',
@@ -53,13 +55,13 @@ export default defineConfig({
         lang: 'en',
         label: 'English',
         title: 'Rsdoctor',
-        description: 'TAnalyzer for Rspack and Webpack',
+        description: 'Analyzer for Rspack and Webpack',
       },
       {
         lang: 'zh',
         label: '简体中文',
         title: 'Rsdoctor',
-        description: 'Rspack 和 Webpack 项目的构建分析器',
+        description: 'Rspack 和 Webpack 项目的构建分析工具',
       },
     ],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1(@types/react@18.2.39)(react@18.2.0)
       rsfamily-nav-icon:
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: ^1.0.2
+        version: 1.0.2
       rspress:
         specifier: ^1.15.0
         version: 1.15.0(@swc/helpers@0.5.3)(webpack@5.89.0)
@@ -84,6 +84,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      rspress-plugin-font-open-sans:
+        specifier: ^1.0.0
+        version: 1.0.0
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@16.18.66)(typescript@5.3.3)
@@ -13814,7 +13817,6 @@ packages:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: false
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -14905,7 +14907,6 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: false
 
   /preferred-pm@3.1.2:
     resolution: {integrity: sha512-nk7dKrcW8hfCZ4H6klWcdRknBOXWzNQByJ0oJyX97BOupsYD+FzLS4hflgEu/uPUEHZCuRfMxzCBsuWd7OzT8Q==}
@@ -16926,8 +16927,8 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /rsfamily-nav-icon@1.0.1:
-    resolution: {integrity: sha512-TJdyzLpFfmEGfJiPAwZqn1TdXwoR7j/Y0j9ejovNk3zABzJ1FRQ6WZl7DVQQTHoJnABlRgXphMuxnAZ2UMePdQ==}
+  /rsfamily-nav-icon@1.0.2:
+    resolution: {integrity: sha512-gbvJ3wxy1iV6g6T1m/+UIM09t1Sr1ISEBMLUVwPITW+Ckhjuca1xyDh2gbMpYnYX+jXhOSSqA9qtlXpchUOH9Q==}
     dev: false
 
   /rslog@1.2.0:
@@ -16939,6 +16940,10 @@ packages:
     dependencies:
       fs-extra: 11.2.0
     dev: false
+
+  /rspress-plugin-font-open-sans@1.0.0:
+    resolution: {integrity: sha512-4GP0pd7h3W8EWdqE0VkA62nzUJZNy4ZnYK7be8+lOKHQKsQ5nZ+22A/VurNssi1eZFx3kjwbmIuoAkgb5W8S9Q==}
+    dev: true
 
   /rspress@1.15.0(@swc/helpers@0.5.3)(webpack@5.89.0):
     resolution: {integrity: sha512-MN2959YlFFL5HkkPOIYzTKYWTD2bNB8v/y9WWwUekCEeMuNEw0QDkRoHam8mYByBWG9nRB83YIc3yMmLs4FXyg==}
@@ -17754,7 +17759,7 @@ packages:
       '@types/stylis': 4.2.4
       css-to-react-native: 3.2.0
       csstype: 3.1.3
-      postcss: 8.4.31
+      postcss: 8.4.35
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       shallowequal: 1.1.0


### PR DESCRIPTION
## Summary

This PR adds Open Sans as the default font for Rspack website, uses https://github.com/rspack-contrib/rspress-plugin-font-open-sans.

The Node.js new website is using Open Sans and looks good. see http://nodejs.org/

![image](https://github.com/web-infra-dev/rsdoctor/assets/7237365/a30f0f04-aebc-4742-85f3-a9618d8b4acf)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
