### PR TITLE
chore(workflow): let renovate bump package.json

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:recommended"],
+	"extends": ["config:recommended", "schedule:weekly"],
 	"packageRules": [
 		// Use chore as semantic commit type for commit messages
 		{

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,9 @@
 		// Use chore as semantic commit type for commit messages
 		{
 			"matchPackagePatterns": ["*"],
-			"semanticCommitType": "chore"
+			"semanticCommitType": "chore",
+			// always bump package.json
+			"rangeStrategy": "bump"
 		},
 		{
 			"groupName": "rspack",


### PR DESCRIPTION
## Summary

Let renovate bump package.json instead of update lockfile, and trigger updates weekly.

## Related Links

https://docs.renovatebot.com/configuration-options/#rangestrategy

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
