### PR TITLE
chore(CI): run cases in Node 18

### DIFF
--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -25,8 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Rsdoctor need to compat Node.js 16
-        node-version: [16.x] 
+        node-version: [18.x] 
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -65,8 +64,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   strategy:
   #     matrix:
-  #       # Rsdoctor need to compat Node.js 16
-  #       node-version: [16.x] 
+  #       node-version: [18.x] 
 
   #   # Steps represent a sequence of tasks that will be executed as part of the job
   #   steps:


### PR DESCRIPTION
## Summary

Run cases in Node 18, as Node 16 can not be setup correctly.

The same as https://github.com/web-infra-dev/rspress/pull/909

![image](https://github.com/web-infra-dev/rsdoctor/assets/7237365/f9fbab00-15f5-4fd0-a671-9496baed3c9d)

