### PR TITLE
chore(workflow): disable changeset changelog

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.0.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": false,
   "commit": false,
   "linked": [],
   "access": "restricted",


### PR DESCRIPTION
## Summary

Disable changeset changelog, we now use GitHub releases to generate changelog.

same as https://github.com/web-infra-dev/rspress/pull/919