### PR TITLE
fix: make ECMA check log more authentic

### DIFF
--- a/packages/core/src/rules/rules/ecma-version-check/index.ts
+++ b/packages/core/src/rules/rules/ecma-version-check/index.ts
@@ -43,7 +43,7 @@ export const rule = defineRule<typeof title, Config>(() => {
           const assetsName = path.basename(asset.path);
 
           report({
-            message: `The ECMA version of asset ${assetsName} is ${currentVersion}, which is bigger than ${ruleConfig.highestVersion}.`,
+            message: `The ECMA version used in "${assetsName}" is ${currentVersion}, which exceeds the ${ruleConfig.highestVersion} standard.`,
             detail: {
               type: 'link',
             },


### PR DESCRIPTION
## Summary

Make the ECMA check log more authentic, "is bigger than" is not appropriate here.

