### PR TITLE
fix(plugin): the error of analyzing the missing builtin loader when rspack uses dev mode

### DIFF
--- a/packages/rspack-plugin/src/builtinLoaderPlugin.ts
+++ b/packages/rspack-plugin/src/builtinLoaderPlugin.ts
@@ -13,43 +13,53 @@ export class BuiltinLoaderPlugin {
         name: 'BuiltinLoaderPlugin',
       },
       () => {
-        const rules = compiler.options.module.rules as Plugin.RuleSetRule[];
-        const appendRule = (rule: Plugin.RuleSetRule, index: number) => {
-          if ('use' in rule && Array.isArray(rule.use)) {
-            const _builtinRule = rule.use[index] as Plugin.RuleSetRule;
-            const _options =
-              typeof _builtinRule.options === 'string'
-                ? {}
-                : { ..._builtinRule };
-
-            rule.use.splice(index, 0, {
-              loader: path.join(__dirname, './probeLoader.js'),
-              options: {
-                ..._options,
-                type: 'end',
-                builderName: compiler.options.name,
-              },
-            });
-
-            rule.use.splice(index + 2, 0, {
-              loader: path.join(__dirname, './probeLoader.js'),
-              options: {
-                ..._options,
-                type: 'start',
-                builderName: compiler.options.name,
-              },
-            });
-          }
-          return rule;
-        };
-
-        compiler.options.module.rules =
-          Utils.changeBuiltinLoader<Plugin.RuleSetRule>(
-            rules,
-            BuiltinLoaderName,
-            appendRule,
-          ) as RuleSetRules;
+        this.addProbeLoader(compiler);
       },
     );
+
+    compiler.hooks.watchRun.tap(
+      {
+        name: 'BuiltinLoaderPlugin',
+      },
+      () => {
+        this.addProbeLoader(compiler);
+      },
+    );
+  }
+
+  private addProbeLoader(compiler: Compiler) {
+    const rules = compiler.options.module.rules as Plugin.RuleSetRule[];
+    const appendRule = (rule: Plugin.RuleSetRule, index: number) => {
+      if ('use' in rule && Array.isArray(rule.use)) {
+        const _builtinRule = rule.use[index] as Plugin.RuleSetRule;
+        const _options =
+          typeof _builtinRule.options === 'string' ? {} : { ..._builtinRule };
+
+        rule.use.splice(index, 0, {
+          loader: path.join(__dirname, './probeLoader.js'),
+          options: {
+            ..._options,
+            type: 'end',
+            builderName: compiler.options.name,
+          },
+        });
+
+        rule.use.splice(index + 2, 0, {
+          loader: path.join(__dirname, './probeLoader.js'),
+          options: {
+            ..._options,
+            type: 'start',
+            builderName: compiler.options.name,
+          },
+        });
+      }
+      return rule;
+    };
+
+    compiler.options.module.rules = Utils.changeBuiltinLoader(
+      rules,
+      BuiltinLoaderName,
+      appendRule,
+    ) as RuleSetRules;
   }
 }


### PR DESCRIPTION
## Summary
fix(plugin): the error of analyzing the missing builtin loader when rspack uses dev mode

## Related Links
#192
<!--- Provide links of related issues or pages -->
