### PR TITLE
fix: multi plugin rspack output path error

### DIFF
--- a/packages/rspack-plugin/src/plugin.ts
+++ b/packages/rspack-plugin/src/plugin.ts
@@ -11,6 +11,7 @@ import {
   ensureModulesChunksGraphFn,
   InternalBundlePlugin,
   InternalRulesPlugin,
+  getSDK,
 } from '@rsdoctor/core/plugins';
 import type {
   RsdoctorPluginInstance,
@@ -134,7 +135,9 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
       ManifestType.RsdoctorManifestClientRoutes.Overall,
     ]);
 
-    this.sdk.setOutputDir(
+    const _sdk = getSDK(compiler.build.name);
+
+    _sdk.setOutputDir(
       path.resolve(compiler.outputPath, `./${Constants.RsdoctorOutputFolder}`),
     );
     await this.sdk.writeStore();


### PR DESCRIPTION
## Summary
fix: multi plugin rspack output path error, has two .rsdoctor dir.
![img_v3_02a7_f3f18b48-c0fc-416d-bc58-2d2cc930fbeg](https://github.com/web-infra-dev/rsdoctor/assets/18437716/49171e1b-da0e-4d0a-af87-d81d390d25e8)

## Related Links

<!--- Provide links of related issues or pages -->
