### PR TITLE
fix(type): the rule's config types to support for user to set the rule config:

### DIFF
--- a/packages/core/src/inner-plugins/plugins/base.ts
+++ b/packages/core/src/inner-plugins/plugins/base.ts
@@ -13,7 +13,7 @@ export abstract class InternalBasePlugin<T extends Plugin.BaseCompiler>
 
   constructor(
     public readonly scheduler: RsdoctorPluginInstance<
-      Plugin.BaseCompiler,
+      T,
       Linter.ExtendRuleData[]
     >,
   ) {}

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -7,9 +7,8 @@ import type {
 import type { RsdoctorSlaveSDK, RsdoctorWebpackSDK } from '@rsdoctor/sdk';
 import { ChunkGraph, ModuleGraph } from '@rsdoctor/graph';
 import { rules } from '@/rules/rules';
-import { RuleData } from '@rsdoctor/types/dist/linter';
 
-type InternalRules = (typeof rules)[number] & RuleData[];
+type InternalRules = Common.UnionToTuple<(typeof rules)[number]>;
 
 export interface RsdoctorWebpackPluginOptions<
   Rules extends LinterType.ExtendRuleData[],

--- a/packages/rspack-plugin/src/plugin.ts
+++ b/packages/rspack-plugin/src/plugin.ts
@@ -84,6 +84,8 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
       this.done.bind(this, compiler),
     );
 
+    // TODO: to fix the TypeError: Type instantiation is excessively deep and possibly infinite.
+    // @ts-ignore
     new InternalSummaryPlugin<Compiler>(this).apply(compiler);
 
     if (this.options.features.loader && !Loader.isVue(compiler)) {

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -78,7 +78,8 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
     if (!this.outsideInstance) {
       setSDK(this.sdk);
     }
-
+    // TODO: to fix the TypeError: Type instantiation is excessively deep and possibly infinite.
+    // @ts-ignore
     new InternalSummaryPlugin<Compiler>(this).apply(compiler);
 
     if (this.options.features.loader && !Loader.isVue(compiler)) {


### PR DESCRIPTION
## Summary
fix: rule config types. fix the rule's config types to support for user to set the rule config:
```js
new RsdoctorWebpackPlugin({
      linter: {
        level: "Error",
        extends: [],
        rules: {
          "default-import-check": "off",
          "duplicate-package": [
            "Error",
            {
              checkVersion: "minor",
              ignore: ["chalk", "@bable/runtime"],
            },
          ],
        },
      },
    }),

```

## Related Links
[#311](https://github.com/web-infra-dev/rsdoctor/issues/311)
<!--- Provide links of related issues or pages -->
