### PR TITLE
fix: remove use of rspack compiler.compilation api

### DIFF
--- a/packages/rspack-plugin/src/plugin.ts
+++ b/packages/rspack-plugin/src/plugin.ts
@@ -1,4 +1,4 @@
-import type { Compiler, Configuration, RuleSetRule } from '@rspack/core';
+import type { Compiler, Configuration, RuleSetRule, Stats } from '@rspack/core';
 import { ModuleGraph } from '@rsdoctor/graph';
 import { RsdoctorSlaveSDK, RsdoctorWebpackSDK } from '@rsdoctor/sdk';
 import {
@@ -120,8 +120,8 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
     ensureModulesChunksGraphFn(compiler, this);
   }
 
-  public done = async (compiler: Compiler): Promise<void> => {
-    const json = compiler.compilation.getStats().toJson({
+  public done = async (compiler: Compiler, stats: Stats): Promise<void> => {
+    const json = stats.toJson({
       all: false,
       version: true,
       chunks: true,


### PR DESCRIPTION
## Summary

The `compiler.compilation` api will be removed in Rspack `v0.7`. And we can get `stats` from the `compiler.hooks.done` callback parameter, not from the `compiler.compilation` api.



https://www.rspack.dev/api/plugin-api/compiler-hooks#done

## Related Links

https://github.com/web-infra-dev/rspack/pull/6448

<!--- Provide links of related issues or pages -->
