### PR TITLE
docs(CONTRIBUTING.md): fix error description (e2e command)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ In addition to the unit tests, the Rsdoctor also includes end-to-end (E2E) tests
 You can run the `test:e2e` command to run the E2E tests:
 
 ```sh
-pnpm run test:e2e
+pnpm run e2e
 ```
 
 ## Linting


### PR DESCRIPTION
## Summary

When I read  CONTRIBUTING.md, I found the e2e command has some error

In before CONTRIBUTING.md

![image](https://github.com/web-infra-dev/rsdoctor/assets/44056372/d3854a39-d812-47e8-b08e-2938fdfbc7d6)

In fact, the current command to run e2e is

![image](https://github.com/web-infra-dev/rsdoctor/assets/44056372/5b2fcd84-c851-4d0d-a19e-ed39a997fe20)

## Related Links 

None! 
<!--- Provide links of related issues or pages -->
