### PR TITLE
chore(CI): remove release with comment feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,48 +24,6 @@ permissions:
   id-token: write
 
 jobs:
-  issue_comment:
-    name: Release with comment
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '!canary')
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          token: ${{ secrets.REPO_SCOPED_TOKEN }}
-          ref: refs/pull/${{ github.event.issue.number }}/head
-
-      - name: Install Pnpm
-        run: corepack enable
-
-      - name: Setup Node.js 18
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-          cache: 'pnpm'
-
-      - name: Install npm v9
-        run: npm install -g npm@9
-
-      - name: Install Dependencies
-        run: pnpm install
-
-      - name: Release
-        uses: web-infra-dev/actions@v2
-        with:
-          version: 'next'
-          type: 'release'
-          branch: ''
-          tools: 'changeset'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
-          PULL_REQUEST_NUMBER: ${{ github.event.issue.number }}
-          COMMENT: ${{ toJson(github.event.comment) }}
-
   release:
     name: Release
     if: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Summary

release with comment is not security, and we can release canary through [actions - release workflow]

## Related Links

<!--- Provide links of related issues or pages -->
