### PR TITLE
feat: support for  banner plugin.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -81,6 +81,7 @@
     "path-browserify": "1.0.1",
     "semver": "^7.5.4",
     "source-map": "^0.7.4",
+    "webpack-sources": "^3.2.3",
     "webpack-bundle-analyzer": "^4.9.1"
   },
   "devDependencies": {
@@ -96,6 +97,7 @@
     "@types/semver": "^7.5.4",
     "@types/tapable": "2.2.2",
     "@types/webpack": "5.28.0",
+    "@types/webpack-sources": "^3.2.3",
     "babel-loader": "9.1.3",
     "string-loader": "0.0.1",
     "ts-loader": "^9.5.1",

--- a/packages/core/src/inner-plugins/plugins/bundleTagPlugin.ts
+++ b/packages/core/src/inner-plugins/plugins/bundleTagPlugin.ts
@@ -1,9 +1,16 @@
-import { type Compiler } from '@rspack/core';
+import { Plugin } from '@rsdoctor/types';
 import { extname } from 'path';
-import { ConcatSource } from 'webpack-sources';
+import { ConcatSource, Source } from 'webpack-sources';
+import { InternalBasePlugin } from './base';
+import { chalk, logger } from '@rsdoctor/utils/logger';
 
-export class BundleTagPlugin {
-  apply(compiler: Compiler) {
+export class InternalBundleTagPlugin<
+  T extends Plugin.BaseCompiler,
+> extends InternalBasePlugin<T> {
+  public readonly name = 'bundleTag';
+
+  public apply(compiler: Plugin.BaseCompiler) {
+    const supportBannerPlugin = !!this.options.supports?.banner;
     compiler.hooks.compilation.tap('RsdoctorTagBannerPlugin', (compilation) => {
       compilation.hooks.processAssets.tapPromise(
         {
@@ -11,6 +18,20 @@ export class BundleTagPlugin {
           stage: -2000,
         },
         async () => {
+          if (
+            !compilation.options.plugins
+              .map((p) => p && p.constructor.name)
+              .includes('BannerPlugin') &&
+            !supportBannerPlugin
+          ) {
+            return;
+          }
+          logger.info(
+            chalk.bgMagenta(
+              'Rsdoctor BannerTagPlugin has open. Do not use Rsdoctor on production version.',
+            ),
+          );
+
           const chunks = compilation.chunks;
           for (let chunk of chunks) {
             for (const file of chunk.files) {
@@ -20,7 +41,8 @@ export class BundleTagPlugin {
 
               compilation.updateAsset(
                 file,
-                (old) => {
+                // @ts-ignore
+                (old: Source) => {
                   const concatSource = new ConcatSource();
                   let header = "\n console.log('RSDOCTOR_START::');\n";
                   let footer = "\n console.log('RSDOCTOR_END::');\n";
@@ -28,7 +50,6 @@ export class BundleTagPlugin {
                   concatSource.add(header);
                   concatSource.add(old);
                   concatSource.add(footer);
-
                   return concatSource;
                 },
                 () => {},

--- a/packages/core/src/inner-plugins/plugins/index.ts
+++ b/packages/core/src/inner-plugins/plugins/index.ts
@@ -7,3 +7,4 @@ export * from './base';
 export * from './bundle';
 export * from './ensureModulesChunkGraph';
 export * from './rules';
+export * from './bundleTagPlugin';

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -27,6 +27,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     reportCodeType = { noModuleSource: false, noAssetsAndModuleSource: false },
     disableTOSUpload = false,
     innerClientPath = '',
+    supports = { banner: false },
   } = config;
 
   assert(linter && typeof linter === 'object');
@@ -84,13 +85,14 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
       ? reportCodeType.noModuleSource
         ? SDK.ToDataType.Lite
         : reportCodeType.noAssetsAndModuleSource
-        ? SDK.ToDataType.LiteAndNoAsset
-        : SDK.ToDataType.Normal
+          ? SDK.ToDataType.LiteAndNoAsset
+          : SDK.ToDataType.Normal
       : _features.lite
-      ? SDK.ToDataType.Lite
-      : SDK.ToDataType.Normal,
+        ? SDK.ToDataType.Lite
+        : SDK.ToDataType.Normal,
     disableTOSUpload,
     innerClientPath,
+    supports,
   };
 
   return res;

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -46,6 +46,11 @@ export interface RsdoctorWebpackPluginOptions<
   reportCodeType?:
     | { noModuleSource?: boolean; noAssetsAndModuleSource?: boolean }
     | undefined;
+
+  /**
+   * Whether to turn on some characteristic analysis capabilities, such as: the support for the BannerPlugin.
+   */
+  supports?: ISupport | undefined;
   /**
    * control the Rsdoctor upload data to TOS, used by inner-rsdoctor.
    * @default false
@@ -68,6 +73,10 @@ export interface RsdoctorMultiplePluginOptions<
    */
   name?: string;
 }
+
+type ISupport = {
+  banner: boolean;
+};
 
 export interface RsdoctorPluginOptionsNormalized<
   Rules extends LinterType.ExtendRuleData[] = [],

--- a/packages/rspack-plugin/package.json
+++ b/packages/rspack-plugin/package.json
@@ -25,8 +25,7 @@
     "@rsdoctor/utils": "workspace:*",
     "loader-utils": "^2.0.4",
     "lodash": "^4.17.21",
-    "@rsdoctor/types": "workspace:*",
-    "webpack-sources": "^3.2.3"
+    "@rsdoctor/types": "workspace:*"
   },
   "devDependencies": {
     "@rspack/core": "0.6.5",
@@ -34,7 +33,6 @@
     "@types/lodash": "^4.17.0",
     "@types/node": "^16",
     "@types/tapable": "2.2.2",
-    "@types/webpack-sources": "^3.2.3",
     "tslib": "2.4.1",
     "typescript": "^5.2.2"
   },

--- a/packages/rspack-plugin/src/plugin.ts
+++ b/packages/rspack-plugin/src/plugin.ts
@@ -12,6 +12,7 @@ import {
   InternalBundlePlugin,
   InternalRulesPlugin,
   InternalErrorReporterPlugin,
+  InternalBundleTagPlugin,
 } from '@rsdoctor/core/plugins';
 import type {
   RsdoctorPluginInstance,
@@ -30,7 +31,6 @@ import { pluginTapName, pluginTapPostOptions } from './constants';
 import { cloneDeep } from 'lodash';
 import { ProbeLoaderPlugin } from './probeLoaderPlugin';
 import { Loader } from '@rsdoctor/utils/common';
-import { BundleTagPlugin } from './bundleTagPlugin';
 
 export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
   implements RsdoctorPluginInstance<Compiler, Rules>
@@ -103,7 +103,7 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
 
     if (this.options.features.bundle) {
       new InternalBundlePlugin<Compiler>(this).apply(compiler);
-      new BundleTagPlugin().apply(compiler);
+      new InternalBundleTagPlugin<Compiler>(this).apply(compiler);
     }
 
     new InternalRulesPlugin(this).apply(compiler);

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -9,6 +9,7 @@ import {
   makeRulesSerializable,
   normalizeUserConfig,
   setSDK,
+  InternalBundleTagPlugin,
 } from '@rsdoctor/core/plugins';
 import type {
   RsdoctorPluginInstance,
@@ -96,6 +97,7 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
 
     if (this.options.features.bundle) {
       new InternalBundlePlugin<Compiler>(this).apply(compiler);
+      new InternalBundleTagPlugin<Compiler>(this).apply(compiler);
     }
 
     // InternalErrorReporterPlugin must called before InternalRulesPlugin, to avoid treat Rsdoctor's lint warnings/errors as Webpack's warnings/errors.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -657,6 +657,9 @@ importers:
       webpack-bundle-analyzer:
         specifier: ^4.9.1
         version: 4.10.1
+      webpack-sources:
+        specifier: ^3.2.3
+        version: 3.2.3
     devDependencies:
       '@rspack/core':
         specifier: 0.6.5
@@ -694,6 +697,9 @@ importers:
       '@types/webpack':
         specifier: 5.28.0
         version: 5.28.0
+      '@types/webpack-sources':
+        specifier: ^3.2.3
+        version: 3.2.3
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.23.2)(webpack@5.89.0)
@@ -822,9 +828,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      webpack-sources:
-        specifier: ^3.2.3
-        version: 3.2.3
     devDependencies:
       '@rspack/core':
         specifier: 0.6.5
@@ -841,9 +844,6 @@ importers:
       '@types/tapable':
         specifier: 2.2.2
         version: 2.2.2
-      '@types/webpack-sources':
-        specifier: ^3.2.3
-        version: 3.2.3
       tslib:
         specifier: 2.4.1
         version: 2.4.1


### PR DESCRIPTION
## Summary

When BannerPlugin is used in the rspack project to add templates code to the assets, it will cause Rsdoctor's Bundle parsing to fail. In summary, Rsdoctor bundle analysis is required to support Banner Plugin.

### demo
```js
// rspack.config.js

plugins: [
    new rspack.BannerPlugin({
      test: /\.js/,
      banner,
      raw: true,
    }),

]
```


### Turn on InternalBannerPlugin support in two cases:

1. Plugins that detect Compiler options have plug-in name === "BannerPlugin';

2. The second is to open it manually:

```ts

New RsdoctorRspackPlugin (

  Supports: {

    Banner: true

  }
)
```
When InternalBannerPlugin is turned on, do not turn on Rsdoctor in the online template.


## Related Links
 #345
<!--- Provide links of related issues or pages -->
