### PR TITLE
chore: Modified the method of querying the current config

### DIFF
--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -136,10 +136,14 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
       plugins: plugins.map((e) => e?.constructor.name),
     } as unknown as Configuration;
 
-    // save webpack configuration to sdk
+    // @ts-expect-error
+    const rspackVersion = compiler.webpack?.rspackVersion;
+    const webpackVersion = compiler.webpack?.version;
+
+    // save webpack or rspack configuration to sdk
     this.sdk.reportConfiguration({
-      name: 'webpack',
-      version: compiler.webpack?.version || 'unknown',
+      name: rspackVersion ? 'rspack' : 'webpack',
+      version: rspackVersion || webpackVersion || 'unknown',
       config: configuration,
     });
 


### PR DESCRIPTION
## Summary

I think the current way of determining whether to use webpack or rspack is not compatible with most scenarios. For example, in my scenario, I build the project through `@rspack/core`, but in the plugin, I use `@rsdoctor/webpack-plugin`.

Another note is that in this case, a compatible version of webpack in rspack will be used by default. For example, in `@rspack/core@0.7.0`, webpackVersion is "5.75.0". When I saw "5.75.0" on rsdoctor, I was very confused.
## Related Links

