### PR TITLE
perf: optimize the package graph algorithm

### DIFF
--- a/packages/graph/src/graph/package-graph/package.ts
+++ b/packages/graph/src/graph/package-graph/package.ts
@@ -91,12 +91,14 @@ export class Package implements SDK.PackageInstance {
   }
 
   contain(file: string) {
-    const subPath = relative(this.root, file);
+    const ifCotain = file.includes(this.root);
 
     // Non-identical directories.
-    if (subPath.startsWith('..')) {
+    if (!ifCotain) {
       return false;
     }
+
+    const subPath = relative(this.root, file);
 
     // Some modules will be in the node_modules of the current module, and another judgment needs to be made here.
     return !isPackagePath(subPath);


### PR DESCRIPTION
## Summary
perf: optimize the package graph algorithm.

In some repositories, a large amount of time is spent on the createPackageGraph function. It is because the path.relative api. So optimize the algorithm of `contain` function. After optimization, the createPackageGraph function has a 75% improvement in time efficiency.


Before：
![img_v3_02ce_685513b2-a168-4e76-8b80-944b10e92f6g](https://github.com/web-infra-dev/rsdoctor/assets/18437716/1687f3b9-99d0-4096-a72d-0bae4891486e)
<img width="1099" alt="image" src="https://github.com/web-infra-dev/rsdoctor/assets/18437716/d55a3c9d-61c5-40bf-ac39-606c77b539b1">

After:
![img_v3_02cf_948edf00-92e3-413d-a7e5-8fe7d3383a4g](https://github.com/web-infra-dev/rsdoctor/assets/18437716/dfbde76f-0ce9-4fdf-8d12-d5d9668c571a)
<img width="1150" alt="image" src="https://github.com/web-infra-dev/rsdoctor/assets/18437716/62ef57af-b58a-4d8d-94fe-f0a0120e0943">



## Related Links
 closes: #414
<!--- Provide links of related issues or pages -->
