### PR TITLE
fix(server): the client page get error on '/' path

### DIFF
--- a/packages/sdk/src/sdk/server/apis/renderer.ts
+++ b/packages/sdk/src/sdk/server/apis/renderer.ts
@@ -1,13 +1,9 @@
 import { SDK } from '@rsdoctor/types';
-import serve from 'serve-static';
-import path from 'path';
 import { File } from '@rsdoctor/utils/build';
 import { BaseAPI } from './base';
 import { Router } from '../router';
 
 export class RendererAPI extends BaseAPI {
-  private isClientServed = false;
-
   /** sdk manifest api */
   @Router.get(SDK.ServerAPI.API.EntryHtml)
   public async entryHtml(): Promise<
@@ -20,11 +16,7 @@ export class RendererAPI extends BaseAPI {
     const clientHtmlPath = server.innerClientPath
       ? server.innerClientPath
       : require.resolve('@rsdoctor/client');
-    if (!this.isClientServed) {
-      this.isClientServed = true;
-      const clientDistPath = path.resolve(clientHtmlPath, '..');
-      server.app.use(serve(clientDistPath));
-    }
+
     const clientHtml = await File.fse.readFile(clientHtmlPath, 'utf-8');
 
     res.setHeader('Content-Type', 'text/html');

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -1,5 +1,6 @@
 import { Common, SDK, Thirdparty, Client } from '@rsdoctor/types';
 import { Server } from '@rsdoctor/utils/build';
+import serve from 'serve-static';
 import { Bundle } from '@rsdoctor/utils/common';
 import assert from 'assert';
 import bodyParser from 'body-parser';
@@ -11,6 +12,7 @@ import { Router } from './router';
 import * as APIs from './apis';
 import { chalk, logger } from '@rsdoctor/utils/logger';
 import { openBrowser } from '@/sdk/utils/openBrowser';
+import path from 'path';
 export * from './utils';
 
 export class RsdoctorServer implements SDK.RsdoctorServerInstance {
@@ -79,6 +81,11 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
 
     this.app.use(cors());
     this.app.use(bodyParser.json({ limit: '500mb' }));
+    const clientHtmlPath = this._innerClientPath
+      ? this._innerClientPath
+      : require.resolve('@rsdoctor/client');
+    const clientDistPath = path.resolve(clientHtmlPath, '..');
+    this.app.use(serve(clientDistPath));
 
     await this._router.setup();
 
@@ -194,6 +201,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     const relativeUrl = this.getClientUrl(
       ...(args as Parameters<SDK.RsdoctorServerInstance['getClientUrl']>),
     );
+
     const url = `http://${this.host}:${this.port}${relativeUrl}`;
     const localhostUrl = `http://localhost:${this.port}${relativeUrl}`;
     await openBrowser(localhostUrl);


### PR DESCRIPTION
## Summary
fix(server): when no path,the client get error on '/' path.

When the user opens the page without a path path, but only the host and port point to the root path of the server, the page will be "GET ERROR Kawa, and this mr is to fix this problem. |

## Related Links

<!--- Provide links of related issues or pages -->
