### PR TITLE
feat(utils): replace zlib by lz4

### DIFF
--- a/.changeset/popular-ties-wink.md
+++ b/.changeset/popular-ties-wink.md
@@ -1,0 +1,5 @@
+---
+'@rsdoctor/rspack-plugin': patch
+---
+
+feat(utils): replace zlib by lz4

--- a/packages/client/rsbuild.config.ts
+++ b/packages/client/rsbuild.config.ts
@@ -49,6 +49,9 @@ export default defineConfig(({ env }) => {
     },
 
     output: {
+      externals: {
+        lz4: 'window.lz4',
+      },
       distPath: {
         root: path.basename(DistPath),
         js: 'resource/js',
@@ -67,6 +70,25 @@ export default defineConfig(({ env }) => {
         css: false,
       },
       legalComments: 'none',
+      minify: false,
+    },
+    html: {
+      title: 'Rsdoctor',
+      tags: [
+        {
+          tag: 'script',
+          attrs: {
+            src: 'https://cdn.jsdelivr.net/npm/lz4@0.6.5/build/lz4.min.js',
+          },
+          head: false,
+          publicPath: false,
+        },
+        {
+          tag: 'script',
+          children: "window.lz4 = require('lz4')",
+          head: false,
+        },
+      ],
     },
 
     performance: {
@@ -134,10 +156,6 @@ export default defineConfig(({ env }) => {
           ]);
         }
       },
-    },
-
-    html: {
-      title: 'Rsdoctor',
     },
 
     server: {

--- a/packages/components/src/utils/hooks.ts
+++ b/packages/components/src/utils/hooks.ts
@@ -12,6 +12,22 @@ import { setLocaleToStorage } from './storage';
 
 const route = Client.RsdoctorClientRoutes.RuleIndex;
 
+export function decompressText(input: string): string {
+  try {
+    // @ts-ignore
+    if (!window.lz4) return '';
+    const compressedBlock = Buffer.from(input);
+    let uncompressedBlock = Buffer.alloc(input.length * 10);
+    // @ts-ignore
+    const n = window.lz4.decodeBlock(compressedBlock, uncompressedBlock);
+    uncompressedBlock = uncompressedBlock.slice(0, n);
+    return uncompressedBlock.toString('utf-8');
+  } catch (e) {
+    console.log(e);
+    return '';
+  }
+}
+
 export const useI18n: typeof useTranslation = () => {
   const { i18n, ...rest } = useTranslation();
 
@@ -39,7 +55,9 @@ export function useRuleIndexNavigate(code: string, link?: string | undefined) {
   }
 
   return () => {
-    navigate(`${route}?${Rule.RsdoctorRuleClientConstant.UrlQueryForErrorCode}=${code}`);
+    navigate(
+      `${route}?${Rule.RsdoctorRuleClientConstant.UrlQueryForErrorCode}=${code}`,
+    );
   };
 }
 
@@ -55,7 +73,9 @@ export function useLoading(defaultLoading = false) {
   return {
     loading,
     setLoading,
-    async withLoading(func: (...args: unknown[]) => Promise<unknown> | unknown) {
+    async withLoading(
+      func: (...args: unknown[]) => Promise<unknown> | unknown,
+    ) {
       try {
         setLoading(true);
         await func();
@@ -75,7 +95,10 @@ export function useHashByManifest(manifest: Manifest.RsdoctorManifest) {
 }
 
 export function useCloudManifestUrlByManifest(
-  manifest: Manifest.RsdoctorManifest | Manifest.RsdoctorManifestWithShardingFiles | void,
+  manifest:
+    | Manifest.RsdoctorManifest
+    | Manifest.RsdoctorManifestWithShardingFiles
+    | void,
 ) {
   if (!manifest) return;
 }
@@ -94,14 +117,24 @@ function ensurePlainObject<T extends object>(value: T, dfts: T): T {
 export function useChunkGraphByManifest(manifest: Manifest.RsdoctorManifest) {
   const prev = manifest.data.chunkGraph;
   if (typeof prev === 'string') {
-    manifest.data.chunkGraph = JSON.parse(Algorithm.decompressText(prev as string));
+    manifest.data.chunkGraph = JSON.parse(
+      Algorithm.decompressText(prev as string),
+    );
   }
 
-  return ensurePlainObject(manifest.data.chunkGraph, { assets: [], chunks: [], entrypoints: [] });
+  return ensurePlainObject(manifest.data.chunkGraph, {
+    assets: [],
+    chunks: [],
+    entrypoints: [],
+  });
 }
 
-export function useConfigOutputFileNameByManifest(manifest: Manifest.RsdoctorManifest) {
-  if (typeof manifest.data.configs?.[0]?.config?.output?.filename === 'string') {
+export function useConfigOutputFileNameByManifest(
+  manifest: Manifest.RsdoctorManifest,
+) {
+  if (
+    typeof manifest.data.configs?.[0]?.config?.output?.filename === 'string'
+  ) {
     return manifest.data.configs?.[0]?.config?.output?.filename;
   }
   return '';
@@ -110,7 +143,9 @@ export function useConfigOutputFileNameByManifest(manifest: Manifest.RsdoctorMan
 export function useModuleGraphByManifest(manifest: Manifest.RsdoctorManifest) {
   const prev = manifest.data.moduleGraph;
   if (typeof prev === 'string') {
-    manifest.data.moduleGraph = JSON.parse(Algorithm.decompressText(prev as string));
+    manifest.data.moduleGraph = JSON.parse(
+      Algorithm.decompressText(prev as string),
+    );
   }
 
   return ensurePlainObject(manifest.data.moduleGraph, {
@@ -142,7 +177,9 @@ export function useModuleGraph(moduleGraph: SDK.ModuleGraphData) {
 export function usePackageGraphByManifest(manifest: Manifest.RsdoctorManifest) {
   const prev = manifest.data.packageGraph;
   if (typeof prev === 'string') {
-    manifest.data.packageGraph = JSON.parse(Algorithm.decompressText(prev as string));
+    manifest.data.packageGraph = JSON.parse(
+      Algorithm.decompressText(prev as string),
+    );
   }
   return ensurePlainObject(manifest.data.packageGraph, {
     packages: [],
@@ -178,25 +215,35 @@ export function useDuplicatePackagesByManifest(
   return useDuplicatePackagesByErrors(alerts);
 }
 
-export function useCompileAlertsByErrors(errors: Manifest.RsdoctorManifestData['errors']) {
+export function useCompileAlertsByErrors(
+  errors: Manifest.RsdoctorManifestData['errors'],
+) {
   if (isArray(errors)) {
     return errors.filter(
-      (e) => e.category === Rule.RuleMessageCategory.Compile && e.code !== Rule.RuleMessageCodeEnumerated.Overlay,
+      (e) =>
+        e.category === Rule.RuleMessageCategory.Compile &&
+        e.code !== Rule.RuleMessageCodeEnumerated.Overlay,
     );
   }
   return [];
 }
 
-export function useBundleAlertsByErrors(errors: Manifest.RsdoctorManifestData['errors']) {
+export function useBundleAlertsByErrors(
+  errors: Manifest.RsdoctorManifestData['errors'],
+) {
   if (isArray(errors)) {
     return errors.filter(
-      (e) => e.category === Rule.RuleMessageCategory.Bundle && e.code !== Rule.RuleMessageCodeEnumerated.Overlay,
+      (e) =>
+        e.category === Rule.RuleMessageCategory.Bundle &&
+        e.code !== Rule.RuleMessageCodeEnumerated.Overlay,
     );
   }
   return [];
 }
 
-export function useDuplicatePackagesByErrors(errors: Manifest.RsdoctorManifestData['errors']) {
+export function useDuplicatePackagesByErrors(
+  errors: Manifest.RsdoctorManifestData['errors'],
+) {
   return useBundleAlertsByErrors(errors).filter(
     (e) => e.code === Rule.RuleErrorMap.E1001.code,
   ) as Rule.PackageRelationDiffRuleStoreData[];
@@ -204,13 +251,16 @@ export function useDuplicatePackagesByErrors(errors: Manifest.RsdoctorManifestDa
 
 export function useWebpackConfigurationByConfigs(configs: SDK.ConfigData = []) {
   if (isArray(configs)) {
-    return configs.find((e) => (e.name === 'webpack' ||  e.name === 'rspack'));
+    return configs.find((e) => e.name === 'webpack' || e.name === 'rspack');
   }
   return null;
 }
 
 export function useDetectIfCloudIdeEnv() {
-  if (window.location.protocol === 'https:' && window.location.href.indexOf('ide-proxy') > 0) {
+  if (
+    window.location.protocol === 'https:' &&
+    window.location.href.indexOf('ide-proxy') > 0
+  ) {
     return true;
   }
   return false;
@@ -226,7 +276,6 @@ export function useWindowWidth() {
       window.removeEventListener('resize', handleResize);
     };
   }, []);
-  
+
   return windowWidth;
 }
-

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -89,6 +89,7 @@
     "json-stream-stringify": "3.0.1",
     "lines-and-columns": "2.0.4",
     "lodash": "^4.17.21",
+    "lz4": "^0.6.5",
     "rslog": "^1.2.0",
     "strip-ansi": "^6.0.1"
   },
@@ -99,6 +100,7 @@
     "@types/envinfo": "7.8.4",
     "@types/fs-extra": "^11.0.2",
     "@types/lodash": "^4.17.0",
+    "@types/lz4": "^0.6.4",
     "@types/node": "^16",
     "tslib": "2.4.1",
     "typescript": "^5.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1005,6 +1005,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      lz4:
+        specifier: ^0.6.5
+        version: 0.6.5
       rslog:
         specifier: ^1.2.0
         version: 1.2.0
@@ -1030,6 +1033,9 @@ importers:
       '@types/lodash':
         specifier: ^4.17.0
         version: 4.17.0
+      '@types/lz4':
+        specifier: ^0.6.4
+        version: 0.6.4
       '@types/node':
         specifier: ^16
         version: 16.18.66
@@ -8230,6 +8236,12 @@ packages:
   /@types/lodash@4.17.0:
     resolution: {integrity: sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==}
 
+  /@types/lz4@0.6.4:
+    resolution: {integrity: sha512-vvxMIkowyHbY6zkCantyYwAK83N5E04bzFZSPJICG1SDpaL89L7lObs9DhLuhJhXHCQMkjzN3LYoAH6LjfwMFQ==}
+    dependencies:
+      '@types/node': 16.18.66
+    dev: true
+
   /@types/mdast@3.0.15:
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
     dependencies:
@@ -10728,6 +10740,10 @@ packages:
       csv-stringify: 5.6.5
       stream-transform: 2.1.3
     dev: true
+
+  /cuint@0.2.2:
+    resolution: {integrity: sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==}
+    dev: false
 
   /data-uri-to-buffer@3.0.1:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
@@ -14181,6 +14197,17 @@ packages:
     dependencies:
       yallist: 4.0.0
 
+  /lz4@0.6.5:
+    resolution: {integrity: sha512-KSZcJU49QZOlJSItaeIU3p8WoAvkTmD9fJqeahQXNu1iQ/kR0/mQLdbrK8JY9MY8f6AhJoMrihp1nu1xDbscSQ==}
+    engines: {node: '>= 0.10'}
+    requiresBuild: true
+    dependencies:
+      buffer: 5.7.1
+      cuint: 0.2.2
+      nan: 2.20.0
+      xxhashjs: 0.2.2
+    dev: false
+
   /magic-string@0.30.5:
     resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
     engines: {node: '>=12'}
@@ -15259,6 +15286,10 @@ packages:
       object-assign: 4.1.1
       thenify-all: 1.6.0
     dev: true
+
+  /nan@2.20.0:
+    resolution: {integrity: sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==}
+    dev: false
 
   /nano-staged@0.8.0:
     resolution: {integrity: sha512-QSEqPGTCJbkHU2yLvfY6huqYPjdBrOaTMKatO1F8nCSrkQGXeKwtCiCnsdxnuMhbg3DTVywKaeWLGCE5oJpq0g==}
@@ -21327,6 +21358,12 @@ packages:
   /xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
+
+  /xxhashjs@0.2.2:
+    resolution: {integrity: sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==}
+    dependencies:
+      cuint: 0.2.2
+    dev: false
 
   /y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}


### PR DESCRIPTION
## Summary
feat(utils): replace zlib by lz4

Compress text function will consume ~15s by zlib in big repo. So use lz4 to optimize this consume time.
By diff this time data, lz4 will  at least 2x faster than zlib when compress the big data.

## Related Links

<!--- Provide links of related issues or pages -->
