### PR TITLE
fix: change ip to resolve the ip's SSRF risk

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -28,7 +28,6 @@
     "body-parser": "1.20.1",
     "cors": "2.8.5",
     "dayjs": "1.11.6",
-    "ip": "1.1.9",
     "lodash": "^4.17.21",
     "open": "^8.4.0",
     "serve-static": "1.15.0",
@@ -39,7 +38,6 @@
   "devDependencies": {
     "@types/body-parser": "1.19.2",
     "@types/cors": "2.8.13",
-    "@types/ip": "1.1.0",
     "@types/lodash": "^4.17.0",
     "@types/node": "^16",
     "@types/serve-static": "1.15.0",

--- a/packages/sdk/src/sdk/server/apis/project.ts
+++ b/packages/sdk/src/sdk/server/apis/project.ts
@@ -1,7 +1,7 @@
 import { SDK } from '@rsdoctor/types';
-import ip from 'ip';
 import { BaseAPI } from './base';
 import { Router } from '../router';
+import { getLocalIpAddress } from '../utils';
 
 export class ProjectAPI extends BaseAPI {
   @Router.get(SDK.ServerAPI.API.Env)
@@ -11,7 +11,7 @@ export class ProjectAPI extends BaseAPI {
     const { server } = this.ctx;
 
     return {
-      ip: ip.address(),
+      ip: getLocalIpAddress(),
       port: server.port,
     };
   }

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -4,7 +4,6 @@ import serve from 'serve-static';
 import { Bundle } from '@rsdoctor/utils/common';
 import assert from 'assert';
 import bodyParser from 'body-parser';
-import ip from 'ip';
 import cors from 'cors';
 import { PassThrough } from 'stream';
 import { Socket } from './socket';
@@ -13,6 +12,7 @@ import * as APIs from './apis';
 import { chalk, logger } from '@rsdoctor/utils/logger';
 import { openBrowser } from '@/sdk/utils/openBrowser';
 import path from 'path';
+import { getLocalIpAddress } from './utils';
 export * from './utils';
 
 export class RsdoctorServer implements SDK.RsdoctorServerInstance {
@@ -45,7 +45,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
   }
 
   public get host(): string {
-    const host = ip.address();
+    const host = getLocalIpAddress();
     return host;
   }
 

--- a/packages/sdk/src/sdk/server/utils.ts
+++ b/packages/sdk/src/sdk/server/utils.ts
@@ -1,4 +1,5 @@
 import { SDK } from '@rsdoctor/types';
+import os from 'os';
 
 export function getDataByPagination<T>(
   data: T[],
@@ -17,4 +18,16 @@ export function getDataByPagination<T>(
       hasNextPage: page <= 0 ? false : page * pageSize < data.length,
     },
   };
+}
+
+export function getLocalIpAddress() {
+  const interfaces = os.networkInterfaces();
+  for (const iface of Object.values(interfaces)) {
+    for (const alias of iface as os.NetworkInterfaceInfo[]) {
+      if (alias.family === 'IPv4' && !alias.internal) {
+        return alias.address;
+      }
+    }
+  }
+  return '127.0.0.1'; // fallback to localhost if no external IP found
 }

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import ip from 'ip';
 import { Manifest, SDK } from '@rsdoctor/types';
 import { Manifest as ManifestShared } from '@rsdoctor/utils/common';
 
 import { cwd, setupSDK } from '../../utils';
+import { getLocalIpAddress } from '@/sdk/server/utils';
 
 vi.setConfig({ testTimeout: 50000 });
 
@@ -13,7 +13,7 @@ describe('test server/apis/project.ts', () => {
   it(`test api: ${SDK.ServerAPI.API.Env}`, async () => {
     const env = (await target.get(SDK.ServerAPI.API.Env)).toJSON();
 
-    expect(env.ip).toEqual(ip.address());
+    expect(env.ip).toEqual(getLocalIpAddress());
     expect(env.port).toEqual(target.server.port);
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -880,9 +880,6 @@ importers:
       dayjs:
         specifier: 1.11.6
         version: 1.11.6
-      ip:
-        specifier: 1.1.9
-        version: 1.1.9
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -908,9 +905,6 @@ importers:
       '@types/cors':
         specifier: 2.8.13
         version: 2.8.13
-      '@types/ip':
-        specifier: 1.1.0
-        version: 1.1.0
       '@types/lodash':
         specifier: ^4.17.0
         version: 4.17.0
@@ -8179,12 +8173,6 @@ packages:
       '@types/node': 16.18.66
     dev: true
 
-  /@types/ip@1.1.0:
-    resolution: {integrity: sha512-dwNe8gOoF70VdL6WJBwVHtQmAX4RMd62M+mAB9HQFjG1/qiCLM/meRy95Pd14FYBbEDwCq7jgJs89cHpLBu4HQ==}
-    dependencies:
-      '@types/node': 16.18.66
-    dev: true
-
   /@types/istanbul-lib-coverage@2.0.6:
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
     dev: true
@@ -13397,10 +13385,6 @@ packages:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
     dependencies:
       loose-envify: 1.4.0
-
-  /ip@1.1.9:
-    resolution: {integrity: sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==}
-    dev: false
 
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}


### PR DESCRIPTION
## Summary

The ip package through 2.0.1 for Node.js might allow SSRF because some IP addresses, so need upgrade.
https://github.com/advisories/GHSA-2p57-rm9w-gvfp

## Related Links

<!--- Provide links of related issues or pages -->
