### PR TITLE
docs: fix wording of plugin used in rsbuild

### DIFF
--- a/packages/document/docs/zh/guide/start/quick-start-shared.mdx
+++ b/packages/document/docs/zh/guide/start/quick-start-shared.mdx
@@ -25,7 +25,7 @@ module.exports = {
 
 ### Rsbuild 项目
 
-在 `rsbuild.config.ts` 的 [tools.rspack](https://rsbuild.dev/config/tools/rspack) 中初始化 RsdoctorWebpackPlugin 插件，参考：
+在 `rsbuild.config.ts` 的 [tools.rspack](https://rsbuild.dev/config/tools/rspack) 中初始化 RsdoctorRspackPlugin 插件，参考：
 
 ```js title="rsbuild.config.ts"
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';


### PR DESCRIPTION
## Summary

The wording of plugin used in rsbuild should be `RsdoctorRspackPlugin`, but get `RsdoctorWebpackPlugin` in zh doc now.
