### PR TITLE
chore: support rspack 1.x-beta

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -54,6 +54,12 @@
 		"socket.io",
 		"tailwindcss",
 		"antd",
-		"i18next"
+		"i18next",
+		"rc-tree",
+		"rc-dialog",
+		"monaco-editor",
+		"react-i18next",
+		"socket.io-client",
+		"react-router-dom"
 	]
 }

--- a/packages/rspack-plugin/package.json
+++ b/packages/rspack-plugin/package.json
@@ -37,7 +37,7 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@rspack/core": "0.x || 1.x"
+    "@rspack/core": "*"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -32,7 +32,7 @@
     "@rspack/core": "0.7.5"
   },
   "peerDependencies": {
-    "@rspack/core": "0.x || 1.x"
+    "@rspack/core": "*"
   },
   "peerDependenciesMeta": {
     "@rspack/core": {


### PR DESCRIPTION
## Summary
- fix: support rspack 1.x-beta.
- renovate: add ignore npm dependencies.

## Related Links

<!--- Provide links of related issues or pages -->
