### PR TITLE
feat(plugin): add pringLog options to control the terminal log outputs

### DIFF
--- a/examples/rsbuild-minimal/rsbuild.config.ts
+++ b/examples/rsbuild-minimal/rsbuild.config.ts
@@ -27,6 +27,9 @@ export default defineConfig({
             },
           },
           port: 9988,
+          printLog: {
+            serverUrls: false,
+          },
         },
       ]);
     },

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -29,6 +29,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     innerClientPath = '',
     supports = { parseBundle: true, banner: false, generateTileGraph: true },
     port,
+    printLog = { serverUrls: true },
   } = config;
 
   assert(linter && typeof linter === 'object');
@@ -95,6 +96,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     innerClientPath,
     supports,
     port,
+    printLog,
   };
 
   return res;

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -67,6 +67,11 @@ export interface RsdoctorWebpackPluginOptions<
    * The port of the Rsdoctor server.
    */
   port?: number;
+
+  /**
+   * Options to control the log printing.
+   */
+  printLog?: SDK.IPrintLog;
 }
 
 export interface RsdoctorMultiplePluginOptions<

--- a/packages/rspack-plugin/src/plugin.ts
+++ b/packages/rspack-plugin/src/plugin.ts
@@ -69,8 +69,11 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
         name: pluginTapName,
         root: process.cwd(),
         type: this.options.reportCodeType,
-        config: { disableTOSUpload: this.options.disableTOSUpload },
-        innerClientPath: this.options.innerClientPath,
+        config: {
+          disableTOSUpload: this.options.disableTOSUpload,
+          innerClientPath: this.options.innerClientPath,
+          printLog: this.options.printLog,
+        },
       });
     this.outsideInstance = Boolean(this.options.sdkInstance);
     this.modulesGraph = new ModuleGraph();

--- a/packages/sdk/src/sdk/sdk/types.ts
+++ b/packages/sdk/src/sdk/sdk/types.ts
@@ -25,9 +25,7 @@ export interface RsdoctorBuilderSDK extends RsdoctorSDKOptions {
    * port for client server
    */
   port?: number;
-  noServer?: boolean;
   config?: SDK.SDKOptionsType;
-  innerClientPath?: string;
 }
 
 export interface RsdoctorWebpackSDKOptions extends RsdoctorBuilderSDK {}

--- a/packages/sdk/src/sdk/sdk/webpack.ts
+++ b/packages/sdk/src/sdk/sdk/webpack.ts
@@ -8,7 +8,6 @@ import { RsdoctorServer } from '../server';
 import { RsdoctorFakeServer } from '../server/fakeServer';
 import { RsdoctorWebpackSDKOptions } from './types';
 import { SDKCore } from './core';
-import { ResourceLoaderData } from '@rsdoctor/types/dist/sdk';
 
 export class RsdoctorWebpackSDK<
     T extends RsdoctorWebpackSDKOptions = RsdoctorWebpackSDKOptions,
@@ -50,9 +49,12 @@ export class RsdoctorWebpackSDK<
 
   constructor(options: T) {
     super(options);
-    this.server = options.noServer
+    this.server = options.config?.noServer
       ? new RsdoctorFakeServer(this, undefined)
-      : new RsdoctorServer(this, options.port, options.innerClientPath);
+      : new RsdoctorServer(this, options.port, {
+          innerClientPath: options.config?.innerClientPath || '',
+          printServerUrl: options.config?.printLog?.serverUrls,
+        });
     this.type = options.type || SDK.ToDataType.Normal;
     this.extraConfig = options.config;
   }
@@ -217,7 +219,7 @@ export class RsdoctorWebpackSDK<
     this.onDataReport();
   }
 
-  reportLoaderStartOrEnd(data: ResourceLoaderData) {
+  reportLoaderStartOrEnd(data: SDK.ResourceLoaderData) {
     // Just one loader data in array list.
     const _builtinLoader = data.loaders[0];
     if (_builtinLoader.startAt) {

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -13,6 +13,7 @@ import { chalk, logger } from '@rsdoctor/utils/logger';
 import { openBrowser } from '@/sdk/utils/openBrowser';
 import path from 'path';
 import { getLocalIpAddress } from './utils';
+import { isUndefined } from 'lodash';
 export * from './utils';
 
 export class RsdoctorServer implements SDK.RsdoctorServerInstance {
@@ -28,16 +29,21 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
 
   private _innerClientPath: string;
 
+  private _printServerUrl: boolean;
+
   constructor(
     protected sdk: SDK.RsdoctorBuilderSDKInstance,
     port = Server.defaultPort,
-    innerClientPath = '',
+    config?: { innerClientPath?: string; printServerUrl?: boolean },
   ) {
     assert(typeof port === 'number');
     // maybe the port will be rewrite in bootstrap()
     this.port = port;
     this._router = new Router({ sdk, server: this, apis: Object.values(APIs) });
-    this._innerClientPath = innerClientPath;
+    this._innerClientPath = config?.innerClientPath || '';
+    this._printServerUrl = isUndefined(config?.printServerUrl)
+      ? true
+      : config?.printServerUrl;
   }
 
   public get app(): SDK.RsdoctorServerInstance['app'] {
@@ -205,10 +211,12 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     const url = `http://${this.host}:${this.port}${relativeUrl}`;
     const localhostUrl = `http://localhost:${this.port}${relativeUrl}`;
     await openBrowser(localhostUrl);
-    logger.info(`Rsdoctor analyze server running on: ${chalk.cyan(url)}`);
-    logger.info(
-      `Rsdoctor analyze server running on: ${chalk.cyan(localhostUrl)}`,
-    );
+    if (this._printServerUrl) {
+      logger.info(`Rsdoctor analyze server running on: ${chalk.cyan(url)}`);
+      logger.info(
+        `Rsdoctor analyze server running on: ${chalk.cyan(localhostUrl)}`,
+      );
+    }
   }
 
   public sendAPIDataToClient<

--- a/packages/types/src/sdk/instance.ts
+++ b/packages/types/src/sdk/instance.ts
@@ -104,7 +104,16 @@ export interface RsdoctorSDKInstance {
   ): Promise<string>;
 }
 
-export type SDKOptionsType = { disableTOSUpload: boolean };
+export interface IPrintLog {
+  serverUrls: boolean;
+}
+
+export type SDKOptionsType = {
+  disableTOSUpload: boolean;
+  innerClientPath?: string;
+  noServer?: boolean;
+  printLog?: IPrintLog;
+};
 
 /**
  * @deprecated

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -60,8 +60,11 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
         name: pluginTapName,
         root: process.cwd(),
         type: this.options.reportCodeType,
-        config: { disableTOSUpload: this.options.disableTOSUpload },
-        innerClientPath: this.options.innerClientPath,
+        config: {
+          disableTOSUpload: this.options.disableTOSUpload,
+          innerClientPath: this.options.innerClientPath,
+          printLog: this.options.printLog,
+        },
       });
     this.outsideInstance = Boolean(this.options.sdkInstance);
     this.modulesGraph = new ModuleGraph();


### PR DESCRIPTION
## Summary
- feat(plugin): add pringLog options to control the terminal log outputs.
- refactor: the options.config object type.
## Related Links
#427 
<!--- Provide links of related issues or pages -->
