### PR TITLE
[optimize]: the brief page

### DIFF
--- a/packages/components/src/components/CodeViewer/viewer.tsx
+++ b/packages/components/src/components/CodeViewer/viewer.tsx
@@ -8,6 +8,7 @@ import type { editor } from 'monaco-editor';
 import { getOriginalLanguage, getSelectionRange } from '../../utils';
 import { DefaultEditorConfig } from './config';
 import { TextDrawer } from '../TextDrawer';
+import { Empty } from 'antd';
 
 interface CodeViewerProps {
   path: string;
@@ -15,9 +16,17 @@ interface CodeViewerProps {
   defaultLine?: number;
   ranges?: SDK.SourceRange[];
   editorConfig?: editor.IStandaloneEditorConstructionOptions;
+  emptyReason?: string;
 }
 
-export const CodeViewer: React.FC<CodeViewerProps> = ({ content, ranges, path, defaultLine, editorConfig = {} }) => {
+export const CodeViewer: React.FC<CodeViewerProps> = ({
+  content,
+  ranges,
+  path,
+  defaultLine,
+  editorConfig = {},
+  emptyReason,
+}) => {
   const handleEditorDidMount: OnMount = (editor, monaco) => {
     if (isNumber(defaultLine)) {
       editor.revealLine(defaultLine);
@@ -36,7 +45,7 @@ export const CodeViewer: React.FC<CodeViewerProps> = ({ content, ranges, path, d
     }
   };
 
-  return (
+  return content ? (
     <Editor
       theme="vs-dark"
       language={getOriginalLanguage(path)}
@@ -46,6 +55,8 @@ export const CodeViewer: React.FC<CodeViewerProps> = ({ content, ranges, path, d
       options={{ ...DefaultEditorConfig, ...editorConfig }}
       onMount={handleEditorDidMount}
     />
+  ) : (
+    <Empty description={emptyReason} />
   );
 };
 

--- a/packages/components/src/components/Loader/executions.tsx
+++ b/packages/components/src/components/Loader/executions.tsx
@@ -1,14 +1,32 @@
 import { ClockCircleOutlined } from '@ant-design/icons';
 import Editor from '@monaco-editor/react';
 import { Constants, SDK } from '@rsdoctor/types';
-import { Badge, Button, Col, Divider, Empty, Row, Space, Tag, Timeline, Tooltip, Typography } from 'antd';
+import {
+  Badge,
+  Button,
+  Col,
+  Divider,
+  Empty,
+  Row,
+  Space,
+  Tag,
+  Timeline,
+  Tooltip,
+  Typography,
+  Tabs,
+} from 'antd';
 import type { EllipsisConfig } from 'antd/lib/typography/Base';
 import type { TextProps } from 'antd/lib/typography/Text';
 import dayjs from 'dayjs';
 import { endsWith } from 'lodash-es';
-import { PropsWithChildren, useState } from 'react';
+import { PropsWithChildren, useCallback, useState } from 'react';
 import { Size } from '../../constants';
-import { beautifyPath, formatCosts, getModifiedLanguage, useTheme } from '../../utils';
+import {
+  beautifyPath,
+  formatCosts,
+  getModifiedLanguage,
+  useTheme,
+} from '../../utils';
 import { Card } from '../Card';
 import { DiffViewer } from '../CodeViewer';
 import { CodeOpener } from '../Opener';
@@ -53,7 +71,85 @@ const LoaderInfoItem = ({
   );
 };
 
-export const LoaderExecutions = ({ data, cwd, index }: PropsWithChildren<LoaderExecutionsProps>): JSX.Element => {
+const LoaderPropsItem = ({
+  loader,
+  hasError,
+  resource,
+  before,
+  cwd,
+}: {
+  loader: SDK.LoaderTransformData & {
+    costs: number;
+  };
+  hasError: number;
+  resource: SDK.ResourceData;
+  before: string;
+  cwd: string;
+}): JSX.Element => {
+  return (
+    <Card
+      title={'Loader Details'}
+      style={{ border: 'none' }}
+      extra={
+        <Tag icon={<ClockCircleOutlined />} color="default">
+          {dayjs(loader.startAt).format('YYYY-MM-DD HH:mm:ss')}
+        </Tag>
+      }
+    >
+      {loader.isPitch ? <Typography.Text code>pitch</Typography.Text> : null}
+      {loader.isPitch ||
+      hasError ||
+      !endsWith(resource.path, Constants.JSExtension) ? null : (
+        <JSIsEqualTag input={before} output={loader.result || ''} />
+      )}
+      <Space
+        direction="vertical"
+        style={{ padding: Size.BasePadding, wordBreak: 'break-all' }}
+      >
+        <LoaderInfoItem
+          label="file path"
+          value={beautifyPath(resource.path, cwd)}
+          code
+        />
+        <LoaderInfoItem
+          label="resource path"
+          value={<CodeOpener cwd={cwd} url={resource.path} loc="" disabled />}
+        />
+        <LoaderInfoItem
+          label="resource query"
+          value={resource.queryRaw || '-'}
+        />
+        <LoaderInfoItem
+          label="duration"
+          value={formatCosts(loader.costs)}
+          mark
+        />
+        <LoaderInfoItem label="loader name" value={loader.loader} code />
+        <LoaderInfoItem label="loader index" value={`${loader.loaderIndex}`} />
+        <LoaderInfoItem
+          label="loader path"
+          value={<CodeOpener cwd={cwd} url={loader.path} loc="" disabled />}
+        />
+        <LoaderInfoItem
+          label="options"
+          value={JSON.stringify(loader.options || '-')}
+          copyable
+          ellipsis={{
+            rows: 2,
+            expandable: true,
+            symbol: 'more',
+          }}
+        />
+      </Space>
+    </Card>
+  );
+};
+
+export const LoaderExecutions = ({
+  data,
+  cwd,
+  index,
+}: PropsWithChildren<LoaderExecutionsProps>): JSX.Element => {
   const { loaders, resource } = data;
   const [currentIndex, setCurrentIndex] = useState(index || 0);
   const { theme } = useTheme();
@@ -62,12 +158,20 @@ export const LoaderExecutions = ({ data, cwd, index }: PropsWithChildren<LoaderE
   const before = loader.input || '';
   const leftSpan = 5;
   const hasError = loader.errors && loader.errors.length;
+  const [activeKey, setActiveKey] = useState('loaderDetails');
+
+  const onChange = useCallback((key: string) => {
+    setActiveKey(key);
+  }, []);
 
   return (
     <Row style={{ height: '100%' }}>
       <Col
         span={leftSpan}
-        style={{ borderRight: isLight ? `1px solid #f0f0f0` : undefined, padding: Size.BasePadding }}
+        style={{
+          borderRight: isLight ? `1px solid #f0f0f0` : undefined,
+          padding: Size.BasePadding,
+        }}
       >
         <Space direction="vertical" style={{ width: '100%' }}>
           <Title text="Executions" />
@@ -76,7 +180,15 @@ export const LoaderExecutions = ({ data, cwd, index }: PropsWithChildren<LoaderE
               const { loader, isPitch } = e;
               return (
                 <Timeline.Item
-                  dot={isPitch ? <Tag style={{ marginLeft: 1, fontWeight: 500 }}>pitch</Tag> : <ClockCircleOutlined />}
+                  dot={
+                    isPitch ? (
+                      <Tag style={{ marginLeft: 1, fontWeight: 500 }}>
+                        pitch
+                      </Tag>
+                    ) : (
+                      <ClockCircleOutlined />
+                    )
+                  }
                   style={{ paddingBottom: 10, textAlign: 'center' }}
                   key={i}
                 >
@@ -91,8 +203,14 @@ export const LoaderExecutions = ({ data, cwd, index }: PropsWithChildren<LoaderE
                           }}
                           style={{ textAlign: 'left' }}
                         >
-                          <Typography.Text ellipsis style={{ color: 'inherit' }}>
-                            <Typography.Text strong style={{ color: 'inherit' }}>
+                          <Typography.Text
+                            ellipsis
+                            style={{ color: 'inherit' }}
+                          >
+                            <Typography.Text
+                              strong
+                              style={{ color: 'inherit' }}
+                            >
                               {formatCosts(e.costs)}
                             </Typography.Text>
                             <Divider type="vertical" />
@@ -114,124 +232,138 @@ export const LoaderExecutions = ({ data, cwd, index }: PropsWithChildren<LoaderE
         </Space>
       </Col>
       <Col span={24 - leftSpan} style={{ height: '100%' }}>
-        <Col span={24}>
-        <Card
-          title={"Loader Details"}
-          style={{ border: 'none' }}
-          collapsable
-          defaultCollapsed={true}
-          extra={
-            <Tag icon={<ClockCircleOutlined />} color="default">
-              {dayjs(loader.startAt).format('YYYY-MM-DD HH:mm:ss')}
-            </Tag>
-          }
-        >
-          {loader.isPitch ? <Typography.Text code>pitch</Typography.Text> : null}
-          {loader.isPitch || hasError || !endsWith(resource.path, Constants.JSExtension) ? null : (
-            <JSIsEqualTag input={before} output={loader.result || ''} />
-          )}
-          <Space direction="vertical" style={{ padding: Size.BasePadding, wordBreak: 'break-all' }}>
-            <LoaderInfoItem label="file path" value={beautifyPath(resource.path, cwd)} code />
-            <LoaderInfoItem
-              label="resource path"
-              value={<CodeOpener cwd={cwd} url={resource.path} loc="" disabled />}
-            />
-            <LoaderInfoItem label="resource query" value={resource.queryRaw || '-'} />
-            <LoaderInfoItem label="duration" value={formatCosts(loader.costs)} mark />
-            <LoaderInfoItem label="loader name" value={loader.loader} code />
-            <LoaderInfoItem label="loader index" value={`${loader.loaderIndex}`} />
-            <LoaderInfoItem label="loader path" value={<CodeOpener cwd={cwd} url={loader.path} loc="" disabled />} />
-            <LoaderInfoItem
-              label="options"
-              value={JSON.stringify(loader.options || '-')}
-              copyable
-              ellipsis={{
-                rows: 2,
-                expandable: true,
-                symbol: 'more',
-              }}
-            />
-          </Space>
-        </Card>
-        </Col>
-        {hasError ? (
-          <Col span={24} style={{ height: '53%', minHeight: 400 }}>
-            <div
-              style={{
-                padding: Size.BasePadding,
-                borderTop: `1px solid ${isLight ? '#f0f0f0' : 'rgba(253, 253, 253, 0.12)'}`,
-                borderBottom: `1px solid ${isLight ? '#f0f0f0' : 'rgba(253, 253, 253, 0.12)'}`,
-              }}
-            >
-              <Title text={`the error stack of [${loader.loader}] ${loader.isPitch ? 'pitch' : ''}`} />
-            </div>
-            <div style={{ height: '90%' }}>
-              <Editor
-                theme="vs-dark"
-                options={{
-                  readOnly: true,
-                  domReadOnly: true,
-                  fontSize: 14,
-                  minimap: { enabled: false },
-                  lineNumbers: 'off',
-                }}
-                value={loader.errors[0].message}
-                language="javascript"
-              />
-            </div>
-          </Col>
-        ) : (
-          <Col span={24} style={{ height: '53%', minHeight: 400 }}>
-            <div
-              style={{
-                padding: Size.BasePadding,
-                borderTop: `1px solid ${isLight ? '#f0f0f0' : 'rgba(253, 253, 253, 0.12)'}`,
-                borderBottom: `1px solid ${isLight ? '#f0f0f0' : 'rgba(253, 253, 253, 0.12)'}`,
-              }}
-            >
-              <Title text={`the result of [${loader.loader}] ${loader.isPitch ? 'pitch' : ''}`} />
-            </div>
-            {loader.isPitch ? (
-              loader.result ? (
-                <div style={{ height: '90%' }}>
-                  <Editor
-                    theme="vs-dark"
-                    options={{
-                      readOnly: true,
-                      domReadOnly: true,
-                      fontSize: 14,
-                      formatOnType: true,
-                      formatOnPaste: true
-                    }}
-                    value={loader.result}
-                    language={getModifiedLanguage(resource.path)}
-                  />
+        <Tabs
+          type="card"
+          defaultActiveKey="loaderDetails"
+          activeKey={activeKey}
+          items={[
+            {
+              label: 'Loader Props',
+              key: 'loaderProps',
+              children: (
+                <LoaderPropsItem
+                  loader={loader}
+                  hasError={hasError}
+                  resource={resource}
+                  before={before}
+                  cwd={cwd}
+                />
+              ),
+            },
+            {
+              label: 'Loader Details',
+              key: 'loaderDetails',
+              children: (
+                <div style={{ height: '100%' }}>
+                  {hasError ? (
+                    <Col span={24} style={{ height: '53%', minHeight: 400 }}>
+                      <div
+                        style={{
+                          padding: Size.BasePadding,
+                          borderTop: `1px solid ${isLight ? '#f0f0f0' : 'rgba(253, 253, 253, 0.12)'}`,
+                          borderBottom: `1px solid ${isLight ? '#f0f0f0' : 'rgba(253, 253, 253, 0.12)'}`,
+                        }}
+                      >
+                        <Title
+                          text={`the error stack of [${loader.loader}] ${loader.isPitch ? 'pitch' : ''}`}
+                        />
+                      </div>
+                      <div style={{ height: '90%' }}>
+                        <Editor
+                          theme="vs-dark"
+                          options={{
+                            readOnly: true,
+                            domReadOnly: true,
+                            fontSize: 14,
+                            minimap: { enabled: false },
+                            lineNumbers: 'off',
+                          }}
+                          value={loader.errors[0].message}
+                          language="javascript"
+                        />
+                      </div>
+                    </Col>
+                  ) : (
+                    <Col span={24} style={{ height: '53%', minHeight: 400 }}>
+                      <div
+                        style={{
+                          padding: Size.BasePadding,
+                          borderTop: `1px solid ${isLight ? '#f0f0f0' : 'rgba(253, 253, 253, 0.12)'}`,
+                          borderBottom: `1px solid ${isLight ? '#f0f0f0' : 'rgba(253, 253, 253, 0.12)'}`,
+                        }}
+                      >
+                        <Title
+                          text={`the result of [${loader.loader}] ${loader.isPitch ? 'pitch' : ''}`}
+                        />
+                      </div>
+                      {loader.isPitch ? (
+                        loader.result ? (
+                          <div style={{ height: '90%' }}>
+                            <Editor
+                              theme="vs-dark"
+                              options={{
+                                readOnly: true,
+                                domReadOnly: true,
+                                fontSize: 14,
+                                formatOnType: true,
+                                formatOnPaste: true,
+                              }}
+                              value={loader.result}
+                              language={getModifiedLanguage(resource.path)}
+                            />
+                          </div>
+                        ) : (
+                          <Empty
+                            description={
+                              'No loader result. If you use the Brief Mode, there will not have loader results.'
+                            }
+                          />
+                        )
+                      ) : (
+                        <div style={{ minHeight: '700px' }}>
+                          <Row>
+                            <Col
+                              span={12}
+                              style={{
+                                padding: `${Size.BasePadding / 2}px ${Size.BasePadding}px`,
+                              }}
+                            >
+                              <Typography.Text strong>Input</Typography.Text>
+                            </Col>
+                            <Col
+                              span={12}
+                              style={{
+                                padding: `${Size.BasePadding / 2}px ${Size.BasePadding}px`,
+                              }}
+                            >
+                              <Typography.Text strong>Output</Typography.Text>
+                            </Col>
+                          </Row>
+                          <div style={{ height: '40rem' }}>
+                            {!loader.result && !before ? (
+                              <Empty
+                                description={
+                                  'No loader result. If you use the Brief Mode, there will not have loader results.'
+                                }
+                              />
+                            ) : (
+                              <DiffViewer
+                                filepath={resource.path}
+                                before={before}
+                                after={loader.result || ''}
+                              />
+                            )}
+                          </div>
+                        </div>
+                      )}
+                    </Col>
+                  )}
                 </div>
-              ) : (
-                <Empty />
-              )
-            ) : (
-              <div style={{ height: '90%' }}>
-                <Row>
-                  <Col span={12} style={{ padding: `${Size.BasePadding / 2}px ${Size.BasePadding}px` }}>
-                    <Typography.Text strong>Input</Typography.Text>
-                  </Col>
-                  <Col
-                    span={12}
-                    style={{
-                      padding: `${Size.BasePadding / 2}px ${Size.BasePadding}px`,
-                    }}
-                  >
-                    <Typography.Text strong>Output</Typography.Text>
-                  </Col>
-                </Row>
-                <div style={{ height: '86%' }}>
-                  <DiffViewer filepath={resource.path} before={before} after={loader.result || ''} />
-                </div>
-              </div>
-            )}
-          </Col>
-        )}
+              ),
+            },
+          ]}
+          onChange={onChange}
+        />
       </Col>
     </Row>
   );

--- a/packages/components/src/pages/BundleSize/components/asset.tsx
+++ b/packages/components/src/pages/BundleSize/components/asset.tsx
@@ -53,6 +53,13 @@ const tagStyle = {
   margin: 'none',
   marginInlineEnd: 0,
 };
+const EmptyCodeItem = () => (
+  <Empty
+    description={`Do not have the module code.
+  (1) If you use the brief mode, there will not have any codes to show. 
+  (2) If you use lite mode, there will not have source codes.`}
+  />
+);
 
 export const ModuleCodeViewer: React.FC<{ data: SDK.ModuleData }> = ({
   data,
@@ -93,7 +100,7 @@ export const ModuleCodeViewer: React.FC<{ data: SDK.ModuleData }> = ({
               {!source['source'] &&
               !source['parsedSource'] &&
               !source['transformed'] ? (
-                <Empty description="No Code. Rspack builder not support code yet. And if you upload the stats.json to analysis, it's also no code to show." />
+                <EmptyCodeItem />
               ) : (
                 <Card
                   className="code-size-card"
@@ -160,28 +167,33 @@ export const ModuleCodeViewer: React.FC<{ data: SDK.ModuleData }> = ({
                     </Popover>
                   }
                 >
-                  <Editor
-                    theme="vs-dark"
-                    language={getOriginalLanguage(path)}
-                    // eslint-disable-next-line financial/no-float-calculation
-                    height={window.innerHeight / 1.5}
-                    value={
-                      tab
-                        ? source[tab]
-                        : source['parsedSource']
-                          ? source['parsedSource']
-                          : source['source']
-                    }
-                    options={{
-                      readOnly: true,
-                      domReadOnly: true,
-                      fontSize: 14,
-                      wordWrap: 'bounded',
-                      minimap: {
-                        enabled: false,
-                      },
-                    }}
-                  />
+                  {source['parsedSource'] ||
+                  source['source'] ||
+                  source['transformed'] ? (
+                    <Editor
+                      theme="vs-dark"
+                      language={getOriginalLanguage(path)}
+                      height={window.innerHeight / 1.5}
+                      value={
+                        tab
+                          ? source[tab]
+                          : source['parsedSource']
+                            ? source['parsedSource']
+                            : source['source']
+                      }
+                      options={{
+                        readOnly: true,
+                        domReadOnly: true,
+                        fontSize: 14,
+                        wordWrap: 'bounded',
+                        minimap: {
+                          enabled: false,
+                        },
+                      }}
+                    />
+                  ) : (
+                    <EmptyCodeItem />
+                  )}
                 </Card>
               )}
             </>

--- a/packages/components/src/pages/BundleSize/components/index.tsx
+++ b/packages/components/src/pages/BundleSize/components/index.tsx
@@ -161,6 +161,7 @@ export const WebpackModulesOverallBase: React.FC<
               path={path}
               content={content!}
               editorConfig={{ readOnly: false, domReadOnly: false }}
+              emptyReason="Do not have the codes of assets. If you use the lite or brief mode, there will have codes."
             />
           </Space>
         );

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -75,7 +75,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
         ? loaderInterceptorOptions.skipLoaders
         : [],
     },
-    disableClientServer: mode === 'brief' ? true : disableClientServer,
+    disableClientServer,
     sdkInstance,
     /**
      * Data storage is divided into three types:

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -49,7 +49,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
         resolver: features.includes('resolver'),
         bundle: features.includes('bundle'),
         treeShaking: features.includes('treeShaking'),
-        lite: features.includes('lite'),
+        lite: features.includes('lite') || mode === SDK.IMode[SDK.IMode.lite],
       }
     : {
         loader: defaultBoolean(features.loader, true),
@@ -57,7 +57,9 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
         resolver: defaultBoolean(features.resolver, false),
         bundle: defaultBoolean(features.bundle, true),
         treeShaking: defaultBoolean(features.treeShaking, false),
-        lite: defaultBoolean(features.lite, false),
+        lite:
+          defaultBoolean(features.lite, false) ||
+          mode === SDK.IMode[SDK.IMode.lite],
       };
 
   const _linter: RsdoctorPluginOptionsNormalized<Rules>['linter'] = {

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -30,7 +30,7 @@ export interface RsdoctorWebpackPluginOptions<
    * - lite: Refers to the lightweight mode,
    *   which is a lightweight analysis report in the normal mode with the source code display removed.
    */
-  mode?: SDK.IMode;
+  mode?: keyof typeof SDK.IMode;
 
   /**
    * configuration of the interceptor for webpack loaders.

--- a/packages/sdk/src/sdk/sdk/webpack.ts
+++ b/packages/sdk/src/sdk/sdk/webpack.ts
@@ -5,12 +5,14 @@ import { Common, Constants, Manifest, SDK } from '@rsdoctor/types';
 import { File } from '@rsdoctor/utils/build';
 import { RawSourceMap, SourceMapConsumer } from 'source-map';
 import { ModuleGraph, ChunkGraph, PackageGraph } from '@rsdoctor/graph';
-import { chalk, debug } from '@rsdoctor/utils/logger';
+import { debug } from '@rsdoctor/utils/logger';
 import { RsdoctorServer } from '../server';
 import { RsdoctorFakeServer } from '../server/fakeServer';
 import { RsdoctorWebpackSDKOptions } from './types';
 import { SDKCore } from './core';
 import { Algorithm } from '@rsdoctor/utils/common';
+
+export * from '../utils/openBrowser';
 
 export class RsdoctorWebpackSDK<
     T extends RsdoctorWebpackSDKOptions = RsdoctorWebpackSDKOptions,
@@ -186,7 +188,7 @@ export class RsdoctorWebpackSDK<
 
   reportLoader(data: SDK.LoaderData) {
     data.forEach((item) => {
-      if (this.extraConfig?.mode === 'brief') {
+      if (this.extraConfig?.mode === SDK.IMode[SDK.IMode.brief]) {
         item.loaders.forEach((_loader) => {
           _loader.input = '';
           _loader.result = '';
@@ -372,7 +374,7 @@ export class RsdoctorWebpackSDK<
 
   public writeStore(options?: SDK.WriteStoreOptionsType) {
     debug(() => `sdk.writeStore has run.`, '[SDK.writeStore][end]');
-    if (this.extraConfig?.mode === 'brief') {
+    if (this.extraConfig?.mode === SDK.IMode[SDK.IMode.brief]) {
       const clientHtmlPath = this.extraConfig.innerClientPath
         ? this.extraConfig.innerClientPath
         : require.resolve('@rsdoctor/client');
@@ -422,7 +424,7 @@ export class RsdoctorWebpackSDK<
         return ctx._chunkGraph.toData(ctx.type);
       },
       get moduleCodeMap() {
-        if (ctx.extraConfig?.mode === 'brief') {
+        if (ctx.extraConfig?.mode === SDK.IMode[SDK.IMode.brief]) {
           ctx.type = SDK.ToDataType.NoCode;
         }
         return ctx._moduleGraph.toCodeData(ctx.type);
@@ -599,11 +601,6 @@ export class RsdoctorWebpackSDK<
       encoding: 'utf-8',
       flag: 'w',
     });
-
-    console.log(
-      `${chalk.green('[RSDOCTOR] generated brief report')}: ${outputFilePath}`,
-    );
-
     return outputFilePath;
   }
 }

--- a/packages/types/src/sdk/instance.ts
+++ b/packages/types/src/sdk/instance.ts
@@ -19,7 +19,11 @@ import { Hooks } from './hooks';
 
 export type WriteStoreOptionsType = {};
 
-export type IMode = 'brief' | 'lite' | 'normal';
+export enum IMode {
+  brief,
+  lite,
+  normal,
+}
 
 export interface RsdoctorBuilderSDKInstance extends RsdoctorSDKInstance {
   readonly server: RsdoctorServerInstance;
@@ -114,9 +118,10 @@ export interface IPrintLog {
 export type SDKOptionsType = {
   disableTOSUpload: boolean;
   innerClientPath?: string;
+  disableClientServer?: boolean;
   noServer?: boolean;
   printLog?: IPrintLog;
-  mode?: IMode;
+  mode?: keyof typeof IMode;
 };
 
 /**

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -17,10 +17,10 @@ import type {
   RsdoctorWebpackPluginOptions,
 } from '@rsdoctor/core/types';
 import { ChunkGraph, ModuleGraph } from '@rsdoctor/graph';
-import { RsdoctorWebpackSDK } from '@rsdoctor/sdk';
-import { Constants, Linter } from '@rsdoctor/types';
+import { openBrowser, RsdoctorWebpackSDK } from '@rsdoctor/sdk';
+import { Constants, Linter, SDK } from '@rsdoctor/types';
 import { Process } from '@rsdoctor/utils/build';
-import { debug } from '@rsdoctor/utils/logger';
+import { chalk, debug } from '@rsdoctor/utils/logger';
 import { cloneDeep } from 'lodash';
 import path from 'path';
 import type { Compiler, Configuration, RuleSetRule } from 'webpack';
@@ -168,8 +168,19 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
 
     await this._bootstrapTask.then(() => {
       if (!this.options.disableClientServer && !this.browserIsOpened) {
-        this.browserIsOpened = true;
-        this.sdk.server.openClientPage();
+        if (this.options.mode === SDK.IMode[SDK.IMode.brief]) {
+          const outputFilePath = path.resolve(
+            this.sdk.outputDir,
+            'rsdoctor-report.html',
+          );
+          console.log(
+            `${chalk.green('[RSDOCTOR] generated brief report')}: ${outputFilePath}`,
+          );
+          openBrowser(`file:///${outputFilePath}`);
+        } else {
+          this.browserIsOpened = true;
+          this.sdk.server.openClientPage();
+        }
       }
     });
   };


### PR DESCRIPTION
## Summary
Optimize the brief page：
1. optimize the editor when there no codes to show.
2. add open browser on brief mode.
3. support the `mode: lite`.
4. optimize the page of loader analysis
<img width="1368" alt="image" src="https://github.com/user-attachments/assets/4607a357-aa2f-4718-8f33-0147c968f92e">


## Related Links

<!--- Provide links of related issues or pages -->
