### PR TITLE
fix(progress): do not abort compilation when emit fails

### DIFF
--- a/packages/core/src/inner-plugins/plugins/progress.ts
+++ b/packages/core/src/inner-plugins/plugins/progress.ts
@@ -1,6 +1,7 @@
 import { SDK } from '@rsdoctor/types';
 import type { Plugin } from '@rsdoctor/types';
 import { InternalBasePlugin } from './base';
+import { debug } from '@rsdoctor/utils/logger';
 
 export class InternalProgressPlugin<
   T extends Plugin.BaseCompilerType<'webpack'>,
@@ -22,13 +23,17 @@ export class InternalProgressPlugin<
           currentProgress.message = msg || '';
 
           const api = SDK.ServerAPI.APIExtends.GetCompileProgess;
-          sdk.server.sendAPIDataToClient(api, {
-            req: {
-              api,
-              body: undefined,
-            },
-            res: currentProgress,
-          });
+          try {
+            sdk.server.sendAPIDataToClient(api, {
+              req: {
+                api,
+                body: undefined,
+              },
+              res: currentProgress,
+            });
+          } catch (e: any) {
+            debug(() => e);
+          }
         },
       });
       progress.apply(compiler);


### PR DESCRIPTION
## Summary

Minor fix to innerprogress plugin that prevents whole compilation if sendAPIDataToClient throws.

## Related Links
closes https://github.com/web-infra-dev/rsdoctor/issues/481
<!--- Provide links of related issues or pages -->
