### PR TITLE
Filter out falsey rules

### DIFF
--- a/packages/core/src/build-utils/build/utils/loader.ts
+++ b/packages/core/src/build-utils/build/utils/loader.ts
@@ -88,7 +88,7 @@ export function mapEachRules<T extends Plugin.BuildRuleSetRule>(
   rules: T[],
   callback: (rule: T) => T,
 ): T[] {
-  return rules.map((rule) => {
+  return rules.filter(Boolean).map((rule) => {
     if (typeof rule === 'string') {
       return callback({
         loader: rule,


### PR DESCRIPTION
## Summary

I have code like this that fails when adding rsdoctor
```
rules: [
  enableThing && new Plugin()
]
```


error message:
```
TypeError: Cannot use 'in' operator to search for 'rules' in false
     at /Users/nick.bolles/Code/app/node_modules/@rsdoctor/core/dist/build-utils/build/utils/loader.js:145:17
     at Array.map (<anonymous>)
     at Object.mapEachRules (/Users/nick.bolles/Code/app/node_modules/@rsdoctor/core/dist/build-utils/build/utils/loader.js:92:16)
     at interceptLoader (/Users/nick.bolles/Code/app/node_modules/@rsdoctor/core/dist/inner-plugins/utils/loader.js:110:29)
     at InternalLoaderPlugin.getInterceptRules (/Users/nick.bolles/Code/app/node_modules/@rsdoctor/core/dist/inner-plugins/plugins/loader.js:147:45)
     at InternalLoaderPlugin.afterPlugins (/Users/nick.bolles/Code/app/node_modules/@rsdoctor/core/dist/inner-plugins/plugins/loader.js:47:44)
     at Hook.eval (eval at create (/Users/nick.bolles/Code/app/node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:11:1)
     at Hook.CALL_DELEGATE [as _call] (/Users/nick.bolles/Code/app/node_modules/tapable/lib/Hook.js:14:14)
     at WebpackOptionsApply.process (/Users/nick.bolles/Code/app/node_modules/webpack/lib/WebpackOptionsApply.js:696:31)
     at createCompiler (/Users/nick.bolles/Code/app/node_modules/webpack/lib/webpack.js:85:28)
```


## Related Links

<!--- Provide links of related issues or pages -->
