### PR TITLE
perf(deps): remove `webpack-sources` to reduce dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,8 +80,7 @@
     "path-browserify": "1.0.1",
     "semver": "^7.6.3",
     "source-map": "^0.7.4",
-    "webpack-bundle-analyzer": "^4.10.2",
-    "webpack-sources": "^3.2.3"
+    "webpack-bundle-analyzer": "^4.10.2"
   },
   "devDependencies": {
     "@rspack/core": "0.7.5",
@@ -93,7 +92,6 @@
     "@types/path-browserify": "1.0.3",
     "@types/semver": "^7.5.8",
     "@types/tapable": "2.2.7",
-    "@types/webpack-sources": "^3.2.3",
     "babel-loader": "9.1.3",
     "string-loader": "0.0.1",
     "ts-loader": "^9.5.1",

--- a/packages/core/src/inner-plugins/plugins/bundleTagPlugin.ts
+++ b/packages/core/src/inner-plugins/plugins/bundleTagPlugin.ts
@@ -2,7 +2,6 @@ import { Plugin } from '@rsdoctor/types';
 import { extname } from 'path';
 import { InternalBasePlugin } from './base';
 import { chalk, logger } from '@rsdoctor/utils/logger';
-import type { sources } from 'webpack';
 
 export class InternalBundleTagPlugin<
   T extends Plugin.BaseCompiler,
@@ -45,8 +44,7 @@ export class InternalBundleTagPlugin<
 
                 compilation.updateAsset(
                   file,
-                  // @ts-ignore
-                  (old: sources.Source) => {
+                  (old) => {
                     const concatSource = new ConcatSource();
                     let header = "\n console.log('RSDOCTOR_START::');\n";
                     let footer = "\n console.log('RSDOCTOR_END::');\n";

--- a/packages/core/src/inner-plugins/plugins/bundleTagPlugin.ts
+++ b/packages/core/src/inner-plugins/plugins/bundleTagPlugin.ts
@@ -1,8 +1,8 @@
 import { Plugin } from '@rsdoctor/types';
 import { extname } from 'path';
-import { ConcatSource, Source } from 'webpack-sources';
 import { InternalBasePlugin } from './base';
 import { chalk, logger } from '@rsdoctor/utils/logger';
+import type { sources } from 'webpack';
 
 export class InternalBundleTagPlugin<
   T extends Plugin.BaseCompiler,
@@ -41,10 +41,12 @@ export class InternalBundleTagPlugin<
                   continue;
                 }
 
+                const { ConcatSource } = compiler.webpack.sources;
+
                 compilation.updateAsset(
                   file,
                   // @ts-ignore
-                  (old: Source) => {
+                  (old: sources.Source) => {
                     const concatSource = new ConcatSource();
                     let header = "\n console.log('RSDOCTOR_START::');\n";
                     let footer = "\n console.log('RSDOCTOR_END::');\n";

--- a/packages/types/src/plugin/baseCompiler.ts
+++ b/packages/types/src/plugin/baseCompiler.ts
@@ -4,6 +4,7 @@ import type {
   Stats,
   StatsError,
   RuleSetRule,
+  Asset,
 } from 'webpack';
 import type {
   Compiler as RspackCompiler,
@@ -11,6 +12,7 @@ import type {
   Stats as RspackStats,
   RuleSetRule as RspackRuleSetRule,
   MultiCompiler,
+  Assets as RspackAssets,
 } from '@rspack/core';
 
 type RspackCompilerWrapper = RspackCompiler &
@@ -33,12 +35,22 @@ type RspackRuleSetRuleWrapper = any extends RspackRuleSetRule
 //   ? never
 //   : (RspackRuleSetRule | '...')[] | RspackRuleSetRules;
 
+type updateAsset = (
+  file: string,
+  newSourceOrFunction: (
+    arg0: Asset['source'] | RspackAssets['source'],
+  ) => Asset['source'] | RspackAssets['source'],
+  assetInfoUpdateOrFunction?: (arg0?: any) => any,
+) => void;
+
 export type BaseCompilerType<T extends 'rspack' | 'webpack' = 'webpack'> =
   T extends 'rspack' ? RspackCompilerWrapper : Compiler;
 export type BaseCompiler = BaseCompilerType | BaseCompilerType<'rspack'>;
 
 export type BaseCompilationType<T extends 'rspack' | 'webpack' = 'webpack'> =
-  T extends 'rspack' ? Compilation : RspackCompilation;
+  T extends 'rspack'
+    ? Compilation & { updateAsset: updateAsset }
+    : RspackCompilation & { updateAsset: updateAsset };
 export type BaseCompilation =
   | BaseCompilationType
   | BaseCompilationType<'rspack'>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -662,9 +662,6 @@ importers:
       webpack-bundle-analyzer:
         specifier: ^4.10.2
         version: 4.10.2
-      webpack-sources:
-        specifier: ^3.2.3
-        version: 3.2.3
     devDependencies:
       '@rspack/core':
         specifier: 0.7.5
@@ -693,9 +690,6 @@ importers:
       '@types/tapable':
         specifier: 2.2.7
         version: 2.2.7
-      '@types/webpack-sources':
-        specifier: ^3.2.3
-        version: 3.2.3
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.25.2)(webpack@5.93.0)
@@ -7368,10 +7362,6 @@ packages:
       '@types/node': 16.18.104
     dev: true
 
-  /@types/source-list-map@0.1.6:
-    resolution: {integrity: sha512-5JcVt1u5HDmlXkwOD2nslZVllBBc7HDuOICfiZah2Z0is8M8g+ddAEawbmd3VjedfDHBzxCaXLs07QEmb7y54g==}
-    dev: true
-
   /@types/styled-components@5.1.34:
     resolution: {integrity: sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==}
     dependencies:
@@ -7401,14 +7391,6 @@ packages:
 
   /@types/url-parse@1.4.11:
     resolution: {integrity: sha512-FKvKIqRaykZtd4n47LbK/W/5fhQQ1X7cxxzG9A48h0BGN+S04NH7ervcCjM8tyR0lyGru83FAHSmw2ObgKoESg==}
-    dev: true
-
-  /@types/webpack-sources@3.2.3:
-    resolution: {integrity: sha512-4nZOdMwSPHZ4pTEZzSp0AsTM4K7Qmu40UKW4tJDiOVs20UzYF9l+qUe4s0ftfN0pin06n+5cWWDJXH+sbhAiDw==}
-    dependencies:
-      '@types/node': 16.18.104
-      '@types/source-list-map': 0.1.6
-      source-map: 0.7.4
     dev: true
 
   /@types/ws@8.5.12:


### PR DESCRIPTION
## Summary

Remove `webpack-sources` to reduce dependencies, both Rspack and webpack support `compiler.webpack.sources`.
