### PR TITLE
docs: no need to override sidebar width

### DIFF
--- a/packages/document/theme/index.css
+++ b/packages/document/theme/index.css
@@ -13,7 +13,6 @@ summary {
   --rp-code-block-bg: rgba(214, 188, 70, 0.05);
   --rp-custom-block-info-bg: rgba(250, 192, 61, 0.05);
   --rp-custom-block-info-border: rgba(250, 192, 61, 0.5);
-  --rp-sidebar-width: 260px;
   --rp-home-hero-name-background: linear-gradient(
     120deg,
     var(--rp-c-brand),


### PR DESCRIPTION
## Summary

- before:

![image](https://github.com/user-attachments/assets/45784139-7a47-4938-993d-017e965eddf7)

- after:

<img width="500" alt="Screenshot 2024-10-08 at 11 02 14" src="https://github.com/user-attachments/assets/b0e2db99-a44d-4e15-910a-3463f3550662">

## Related Links

<!--- Provide links of related issues or pages -->
