### PR TITLE
optimize(client): bundle size page add some infos

### DIFF
--- a/packages/components/src/pages/BundleSize/components/asset.tsx
+++ b/packages/components/src/pages/BundleSize/components/asset.tsx
@@ -81,7 +81,11 @@ export const ModuleCodeViewer: React.FC<{ data: SDK.ModuleData }> = ({
       text=""
       buttonProps={{
         size: 'small',
-        icon: <CodepenCircleOutlined />,
+        icon: (
+          <Popover content="Open the Codes Box">
+            <CodepenCircleOutlined />
+          </Popover>
+        ),
         type: 'default',
       }}
       buttonStyle={{ padding: `0 4px` }}
@@ -488,14 +492,16 @@ export const AssetDetail: React.FC<{
                 <Tag color="green">concatenated</Tag>
               </Tooltip>
             ) : null}
-            <Button
-              size="small"
-              icon={<DeploymentUnitOutlined />}
-              onClick={() => {
-                setModuleJumpList([mod.id]);
-                setShow(true);
-              }}
-            />
+            <Popover content="Open the Module Graph Box">
+              <Button
+                size="small"
+                icon={<DeploymentUnitOutlined />}
+                onClick={() => {
+                  setModuleJumpList([mod.id]);
+                  setShow(true);
+                }}
+              />
+            </Popover>
             <ModuleCodeViewer data={mod} />
           </Space>
         );
@@ -507,14 +513,24 @@ export const AssetDetail: React.FC<{
             (e) => includeModules.find((m) => m.path === e)!,
           );
           const parsedSize = sumBy(mods, (e) => e.size?.parsedSize || 0);
+          const sourceSize = sumBy(mods, (e) => e.size?.sourceSize || 0);
           return (
             <Space>
               <Typography.Text>{defaultTitle}</Typography.Text>
               {parsedSize > 0 ? (
-                <Tag style={tagStyle} color={'orange'}>
-                  {'Bundled:' + formatSize(parsedSize)}
+                <>
+                  <Tag style={tagStyle} color={'orange'}>
+                    {'Bundled:' + formatSize(parsedSize)}
+                  </Tag>
+                  <Tag style={tagStyle} color={'lime'}>
+                    {'Source:' + formatSize(sourceSize)}
+                  </Tag>
+                </>
+              ) : (
+                <Tag style={tagStyle} color={'lime'}>
+                  {'Source:' + formatSize(sourceSize)}
                 </Tag>
-              ) : null}
+              )}
             </Space>
           );
         }


### PR DESCRIPTION
## Summary
- Add some button's popover.
- Add directory's Source size Tag
![img_v3_02fo_c2c214ef-4171-4373-84ab-0b81d7961e8g](https://github.com/user-attachments/assets/96670c85-2249-4f8b-965d-08a751b4e9a1)

## Related Links

<!--- Provide links of related issues or pages -->
