### PR TITLE
fix(plugin): multi webpack plugin setSDK error

### DIFF
--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -44,8 +44,6 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
 
   public modulesGraph: ModuleGraph;
 
-  private outsideInstance = false;
-
   public _bootstrapTask!: Promise<unknown>;
 
   protected browserIsOpened = false;
@@ -69,7 +67,6 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
           brief: this.options.brief,
         },
       });
-    this.outsideInstance = Boolean(this.options.sdkInstance);
     this.modulesGraph = new ModuleGraph();
     this.chunkGraph = new ChunkGraph();
     this.isRsdoctorPlugin = true;
@@ -86,9 +83,8 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
     }
 
     // External instances do not need to be injected into the global.
-    if (!this.outsideInstance) {
-      setSDK(this.sdk);
-    }
+    setSDK(this.sdk);
+
     // TODO: to fix the TypeError: Type instantiation is excessively deep and possibly infinite.
     // @ts-ignore
     new InternalSummaryPlugin<Compiler>(this).apply(compiler);


### PR DESCRIPTION
## Summary
Multi webpack plugin setSDK error: 
When in multiplugin, there will be more than one sdk, and getsDK will be based on the constructor. Name to match to get sdk, so you can cancel the judgment condition here.


## Related Links

<!--- Provide links of related issues or pages -->
