### PR TITLE
Chalk to picocolors migration

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,8 +33,8 @@
     "@rsdoctor/types": "workspace:*",
     "@rsdoctor/utils": "workspace:*",
     "axios": "^1.7.7",
-    "chalk": "^4.1.2",
     "ora": "^5.4.1",
+    "picocolors": "^1.1.1",
     "tslib": "2.7.0",
     "yargs": "17.7.2"
   },

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -2,7 +2,7 @@ import { Manifest } from '@rsdoctor/utils/common';
 import { Constants, Manifest as ManifestType, SDK } from '@rsdoctor/types';
 import { RsdoctorWebpackSDK } from '@rsdoctor/sdk';
 import ora from 'ora';
-import { cyan, red } from 'chalk';
+import { cyan, red } from 'picocolors';
 import { Command } from '../types';
 import {
   enhanceCommand,

--- a/packages/cli/src/commands/bundle-diff.ts
+++ b/packages/cli/src/commands/bundle-diff.ts
@@ -1,5 +1,5 @@
 import ora from 'ora';
-import { cyan, red } from 'chalk';
+import { cyan, red } from 'picocolors';
 import { Command } from '../types';
 import {
   enhanceCommand,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 import yargs from 'yargs/yargs';
 import { hideBin } from 'yargs/helpers';
-import chalk from 'chalk';
+import { red } from 'picocolors';
 import { Common } from '@rsdoctor/types';
 import { analyze, bundleDiff } from './commands';
 import { Command, CommandContext, GetCommandArgumentsType } from './types';
@@ -68,7 +68,7 @@ export async function execute(
         } catch (error) {
           const { message, stack } = error as Error;
           console.log('');
-          console.error(chalk.red(stack || message));
+          console.error(red(stack || message));
           process.exit(1);
         }
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,12 +439,12 @@ importers:
       axios:
         specifier: ^1.7.7
         version: 1.7.7(debug@4.3.7)
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
       ora:
         specifier: ^5.4.1
         version: 5.4.1
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
       tslib:
         specifier: 2.7.0
         version: 2.7.0
@@ -14045,7 +14045,7 @@ packages:
     resolution: {integrity: sha512-QSEqPGTCJbkHU2yLvfY6huqYPjdBrOaTMKatO1F8nCSrkQGXeKwtCiCnsdxnuMhbg3DTVywKaeWLGCE5oJpq0g==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
-      picocolors: 1.0.1
+      picocolors: 1.1.0
     dev: true
 
   /nanoid@3.3.7:
@@ -14670,11 +14670,11 @@ packages:
       estree-walker: 3.0.3
       is-reference: 3.0.2
 
-  /picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
-
   /picocolors@1.1.0:
     resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
+
+  /picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -15198,7 +15198,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.1.0
+      picocolors: 1.1.1
       source-map-js: 1.2.1
     dev: true
 
@@ -15207,7 +15207,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.1
+      picocolors: 1.1.0
       source-map-js: 1.2.0
 
   /postcss@8.4.45:
@@ -19039,7 +19039,7 @@ packages:
       gzip-size: 6.0.0
       html-escaper: 2.0.2
       opener: 1.5.2
-      picocolors: 1.0.1
+      picocolors: 1.1.0
       sirv: 2.0.4
       ws: 7.5.10
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

> No dependencies.
> 14 times smaller and 2 times faster than chalk.

If the maintainers agree with the migration then I will migrate other packages too

## Related Links

<!--- Provide links of related issues or pages -->
https://github.com/vercel/next.js/pull/70984
https://e18e.dev/blog/august-contributions-showcase.html#picocolors