### PR TITLE
fix: should link to English documentation

### DIFF
--- a/packages/components/src/pages/BundleSize/components/index.tsx
+++ b/packages/components/src/pages/BundleSize/components/index.tsx
@@ -213,9 +213,9 @@ export const WebpackModulesOverallBase: React.FC<
               <Empty
                 description={
                   <div>
-                    Generate Tile Graph is Closed.
-                    <a href="https://rsdoctor.dev/zh/config/options/options#generatetilegraph">
-                      Please check the document.
+                    Tile graph is disabled,{' '}
+                    <a href="https://rsdoctor.dev/config/options/options#generatetilegraph">
+                      see the documentation to learn how to enable.
                     </a>
                   </div>
                 }


### PR DESCRIPTION
## Summary

- The Tile Graph page should link to English documentation.
- Improve the tip.

![image](https://github.com/user-attachments/assets/d3a920b5-47b7-4c69-a542-e4c94ba85031)
