### PR TITLE
chore(deps): bump Rspack and Rsbuild to v1.1

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,15 +15,14 @@
     "vue": "^3.5.12"
   },
   "devDependencies": {
-    "webpack": "^5.95.0",
     "@playwright/test": "1.33.0",
+    "@rsdoctor/cli": "workspace:*",
     "@rsdoctor/core": "workspace:*",
     "@rsdoctor/rspack-plugin": "workspace:*",
     "@rsdoctor/sdk": "workspace:*",
     "@rsdoctor/types": "workspace:*",
     "@rsdoctor/utils": "workspace:*",
     "@rsdoctor/webpack-plugin": "workspace:*",
-    "@rsdoctor/cli": "workspace:*",
     "@rspack/core": "1.0.14",
     "@types/lodash": "^4.17.13",
     "@types/node": "^16",
@@ -32,6 +31,7 @@
     "fast-glob": "^3.3.2",
     "loader-utils": "^2.0.4",
     "playwright": "1.33.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "webpack": "^5.95.0"
   }
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -23,7 +23,7 @@
     "@rsdoctor/types": "workspace:*",
     "@rsdoctor/utils": "workspace:*",
     "@rsdoctor/webpack-plugin": "workspace:*",
-    "@rspack/core": "1.0.14",
+    "@rspack/core": "^1.1.1",
     "@types/lodash": "^4.17.13",
     "@types/node": "^16",
     "@types/react": "^18.3.12",

--- a/examples/modern-minimal/package.json
+++ b/examples/modern-minimal/package.json
@@ -15,9 +15,9 @@
     "react-dom": "^18"
   },
   "devDependencies": {
+    "@modern-js/app-tools": "^2.60.3",
     "@modern-js/runtime": "^2.60.3",
     "@rsdoctor/webpack-plugin": "workspace:*",
-    "@modern-js/app-tools": "^2.60.3",
     "@types/node": "^16",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/examples/multiple-minimal/package.json
+++ b/examples/multiple-minimal/package.json
@@ -16,11 +16,11 @@
   "devDependencies": {
     "@arco-design/web-react": "2.29.2",
     "@arco-plugins/webpack-react": "1.4.9-beta.2",
+    "@rsdoctor/tsconfig": "workspace:*",
+    "@rsdoctor/webpack-plugin": "workspace:*",
     "@types/node": "^16",
     "@types/react": "^18",
     "@types/react-dom": "18.0.8",
-    "@rsdoctor/tsconfig": "workspace:*",
-    "@rsdoctor/webpack-plugin": "workspace:*",
     "css-loader": "6.7.3",
     "eslint": "8.22.0",
     "less-loader": "11.1.0",

--- a/examples/rsbuild-minimal/package.json
+++ b/examples/rsbuild-minimal/package.json
@@ -21,8 +21,8 @@
     "semver7": "npm:semver@7.5.4"
   },
   "devDependencies": {
-    "@rsbuild/core": "0.7.5",
-    "@rsbuild/plugin-react": "0.7.5",
+    "@rsbuild/core": "^1.1.1",
+    "@rsbuild/plugin-react": "^1.0.7",
     "@rsdoctor/core": "workspace:*",
     "@rsdoctor/rspack-plugin": "workspace:*",
     "@types/react": "^18",

--- a/examples/rspack-banner-minimal/package.json
+++ b/examples/rspack-banner-minimal/package.json
@@ -18,7 +18,6 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "tsm": "2.3.0",
     "@rsdoctor/rspack-plugin": "workspace:*",
     "@rspack/cli": "1.0.0",
     "@rspack/core": "1.0.0",
@@ -26,6 +25,7 @@
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
     "react-refresh": "^0.14.0",
+    "tsm": "2.3.0",
     "web-vitals": "^2.1.4"
   },
   "browserslist": {

--- a/examples/rspack-banner-minimal/package.json
+++ b/examples/rspack-banner-minimal/package.json
@@ -19,8 +19,8 @@
   },
   "devDependencies": {
     "@rsdoctor/rspack-plugin": "workspace:*",
-    "@rspack/cli": "1.0.0",
-    "@rspack/core": "1.0.0",
+    "@rspack/cli": "^1.1.1",
+    "@rspack/core": "^1.1.1",
     "@rspack/plugin-react-refresh": "1.0.0",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",

--- a/examples/rspack-minimal/package.json
+++ b/examples/rspack-minimal/package.json
@@ -20,7 +20,6 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "tsm": "2.3.0",
     "@rsdoctor/rspack-plugin": "workspace:*",
     "@rspack/cli": "1.0.0",
     "@rspack/core": "1.0.0",
@@ -28,6 +27,7 @@
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
     "react-refresh": "^0.14.0",
+    "tsm": "2.3.0",
     "web-vitals": "^2.1.4"
   },
   "browserslist": {

--- a/examples/rspack-minimal/package.json
+++ b/examples/rspack-minimal/package.json
@@ -21,8 +21,8 @@
   },
   "devDependencies": {
     "@rsdoctor/rspack-plugin": "workspace:*",
-    "@rspack/cli": "1.0.0",
-    "@rspack/core": "1.0.0",
+    "@rspack/cli": "^1.1.1",
+    "@rspack/core": "^1.1.1",
     "@rspack/plugin-react-refresh": "1.0.0",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -28,11 +28,11 @@
     "dist/"
   ],
   "devDependencies": {
-    "@rsbuild/core": "0.7.10",
-    "@rsbuild/plugin-node-polyfill": "0.7.10",
-    "@rsbuild/plugin-react": "0.7.10",
-    "@rsbuild/plugin-sass": "0.7.10",
-    "@rsbuild/plugin-type-check": "0.7.10",
+    "@rsbuild/core": "^1.1.1",
+    "@rsbuild/plugin-node-polyfill": "^1.2.0",
+    "@rsbuild/plugin-react": "^1.0.7",
+    "@rsbuild/plugin-sass": "^1.1.0",
+    "@rsbuild/plugin-type-check": "^1.0.1",
     "@rsdoctor/components": "workspace:*",
     "@rsdoctor/types": "workspace:*",
     "@types/node": "^16",

--- a/packages/client/rsbuild.config.ts
+++ b/packages/client/rsbuild.config.ts
@@ -181,10 +181,10 @@ export default defineConfig(({ env }) => {
     server: {
       port: PortForWeb,
       historyApiFallback: true,
+      open: ENABLE_CLIENT_SERVER ? undefined : true,
     },
 
     dev: {
-      startUrl: ENABLE_CLIENT_SERVER ? undefined : true,
       setupMiddlewares: [
         (middlewares) => {
           if (fs.existsSync(WebpackRsdoctorDirPath)) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -83,7 +83,7 @@
     "webpack-bundle-analyzer": "^4.10.2"
   },
   "devDependencies": {
-    "@rspack/core": "1.0.14",
+    "@rspack/core": "^1.1.1",
     "@scripts/test-helper": "workspace:*",
     "@types/fs-extra": "^11.0.4",
     "@types/lodash": "^4.17.13",

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -1,10 +1,13 @@
 import { Common, Linter, Plugin, SDK } from '@rsdoctor/types';
 import assert from 'assert';
-import type { RuleSetCondition as RspackRuleSetCondition } from '@rspack/core';
+import type {
+  RuleSetCondition as RspackRuleSetCondition,
+  RuleSetRule as RspackRuleSetRule,
+} from '@rspack/core';
 import {
-  RuleSetCondition,
-  RuleSetConditionAbsolute,
-  RuleSetRule,
+  RuleSetCondition as WebpackRuleSetCondition,
+  RuleSetConditionAbsolute as WebpackRuleSetConditionAbsolute,
+  RuleSetRule as WebpackRuleSetRule,
 } from 'webpack';
 import {
   RsdoctorWebpackPluginOptions,
@@ -119,9 +122,9 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
 
 export function makeRuleSetSerializable(
   item:
-    | RuleSetConditionAbsolute
-    | RuleSetCondition
     | RspackRuleSetCondition
+    | WebpackRuleSetConditionAbsolute
+    | WebpackRuleSetCondition
     | void,
 ) {
   if (!item) return;
@@ -139,7 +142,10 @@ export function makeRuleSetSerializable(
 }
 
 export function makeRulesSerializable(
-  rules: Plugin.RuleSetRule[] | RuleSetRule['oneOf'],
+  rules:
+    | Plugin.RuleSetRule[]
+    | RspackRuleSetRule['oneOf']
+    | WebpackRuleSetRule['oneOf'],
 ) {
   if (!Array.isArray(rules)) return;
 

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@rsdoctor/types": "workspace:*",
+    "@rspress/plugin-rss": "^1.33.1",
     "@types/node": "^16",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
@@ -34,12 +35,11 @@
     "rsbuild-plugin-open-graph": "^1.0.2",
     "rspress-plugin-font-open-sans": "^1.0.0",
     "rspress-plugin-sitemap": "^1.1.1",
-    "@rspress/plugin-rss": "^1.33.1",
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "react-markdown": "^9.0.1",
     "@rstack-dev/doc-ui": "1.5.3",
+    "react-markdown": "^9.0.1",
     "rspress": "^1.33.1"
   }
 }

--- a/packages/rspack-plugin/package.json
+++ b/packages/rspack-plugin/package.json
@@ -22,9 +22,9 @@
     "@rsdoctor/core": "workspace:*",
     "@rsdoctor/graph": "workspace:*",
     "@rsdoctor/sdk": "workspace:*",
+    "@rsdoctor/types": "workspace:*",
     "@rsdoctor/utils": "workspace:*",
-    "lodash": "^4.17.21",
-    "@rsdoctor/types": "workspace:*"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@rspack/core": "1.0.14",

--- a/packages/rspack-plugin/package.json
+++ b/packages/rspack-plugin/package.json
@@ -27,7 +27,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@rspack/core": "1.0.14",
+    "@rspack/core": "^1.1.1",
     "@types/lodash": "^4.17.13",
     "@types/node": "^16",
     "@types/tapable": "2.2.7",

--- a/packages/sdk/src/sdk/sdk/index.ts
+++ b/packages/sdk/src/sdk/sdk/index.ts
@@ -563,7 +563,7 @@ export class RsdoctorSDK<
     // Extract scripts and links from the HTML
     const scriptSrcs = Array.from(
       htmlContent.matchAll(
-        /<script\s+defer="defer"\s+src=["'](.+?)["']><\/script>/g,
+        /<script\s+(?:defer="defer"|defer)\s+src=["'](.+?)["']><\/script>/g,
       ),
       (m) => m[1],
     );

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -24,11 +24,11 @@
     "source-map": "^0.7.4"
   },
   "devDependencies": {
+    "@rspack/core": "1.0.14",
     "@types/node": "^16",
     "@types/react": "^18.3.12",
     "tslib": "2.7.0",
-    "typescript": "^5.2.2",
-    "@rspack/core": "1.0.14"
+    "typescript": "^5.2.2"
   },
   "peerDependencies": {
     "@rspack/core": "*",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -24,7 +24,7 @@
     "source-map": "^0.7.4"
   },
   "devDependencies": {
-    "@rspack/core": "1.0.14",
+    "@rspack/core": "^1.1.1",
     "@types/node": "^16",
     "@types/react": "^18.3.12",
     "tslib": "2.7.0",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -20,21 +20,21 @@
   },
   "dependencies": {
     "@rsdoctor/core": "workspace:*",
-    "@rsdoctor/sdk": "workspace:*",
     "@rsdoctor/graph": "workspace:*",
-    "@rsdoctor/utils": "workspace:*",
+    "@rsdoctor/sdk": "workspace:*",
     "@rsdoctor/types": "workspace:*",
+    "@rsdoctor/utils": "workspace:*",
     "fs-extra": "^11.1.1",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "webpack": "^5.95.0",
     "@types/fs-extra": "^11.0.4",
     "@types/lodash": "^4.17.13",
     "@types/node": "^16",
     "@types/tapable": "2.2.7",
     "tslib": "2.7.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "webpack": "^5.95.0"
   },
   "peerDependencies": {
     "webpack": "5.x"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/webpack-plugin
       '@rspack/core':
-        specifier: 1.0.14
-        version: 1.0.14(@swc/helpers@0.5.13)
+        specifier: ^1.1.1
+        version: 1.1.1(@swc/helpers@0.5.12)
       '@types/lodash':
         specifier: ^4.17.13
         version: 4.17.13
@@ -276,7 +276,7 @@ importers:
         version: 2.5.1
       css-loader:
         specifier: ^6.9.0
-        version: 6.11.0(@rspack/core@1.0.0)(webpack@5.95.0)
+        version: 6.11.0(@rspack/core@1.1.1)(webpack@5.95.0)
       less-loader:
         specifier: ^11.1.4
         version: 11.1.4(less@4.2.0)(webpack@5.95.0)
@@ -291,11 +291,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspack-plugin
       '@rspack/cli':
-        specifier: 1.0.0
-        version: 1.0.0(@rspack/core@1.0.0)(webpack@5.95.0)
+        specifier: ^1.1.1
+        version: 1.1.1(@rspack/core@1.1.1)(webpack@5.95.0)
       '@rspack/core':
-        specifier: 1.0.0
-        version: 1.0.0(@swc/helpers@0.5.12)
+        specifier: ^1.1.1
+        version: 1.1.1(@swc/helpers@0.5.12)
       '@rspack/plugin-react-refresh':
         specifier: 1.0.0
         version: 1.0.0(react-refresh@0.14.2)
@@ -331,7 +331,7 @@ importers:
         version: 2.5.1
       css-loader:
         specifier: ^6.9.0
-        version: 6.11.0(@rspack/core@1.0.0)(webpack@5.95.0)
+        version: 6.11.0(@rspack/core@1.1.1)(webpack@5.95.0)
       less-loader:
         specifier: ^11.1.4
         version: 11.1.4(less@4.2.0)(webpack@5.95.0)
@@ -346,11 +346,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspack-plugin
       '@rspack/cli':
-        specifier: 1.0.0
-        version: 1.0.0(@rspack/core@1.0.0)(webpack@5.95.0)
+        specifier: ^1.1.1
+        version: 1.1.1(@rspack/core@1.1.1)(webpack@5.95.0)
       '@rspack/core':
-        specifier: 1.0.0
-        version: 1.0.0(@swc/helpers@0.5.12)
+        specifier: ^1.1.1
+        version: 1.1.1(@swc/helpers@0.5.12)
       '@rspack/plugin-react-refresh':
         specifier: 1.0.0
         version: 1.0.0(react-refresh@0.14.2)
@@ -667,8 +667,8 @@ importers:
         version: 4.10.2
     devDependencies:
       '@rspack/core':
-        specifier: 1.0.14
-        version: 1.0.14(@swc/helpers@0.5.13)
+        specifier: ^1.1.1
+        version: 1.1.1(@swc/helpers@0.5.12)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -827,8 +827,8 @@ importers:
         version: 4.17.21
     devDependencies:
       '@rspack/core':
-        specifier: 1.0.14
-        version: 1.0.14(@swc/helpers@0.5.13)
+        specifier: ^1.1.1
+        version: 1.1.1(@swc/helpers@0.5.12)
       '@types/lodash':
         specifier: ^4.17.13
         version: 4.17.13
@@ -934,8 +934,8 @@ importers:
         version: 5.95.0
     devDependencies:
       '@rspack/core':
-        specifier: 1.0.14
-        version: 1.0.14(@swc/helpers@0.5.13)
+        specifier: ^1.1.1
+        version: 1.1.1(@swc/helpers@0.5.12)
       '@types/node':
         specifier: ^16
         version: 16.18.104
@@ -1099,8 +1099,8 @@ importers:
   scripts/test-helper:
     dependencies:
       '@rspack/core':
-        specifier: 1.0.14
-        version: 1.0.14(@swc/helpers@0.5.13)
+        specifier: ^1.1.1
+        version: 1.1.1(@swc/helpers@0.5.12)
       '@types/lodash':
         specifier: ^4.17.13
         version: 4.17.13
@@ -5743,6 +5743,18 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
+  /@isaacs/cliui@8.0.2:
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: /string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: /strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: /wrap-ansi@7.0.0
+    dev: true
+
   /@jest/schemas@29.6.3:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -6891,6 +6903,13 @@ packages:
     dev: true
     optional: true
 
+  /@pkgjs/parseargs@0.11.0:
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@playwright/test@1.33.0:
     resolution: {integrity: sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==}
     engines: {node: '>=14'}
@@ -7642,13 +7661,6 @@ packages:
       - webpack-cli
     dev: true
 
-  /@rspack/binding-darwin-arm64@1.0.0:
-    resolution: {integrity: sha512-ZHQk9YK+swlTG48kJTgzFUW9T26KjhLXRok5la7t2AMoiuHyhGHHgC5iQfPJLZ62XzcJ/rfqs2rwakl97151jQ==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
   /@rspack/binding-darwin-arm64@1.0.14:
     resolution: {integrity: sha512-dHvlF6T6ctThGDIdvkSdacroA1xlCxfteuppBj8BX/UxzLPr4xsaEtNilfJmFfd2/J02UQyTQauN/9EBuA+YkA==}
     cpu: [arm64]
@@ -7659,14 +7671,6 @@ packages:
   /@rspack/binding-darwin-arm64@1.1.1:
     resolution: {integrity: sha512-BnvGPWObGZ2ZVnxe4K3NKwAWxYubOJvfwporXWD3NgkzeV5xJqGBFWRDnr/nfsFpgCTI8goxK5db/wb7NVzLqg==}
     cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-darwin-x64@1.0.0:
-    resolution: {integrity: sha512-qhTXm9wUhv2lBjsqqfCu59RchH1/2jursdPAmTqGc7zMReZdZvtJs2Ri6Ma1M48BLLu+7fS4fbL8Rw1g78TOOQ==}
-    cpu: [x64]
     os: [darwin]
     requiresBuild: true
     optional: true
@@ -7683,14 +7687,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-linux-arm64-gnu@1.0.0:
-    resolution: {integrity: sha512-yKnlsWgvydJRxDBGGKC+cyDeoSzIvOzuVqCloy5oAFAGOMXMY6bznxrkE6/olGZncdeLEpnJzZmXSuF1dYc8ow==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
     optional: true
 
   /@rspack/binding-linux-arm64-gnu@1.0.14:
@@ -7702,14 +7698,6 @@ packages:
 
   /@rspack/binding-linux-arm64-gnu@1.1.1:
     resolution: {integrity: sha512-2Z8YxH4+V0MiNhVQ2IFELDIFtykIdKgmOmGr/PuRQMHMxSn8AKo5uqBD30sZqe0+gryplZwK3hyrBETHOmSltQ==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-linux-arm64-musl@1.0.0:
-    resolution: {integrity: sha512-dKFmlqlF4FELT/AX02hSwX8aRawjH5zAliQzYnvgrqcEyCKE60vKacGJQ3ZeRyru6dh5MlbUNW4H1+TDT+cDVA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -7727,14 +7715,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-linux-x64-gnu@1.0.0:
-    resolution: {integrity: sha512-fRk9i8aE4FiwW7+LkNyw+5vfFzJ8BZ2seAL9V5U2iwYwYibzFJsukg3h3Uh+IsGm30/7+ZRENtGwybQiMruL4g==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
     optional: true
 
   /@rspack/binding-linux-x64-gnu@1.0.14:
@@ -7746,14 +7726,6 @@ packages:
 
   /@rspack/binding-linux-x64-gnu@1.1.1:
     resolution: {integrity: sha512-goaDDrXNulR7FcvUfj8AjhF3g7IXUttjQ4QsfY2xz7s20tDETlq5HpcM2A8GEI6lqkPAv/ITU0AynLK7bfyr4A==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-linux-x64-musl@1.0.0:
-    resolution: {integrity: sha512-qcTJC8o3KvLwsnrJJcuBjfzSrjEbACMiCB4RtbFNecXDtI+Nputx1CO1SlUrINC25/44ILketf0/hsdBQHk60g==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -7771,14 +7743,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-win32-arm64-msvc@1.0.0:
-    resolution: {integrity: sha512-gqtakP0Yl2aj+Q/Giwgt31hz8eOZpo2s+sJlkMJGVdIF4dejB31a8vbj/VNGeSN1tDRiLI4cyqa5eQU//t26aQ==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
     optional: true
 
   /@rspack/binding-win32-arm64-msvc@1.0.14:
@@ -7791,14 +7755,6 @@ packages:
   /@rspack/binding-win32-arm64-msvc@1.1.1:
     resolution: {integrity: sha512-FHIPpueFc/+vWdZeVWRYWW0Z0IsDIHy+WhWxITeLjOVGsUN4rhaztYOausD7WsOlOhmR0SddeOYtRs/BR35wig==}
     cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-win32-ia32-msvc@1.0.0:
-    resolution: {integrity: sha512-nLfGu5DjdzwawzZ7zK69vZX5aL1Gt9+Ovfz4RlngDq/D5ZzqCnNWw93cqKADgFRWS4qK9vOD9RXNNnkyWB2SEw==}
-    cpu: [ia32]
     os: [win32]
     requiresBuild: true
     optional: true
@@ -7815,14 +7771,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-win32-x64-msvc@1.0.0:
-    resolution: {integrity: sha512-H9PqjgtZMw5aP+eXdFo7bgSP/Ycwn3oW81uI9qFqOOQ90W+o3T9ItghHBf2/ksc5GHibd208EwOBNxbKwjZDSQ==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
     optional: true
 
   /@rspack/binding-win32-x64-msvc@1.0.14:
@@ -7837,21 +7785,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
-
-  /@rspack/binding@1.0.0:
-    resolution: {integrity: sha512-eLyqSEM1h/exJYn98k+9MRktP8AYDB13x5oVn8hoxVucuhk0TubFqQSX8h9SQcZp1O3j/Z8eWWwOaNPe3JU40Q==}
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.0.0
-      '@rspack/binding-darwin-x64': 1.0.0
-      '@rspack/binding-linux-arm64-gnu': 1.0.0
-      '@rspack/binding-linux-arm64-musl': 1.0.0
-      '@rspack/binding-linux-x64-gnu': 1.0.0
-      '@rspack/binding-linux-x64-musl': 1.0.0
-      '@rspack/binding-win32-arm64-msvc': 1.0.0
-      '@rspack/binding-win32-ia32-msvc': 1.0.0
-      '@rspack/binding-win32-x64-msvc': 1.0.0
 
   /@rspack/binding@1.0.14:
     resolution: {integrity: sha512-0wWqFvr9hkF4LgNPgWfkTU0hhkZAMvOytoCs2p+wDX1Up1E/SgJ1U1JAsCxsl1XtUKm7mRvdWHzJmHbza3y89Q==}
@@ -7878,19 +7812,18 @@ packages:
       '@rspack/binding-win32-arm64-msvc': 1.1.1
       '@rspack/binding-win32-ia32-msvc': 1.1.1
       '@rspack/binding-win32-x64-msvc': 1.1.1
-    dev: true
 
-  /@rspack/cli@1.0.0(@rspack/core@1.0.0)(webpack@5.95.0):
-    resolution: {integrity: sha512-J6S/7xPR3n042mFurxa527w8DQMaTd3eWrIFmltCRXzGi4K/1VgUUyE1X0K1pKhvtgUUkFW/m+EC8bjpzNrPeg==}
+  /@rspack/cli@1.1.1(@rspack/core@1.1.1)(webpack@5.95.0):
+    resolution: {integrity: sha512-Tm3A6Dc+gBQA67F1ShMU7c+1i3xtPBumnkwJ/TES15YaJ3iQlTehL8qzOSie5gfnWBE3Rzqyo/5t1/vg5DF8eA==}
     hasBin: true
     peerDependencies:
       '@rspack/core': ^1.0.0-alpha || ^1.x
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@rspack/core': 1.0.0(@swc/helpers@0.5.12)
-      '@rspack/dev-server': 1.0.0(@rspack/core@1.0.0)(webpack@5.95.0)
+      '@rspack/core': 1.1.1(@swc/helpers@0.5.12)
+      '@rspack/dev-server': 1.0.9(@rspack/core@1.1.1)(webpack@5.95.0)
       colorette: 2.0.19
-      exit-hook: 3.2.0
+      exit-hook: 4.0.0
       interpret: 3.1.1
       rechoir: 0.8.0
       semver: 7.6.3
@@ -7906,21 +7839,6 @@ packages:
       - webpack-cli
     dev: true
 
-  /@rspack/core@1.0.0(@swc/helpers@0.5.12):
-    resolution: {integrity: sha512-F4RA9uOLLvD1oTKa96Gcly+Sro1qaqPNENadFyiPwepa7DrwexQa/ym6CQKbvKMOYGKlVSFDPUmgFAirz35ETg==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-    dependencies:
-      '@module-federation/runtime-tools': 0.5.1
-      '@rspack/binding': 1.0.0
-      '@rspack/lite-tapable': 1.0.0
-      '@swc/helpers': 0.5.12
-      caniuse-lite: 1.0.30001669
-
   /@rspack/core@1.0.14(@swc/helpers@0.5.13):
     resolution: {integrity: sha512-xHl23lxJZNjItGc5YuE9alz3yjb56y7EgJmAcBMPHMqgjtUt8rBu4xd/cSUjbr9/lLF9N4hdyoJiPJOFs9LEjw==}
     engines: {node: '>=16.0.0'}
@@ -7934,6 +7852,21 @@ packages:
       '@rspack/binding': 1.0.14
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.13
+      caniuse-lite: 1.0.30001669
+
+  /@rspack/core@1.1.1(@swc/helpers@0.5.12):
+    resolution: {integrity: sha512-khYNAho2evyc7N5mYk4K6B587ou/dN1CDCqWrSDeZZNFFQHtuEp5T3kL1ntsKY7agObQhI60osCYaxFUPs0yww==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+    dependencies:
+      '@module-federation/runtime-tools': 0.5.1
+      '@rspack/binding': 1.1.1
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.12
       caniuse-lite: 1.0.30001669
 
   /@rspack/core@1.1.1(@swc/helpers@0.5.15):
@@ -7952,19 +7885,20 @@ packages:
       caniuse-lite: 1.0.30001669
     dev: true
 
-  /@rspack/dev-server@1.0.0(@rspack/core@1.0.0)(webpack@5.95.0):
-    resolution: {integrity: sha512-ORrF+p31/jLS7tmXp7VLAX654NVpO0jNc9VM9ueG5LAyvf4d+Bo6zhFQTWsoW30uh/Xd1EZjfu+9zu4jn8Zv4Q==}
+  /@rspack/dev-server@1.0.9(@rspack/core@1.1.1)(webpack@5.95.0):
+    resolution: {integrity: sha512-VF+apLFfl5LWIhVbfkJ5ccU0Atl5mi+sGTkx+XtE1tbUmMJkde0nm/4+eaQCud7oGl+ZCzt4kW14uuzLSiEGDw==}
     peerDependencies:
       '@rspack/core': '*'
     dependencies:
-      '@rspack/core': 1.0.0(@swc/helpers@0.5.12)
+      '@rspack/core': 1.1.1(@swc/helpers@0.5.12)
       chokidar: 3.6.0
       connect-history-api-fallback: 2.0.0
       express: 4.19.2
       http-proxy-middleware: 2.0.6(@types/express@4.17.21)
       mime-types: 2.1.35
+      p-retry: 4.6.2
       webpack-dev-middleware: 7.4.2(webpack@5.95.0)
-      webpack-dev-server: 5.1.0(webpack@5.95.0)
+      webpack-dev-server: 5.0.4(webpack@5.95.0)
       ws: 8.18.0
     transitivePeerDependencies:
       - '@types/express'
@@ -7975,10 +7909,6 @@ packages:
       - webpack
       - webpack-cli
     dev: true
-
-  /@rspack/lite-tapable@1.0.0:
-    resolution: {integrity: sha512-7MZf4lburSUZoEenwazwUDKHhqyfnLCGnQ/tKcUtztfmVzfjZfRn/EaiT0AKkYGnL2U8AGsw89oUeVyvaOLVCw==}
-    engines: {node: '>=16.0.0'}
 
   /@rspack/lite-tapable@1.0.1:
     resolution: {integrity: sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==}
@@ -8768,6 +8698,10 @@ packages:
       '@types/node': 16.18.104
     dev: true
 
+  /@types/retry@0.12.0:
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+    dev: true
+
   /@types/retry@0.12.2:
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
     dev: true
@@ -9349,6 +9283,7 @@ packages:
   /ansi-html-community@0.0.8:
     resolution: {integrity: sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==}
     engines: {'0': node >= 0.8.0}
+    hasBin: true
     dev: true
 
   /ansi-html@0.0.9:
@@ -9360,6 +9295,11 @@ packages:
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+
+  /ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
+    dev: true
 
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -9376,6 +9316,11 @@ packages:
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
     dev: true
 
   /ansi-to-react@6.1.6(react-dom@18.3.1)(react@18.3.1):
@@ -10717,7 +10662,7 @@ packages:
       postcss: 8.4.47
     dev: true
 
-  /css-loader@6.11.0(@rspack/core@1.0.0)(webpack@5.95.0):
+  /css-loader@6.11.0(@rspack/core@1.1.1)(webpack@5.95.0):
     resolution: {integrity: sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -10729,7 +10674,7 @@ packages:
       webpack:
         optional: true
     dependencies:
-      '@rspack/core': 1.0.0(@swc/helpers@0.5.12)
+      '@rspack/core': 1.1.1(@swc/helpers@0.5.12)
       icss-utils: 5.1.0(postcss@8.4.41)
       postcss: 8.4.41
       postcss-modules-extract-imports: 3.1.0(postcss@8.4.41)
@@ -11040,6 +10985,13 @@ packages:
       default-browser-id: 5.0.0
     dev: true
 
+  /default-gateway@6.0.3:
+    resolution: {integrity: sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==}
+    engines: {node: '>= 10'}
+    dependencies:
+      execa: 5.1.1
+    dev: true
+
   /defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
     dependencies:
@@ -11290,6 +11242,10 @@ packages:
   /duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
+  /eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    dev: true
+
   /echarts-for-react@3.0.2(echarts@5.5.1)(react@18.3.1):
     resolution: {integrity: sha512-DRwIiTzx8JfwPOVgGttDytBqdp5VzCSyMRIxubgU/g2n9y3VLUmF2FK7Icmg/sNVkv4+rktmrLN9w22U2yy3fA==}
     peerDependencies:
@@ -11342,6 +11298,10 @@ packages:
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  /emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    dev: true
 
   /emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
@@ -12072,9 +12032,9 @@ packages:
       strip-final-newline: 3.0.0
     dev: true
 
-  /exit-hook@3.2.0:
-    resolution: {integrity: sha512-aIQN7Q04HGAV/I5BszisuHTZHXNoC23WtLkxdCLuYZMdWviRD0TMIt2bnUBi9MrHaF/hH8b3gwG9iaAUHKnJGA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+  /exit-hook@4.0.0:
+    resolution: {integrity: sha512-Fqs7ChZm72y40wKjOFXBKg7nJZvQJmewP5/7LtePDdnah/+FH9Hp5sgMujSCMPXlxOAW2//1jrW9pnsY7o20vQ==}
+    engines: {node: '>=18'}
     dev: true
 
   /express@4.19.2:
@@ -12393,6 +12353,14 @@ packages:
       is-callable: 1.2.7
     dev: true
 
+  /foreground-child@3.3.0:
+    resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
+    engines: {node: '>=14'}
+    dependencies:
+      cross-spawn: 7.0.3
+      signal-exit: 4.1.0
+    dev: true
+
   /fork-ts-checker-webpack-plugin@9.0.2(typescript@5.5.4)(webpack@5.95.0):
     resolution: {integrity: sha512-Uochze2R8peoN1XqlSi/rGUkDQpRogtLFocP9+PGu68zk1BDAKXfdeCdyVZpgTk8V8WFVQXdEz426VKjXLO1Gg==}
     engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
@@ -12647,6 +12615,18 @@ packages:
 
   /glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  /glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+    dependencies:
+      foreground-child: 3.3.0
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+    dev: true
 
   /glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
@@ -13766,6 +13746,14 @@ packages:
     resolution: {integrity: sha512-4dG1D1x/7g8PwHS9aK6QV5V94+ZvyP4+d19qDv43EzImmrndysIl4prmJ1hWWIGCqrZHyaHBm6BSEWHOLnpoNw==}
     dev: true
 
+  /jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+    dev: true
+
   /jest-diff@29.7.0:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -13946,7 +13934,7 @@ packages:
   /launch-editor@2.8.1:
     resolution: {integrity: sha512-elBx2l/tp9z99X5H/qev8uyDywVh0VXAwEbjk8kJhnc5grOFkGh7aW6q55me9xnYbss261XtnUrysZ+XvGbhQA==}
     dependencies:
-      picocolors: 1.1.0
+      picocolors: 1.1.1
       shell-quote: 1.8.1
     dev: true
 
@@ -15123,6 +15111,13 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
+  /minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -15202,6 +15197,7 @@ packages:
 
   /multicast-dns@7.2.5:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
+    hasBin: true
     dependencies:
       dns-packet: 5.6.1
       thunky: 1.1.0
@@ -15645,6 +15641,14 @@ packages:
       aggregate-error: 3.1.0
     dev: true
 
+  /p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+    dev: true
+
   /p-retry@6.2.0:
     resolution: {integrity: sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==}
     engines: {node: '>=16.17'}
@@ -15657,6 +15661,10 @@ packages:
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+
+  /package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+    dev: true
 
   /package-json@6.5.0:
     resolution: {integrity: sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==}
@@ -17911,6 +17919,13 @@ packages:
       glob: 7.2.3
     dev: true
 
+  /rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
+    dependencies:
+      glob: 10.4.5
+    dev: true
+
   /ripemd160@2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
     dependencies:
@@ -18993,6 +19008,15 @@ packages:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  /string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+    dev: true
+
   /string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
     dependencies:
@@ -19015,6 +19039,13 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
+
+  /strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-regex: 6.1.0
+    dev: true
 
   /strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
@@ -19967,6 +19998,7 @@ packages:
 
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
     dev: true
 
   /uvu@0.5.6:
@@ -20321,8 +20353,8 @@ packages:
       webpack: 5.95.0
     dev: true
 
-  /webpack-dev-server@5.1.0(webpack@5.95.0):
-    resolution: {integrity: sha512-aQpaN81X6tXie1FoOB7xlMfCsN19pSvRAeYUHOdFWOlhpQ/LlbfTqYwwmEDFV0h8GGuqmCmKmT+pxcUV/Nt2gQ==}
+  /webpack-dev-server@5.0.4(webpack@5.95.0):
+    resolution: {integrity: sha512-dljXhUgx3HqKP2d8J/fUMvhxGhzjeNVarDLcbO/EWMSgRizDkxHQDZQaLFL5VJY9tRBj2Gz+rvCEYYvhbqPHNA==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
@@ -20347,6 +20379,7 @@ packages:
       colorette: 2.0.20
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
+      default-gateway: 6.0.3
       express: 4.19.2
       graceful-fs: 4.2.11
       html-entities: 2.5.2
@@ -20355,6 +20388,7 @@ packages:
       launch-editor: 2.8.1
       open: 10.1.0
       p-retry: 6.2.0
+      rimraf: 5.0.10
       schema-utils: 4.2.0
       selfsigned: 2.4.1
       serve-index: 1.9.1
@@ -20620,6 +20654,15 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  /wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+    dev: true
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,11 +236,11 @@ importers:
         version: /semver@7.5.4
     devDependencies:
       '@rsbuild/core':
-        specifier: 0.7.5
-        version: 0.7.5
+        specifier: ^1.1.1
+        version: 1.1.1
       '@rsbuild/plugin-react':
-        specifier: 0.7.5
-        version: 0.7.5(@rsbuild/core@0.7.5)
+        specifier: ^1.0.7
+        version: 1.0.7(@rsbuild/core@1.1.1)
       '@rsdoctor/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -462,20 +462,20 @@ importers:
   packages/client:
     devDependencies:
       '@rsbuild/core':
-        specifier: 0.7.10
-        version: 0.7.10
+        specifier: ^1.1.1
+        version: 1.1.1
       '@rsbuild/plugin-node-polyfill':
-        specifier: 0.7.10
-        version: 0.7.10(@rsbuild/core@0.7.10)
+        specifier: ^1.2.0
+        version: 1.2.0(@rsbuild/core@1.1.1)
       '@rsbuild/plugin-react':
-        specifier: 0.7.10
-        version: 0.7.10(@rsbuild/core@0.7.10)
+        specifier: ^1.0.7
+        version: 1.0.7(@rsbuild/core@1.1.1)
       '@rsbuild/plugin-sass':
-        specifier: 0.7.10
-        version: 0.7.10(@rsbuild/core@0.7.10)
+        specifier: ^1.1.0
+        version: 1.1.0(@rsbuild/core@1.1.1)
       '@rsbuild/plugin-type-check':
-        specifier: 0.7.10
-        version: 0.7.10(@rsbuild/core@0.7.10)(typescript@5.5.4)
+        specifier: ^1.0.1
+        version: 1.0.1(@rsbuild/core@1.1.1)(typescript@5.5.4)
       '@rsdoctor/components':
         specifier: workspace:*
         version: link:../components
@@ -695,7 +695,7 @@ importers:
         version: 2.2.7
       babel-loader:
         specifier: 9.1.3
-        version: 9.1.3(@babel/core@7.25.8)(webpack@5.95.0)
+        version: 9.1.3(@babel/core@7.26.0)(webpack@5.95.0)
       string-loader:
         specifier: 0.0.1
         version: 0.0.1
@@ -3669,7 +3669,7 @@ packages:
       '@babel/helper-module-imports': 7.24.7(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.25.8)
-      '@babel/types': 7.25.8
+      '@babel/types': 7.25.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4227,7 +4227,7 @@ packages:
     dependencies:
       '@babel/core': 7.25.8
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-validator-option': 7.25.7
+      '@babel/helper-validator-option': 7.24.8
       '@babel/plugin-transform-react-display-name': 7.24.7(@babel/core@7.25.8)
       '@babel/plugin-transform-react-jsx': 7.25.2(@babel/core@7.25.8)
       '@babel/plugin-transform-react-jsx-development': 7.24.7(@babel/core@7.25.8)
@@ -4484,10 +4484,6 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
-
-  /@bufbuild/protobuf@1.10.0:
-    resolution: {integrity: sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==}
-    dev: true
 
   /@bufbuild/protobuf@2.1.0:
     resolution: {integrity: sha512-+2Mx67Y3skJ4NCD/qNSdBJNWtu6x6Qr53jeNg+QcwiL6mt0wK+3jwHH2x1p7xaYH6Ve2JKOVn0OxU35WsmqI9A==}
@@ -6657,7 +6653,7 @@ packages:
       '@rsbuild/plugin-css-minimizer': 1.0.2(@rsbuild/core@1.0.14)(esbuild@0.17.19)(webpack@5.95.0)
       '@rsbuild/plugin-less': 1.0.1(@rsbuild/core@1.0.14)
       '@rsbuild/plugin-pug': 1.0.2(@rsbuild/core@1.0.14)
-      '@rsbuild/plugin-react': 1.0.4(@rsbuild/core@1.0.14)
+      '@rsbuild/plugin-react': 1.0.7(@rsbuild/core@1.0.14)
       '@rsbuild/plugin-rem': 1.0.1(@rsbuild/core@1.0.14)
       '@rsbuild/plugin-sass': 1.0.3(@rsbuild/core@1.0.14)
       '@rsbuild/plugin-source-build': 1.0.1(@rsbuild/core@1.0.14)
@@ -6734,43 +6730,19 @@ packages:
       lodash: 4.17.21
       rslog: 1.2.3
 
-  /@module-federation/runtime-tools@0.1.6:
-    resolution: {integrity: sha512-7ILVnzMIa0Dlc0Blck5tVZG1tnk1MmLnuZpLOMpbdW+zl+N6wdMjjHMjEZFCUAJh2E5XJ3BREwfX8Ets0nIkLg==}
-    dependencies:
-      '@module-federation/runtime': 0.1.6
-      '@module-federation/webpack-bundler-runtime': 0.1.6
-    dev: true
-
   /@module-federation/runtime-tools@0.5.1:
     resolution: {integrity: sha512-nfBedkoZ3/SWyO0hnmaxuz0R0iGPSikHZOAZ0N/dVSQaIzlffUo35B5nlC2wgWIc0JdMZfkwkjZRrnuuDIJbzg==}
     dependencies:
       '@module-federation/runtime': 0.5.1
       '@module-federation/webpack-bundler-runtime': 0.5.1
 
-  /@module-federation/runtime@0.1.6:
-    resolution: {integrity: sha512-nj6a+yJ+QxmcE89qmrTl4lphBIoAds0PFPVGnqLRWflwAP88jrCcrrTqRhARegkFDL+wE9AE04+h6jzlbIfMKg==}
-    dependencies:
-      '@module-federation/sdk': 0.1.6
-    dev: true
-
   /@module-federation/runtime@0.5.1:
     resolution: {integrity: sha512-xgiMUWwGLWDrvZc9JibuEbXIbhXg6z2oUkemogSvQ4LKvrl/n0kbqP1Blk669mXzyWbqtSp6PpvNdwaE1aN5xQ==}
     dependencies:
       '@module-federation/sdk': 0.5.1
 
-  /@module-federation/sdk@0.1.6:
-    resolution: {integrity: sha512-qifXpyYLM7abUeEOIfv0oTkguZgRZuwh89YOAYIZJlkP6QbRG7DJMQvtM8X2yHXm9PTk0IYNnOJH0vNQCo6auQ==}
-    dev: true
-
   /@module-federation/sdk@0.5.1:
     resolution: {integrity: sha512-exvchtjNURJJkpqjQ3/opdbfeT2wPKvrbnGnyRkrwW5o3FH1LaST1tkiNviT6OXTexGaVc2DahbdniQHVtQ7pA==}
-
-  /@module-federation/webpack-bundler-runtime@0.1.6:
-    resolution: {integrity: sha512-K5WhKZ4RVNaMEtfHsd/9CNCgGKB0ipbm/tgweNNeC11mEuBTNxJ09Y630vg3WPkKv9vfMCuXg2p2Dk+Q/KWTSA==}
-    dependencies:
-      '@module-federation/runtime': 0.1.6
-      '@module-federation/sdk': 0.1.6
-    dev: true
 
   /@module-federation/webpack-bundler-runtime@0.5.1:
     resolution: {integrity: sha512-mMhRFH0k2VjwHt3Jol9JkUsmI/4XlrAoBG3E0o7HoyoPYv1UFOWyqAflfANcUPgbYpvqmyLzDcO+3IT36LXnrA==}
@@ -7236,31 +7208,6 @@ packages:
     dev: true
     optional: true
 
-  /@rsbuild/core@0.7.10:
-    resolution: {integrity: sha512-m+JbPpuMFuVsMRcsjMxvVk6yc//OW+h72kV2DAD4neoiM0YhkEAN4TXBz3RSOomXHODhhxqhpCqz9nIw6PtvBA==}
-    engines: {node: '>=16.0.0'}
-    hasBin: true
-    dependencies:
-      '@rsbuild/shared': 0.7.10(@swc/helpers@0.5.3)
-      '@rspack/core': 0.7.5(@swc/helpers@0.5.3)
-      '@swc/helpers': 0.5.3
-      core-js: 3.36.1
-      html-webpack-plugin: /html-rspack-plugin@5.7.2(@rspack/core@0.7.5)
-      postcss: 8.4.41
-    dev: true
-
-  /@rsbuild/core@0.7.5:
-    resolution: {integrity: sha512-Q/MDeuNne2UJi3kh5nGm4r/tNanl5Hjo9hMB6Uhf05gPeyGm/XZfvd1sAgSZUQTCp4lMyigJWnECKBWUloThNQ==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      '@rsbuild/shared': 0.7.5(@swc/helpers@0.5.3)
-      '@rspack/core': 0.7.2(@swc/helpers@0.5.3)
-      '@swc/helpers': 0.5.3
-      core-js: 3.36.1
-      html-webpack-plugin: /html-rspack-plugin@5.7.2(@rspack/core@0.7.2)
-      postcss: 8.4.41
-    dev: true
-
   /@rsbuild/core@1.0.13:
     resolution: {integrity: sha512-YPjd+Aal+lMqAYRt2DGEJc3dI9ZcP5j9kefobYszxs0NlgpoK+y+malXYXW4yVu3s84EqtHp+tSoJzaSK23Txw==}
     engines: {node: '>=16.7.0'}
@@ -7282,6 +7229,19 @@ packages:
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.13
       core-js: 3.38.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /@rsbuild/core@1.1.1:
+    resolution: {integrity: sha512-CJoO3PIC0Cm/z1iL6nWoIuQzETEMY+D+UIrlMGmWuhdGiixDE2x0spban7jmmJRE7w3Ns8b2ccCmhp6rovEojw==}
+    engines: {node: '>=16.7.0'}
+    hasBin: true
+    dependencies:
+      '@rspack/core': 1.1.1(@swc/helpers@0.5.15)
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.15
+      core-js: 3.39.0
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
@@ -7369,12 +7329,15 @@ packages:
       reduce-configs: 1.0.0
     dev: true
 
-  /@rsbuild/plugin-node-polyfill@0.7.10(@rsbuild/core@0.7.10):
-    resolution: {integrity: sha512-1b35yi4PyPnz91kRJ+cpEAL7MZGNSx02Z66PVAjvCP2fZgzo7jrGEipAPwkJwx1c6zZsJYxW/Q73mGtXb3mUig==}
+  /@rsbuild/plugin-node-polyfill@1.0.4(@rsbuild/core@1.0.14):
+    resolution: {integrity: sha512-WuYnMmbRpRPGsHn1maLLa4aHY4qSlEI5wbVhf4vcYlz4Zi+F+RgM/cerFZ0zSgNW/7zEHRORoSWFEyOUff8RvQ==}
     peerDependencies:
-      '@rsbuild/core': ^0.7.10
+      '@rsbuild/core': 1.x || ^1.0.1-beta.0
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
     dependencies:
-      '@rsbuild/core': 0.7.10
+      '@rsbuild/core': 1.0.14
       assert: 2.1.0
       browserify-zlib: 0.2.0
       buffer: 5.7.1
@@ -7400,15 +7363,15 @@ packages:
       vm-browserify: 1.1.2
     dev: true
 
-  /@rsbuild/plugin-node-polyfill@1.0.4(@rsbuild/core@1.0.14):
-    resolution: {integrity: sha512-WuYnMmbRpRPGsHn1maLLa4aHY4qSlEI5wbVhf4vcYlz4Zi+F+RgM/cerFZ0zSgNW/7zEHRORoSWFEyOUff8RvQ==}
+  /@rsbuild/plugin-node-polyfill@1.2.0(@rsbuild/core@1.1.1):
+    resolution: {integrity: sha512-mYctpK5Jn2yxTOxQ4rOJ0iFBJNW7sADFtKsLp9dL7MjToMhKiyIs4Mc65piI7B+YOBshdyMqCk3LPjJ+CtSRXQ==}
     peerDependencies:
       '@rsbuild/core': 1.x || ^1.0.1-beta.0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 1.0.14
+      '@rsbuild/core': 1.1.1
       assert: 2.1.0
       browserify-zlib: 0.2.0
       buffer: 5.7.1
@@ -7448,32 +7411,6 @@ packages:
       reduce-configs: 1.0.0
     dev: true
 
-  /@rsbuild/plugin-react@0.7.10(@rsbuild/core@0.7.10):
-    resolution: {integrity: sha512-OyfTrNVRt7Rj5e4PR4VQHnKKpw7YkcG7xvprJbDU/LDtG0aucwCARO1h+YtuZhcUpoG9k4zWLmoRkEXLVnKbdQ==}
-    peerDependencies:
-      '@rsbuild/core': ^0.7.10
-    dependencies:
-      '@rsbuild/core': 0.7.10
-      '@rsbuild/shared': 0.7.10(@swc/helpers@0.5.3)
-      '@rspack/plugin-react-refresh': 0.7.5(react-refresh@0.14.2)
-      react-refresh: 0.14.2
-    transitivePeerDependencies:
-      - '@swc/helpers'
-    dev: true
-
-  /@rsbuild/plugin-react@0.7.5(@rsbuild/core@0.7.5):
-    resolution: {integrity: sha512-LRbcNI1bxI5lNN3OoQQ63hMn0xG0L3cgGvwVsEqh2AGVG77sOt1+d+DyHitxRVCfb1N06vD4TaXdzAMZLZvYpA==}
-    peerDependencies:
-      '@rsbuild/core': ^0.7.5
-    dependencies:
-      '@rsbuild/core': 0.7.5
-      '@rsbuild/shared': 0.7.5(@swc/helpers@0.5.3)
-      '@rspack/plugin-react-refresh': 0.7.2(react-refresh@0.14.2)
-      react-refresh: 0.14.2
-    transitivePeerDependencies:
-      - '@swc/helpers'
-    dev: true
-
   /@rsbuild/plugin-react@1.0.3(@rsbuild/core@1.0.13):
     resolution: {integrity: sha512-HVfPiKINmDsIcLLs7YWAYQgzytVZOydBuPOFg5EoJiMHkFVjH0Rg3QViS3Hn6k3INqdc6ylpcYyOHHYItEIkWA==}
     peerDependencies:
@@ -7493,6 +7430,26 @@ packages:
       react-refresh: 0.14.2
     dev: true
 
+  /@rsbuild/plugin-react@1.0.7(@rsbuild/core@1.0.14):
+    resolution: {integrity: sha512-t7T/GqDwodusTAnxGpqVRnQ/G+HYh98zk71qIg19WkjVJJGv57AC1Ppx0/6zzbZAbxU60bfK8TeEEXjhXCdSxA==}
+    peerDependencies:
+      '@rsbuild/core': 1.x
+    dependencies:
+      '@rsbuild/core': 1.0.14
+      '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.14.2)
+      react-refresh: 0.14.2
+    dev: true
+
+  /@rsbuild/plugin-react@1.0.7(@rsbuild/core@1.1.1):
+    resolution: {integrity: sha512-t7T/GqDwodusTAnxGpqVRnQ/G+HYh98zk71qIg19WkjVJJGv57AC1Ppx0/6zzbZAbxU60bfK8TeEEXjhXCdSxA==}
+    peerDependencies:
+      '@rsbuild/core': 1.x
+    dependencies:
+      '@rsbuild/core': 1.1.1
+      '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.14.2)
+      react-refresh: 0.14.2
+    dev: true
+
   /@rsbuild/plugin-rem@1.0.1(@rsbuild/core@1.0.14):
     resolution: {integrity: sha512-wsaEvFLVpWsvGi5Bh1j3Yxq1C5RgD+AyveNTbEHaoHHj7ChDx1lrTSRZhre3Jmgjse02gUZjbnAhcO+v5aJPVw==}
     peerDependencies:
@@ -7504,20 +7461,6 @@ packages:
       '@rsbuild/core': 1.0.14
       deepmerge: 4.3.1
       terser: 5.36.0
-    dev: true
-
-  /@rsbuild/plugin-sass@0.7.10(@rsbuild/core@0.7.10):
-    resolution: {integrity: sha512-gtYNH+xgxWyroG1z2wqh/l7v88CiH89HtrIs+BbEgn1CV12dQvMI3YtF4aEwS6Ogr+byomdirFLhdBy0WBCbzQ==}
-    peerDependencies:
-      '@rsbuild/core': ^0.7.10
-    dependencies:
-      '@rsbuild/core': 0.7.10
-      '@rsbuild/shared': 0.7.10(@swc/helpers@0.5.3)
-      loader-utils: 2.0.4
-      postcss: 8.4.41
-      sass-embedded: 1.77.8
-    transitivePeerDependencies:
-      - '@swc/helpers'
     dev: true
 
   /@rsbuild/plugin-sass@1.0.2(@rsbuild/core@1.0.13):
@@ -7543,6 +7486,19 @@ packages:
       postcss: 8.4.47
       reduce-configs: 1.0.0
       sass-embedded: 1.79.5
+    dev: true
+
+  /@rsbuild/plugin-sass@1.1.0(@rsbuild/core@1.1.1):
+    resolution: {integrity: sha512-7vF1Bygb3R8xd1jHOv1AourxQ/751fkh9gi/WGABVFMde/OxEpw5hDiAY4Wo+zsxLXOEPHB9eUuv/5P7udwFkg==}
+    peerDependencies:
+      '@rsbuild/core': 1.x
+    dependencies:
+      '@rsbuild/core': 1.1.1
+      deepmerge: 4.3.1
+      loader-utils: 2.0.4
+      postcss: 8.4.47
+      reduce-configs: 1.0.0
+      sass-embedded: 1.80.7
     dev: true
 
   /@rsbuild/plugin-source-build@1.0.1(@rsbuild/core@1.0.14):
@@ -7601,25 +7557,6 @@ packages:
       toml: 3.0.0
     dev: true
 
-  /@rsbuild/plugin-type-check@0.7.10(@rsbuild/core@0.7.10)(typescript@5.5.4):
-    resolution: {integrity: sha512-EGNeHEZEWvABqTGt+CEtw5kQskNrg2nch4wRuAechPgmHmzU/k65EoXTMsB/ImmcdUeU2ax2kdlQOdxs6fNgoA==}
-    peerDependencies:
-      '@rsbuild/core': ^0.7.10
-    dependencies:
-      '@rsbuild/core': 0.7.10
-      '@rsbuild/shared': 0.7.10(@swc/helpers@0.5.3)
-      fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.5.4)(webpack@5.95.0)
-      json5: 2.2.3
-      webpack: 5.95.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/helpers'
-      - esbuild
-      - typescript
-      - uglify-js
-      - webpack-cli
-    dev: true
-
   /@rsbuild/plugin-type-check@1.0.1(@rsbuild/core@1.0.14)(esbuild@0.17.19)(typescript@5.5.4):
     resolution: {integrity: sha512-BahXAJNq4kWtL2dINUlrOL9UCN1t8c/qf5RW8JXx2HSSasfKPJGJ1BVfieMcIaFa/t8/QdafcwoxY1WKPTlSMg==}
     peerDependencies:
@@ -7634,6 +7571,28 @@ packages:
       json5: 2.2.3
       reduce-configs: 1.0.0
       webpack: 5.95.0(esbuild@0.17.19)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - typescript
+      - uglify-js
+      - webpack-cli
+    dev: true
+
+  /@rsbuild/plugin-type-check@1.0.1(@rsbuild/core@1.1.1)(typescript@5.5.4):
+    resolution: {integrity: sha512-BahXAJNq4kWtL2dINUlrOL9UCN1t8c/qf5RW8JXx2HSSasfKPJGJ1BVfieMcIaFa/t8/QdafcwoxY1WKPTlSMg==}
+    peerDependencies:
+      '@rsbuild/core': 1.x || ^1.0.1-beta.0
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+    dependencies:
+      '@rsbuild/core': 1.1.1
+      deepmerge: 4.3.1
+      fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.5.4)(webpack@5.95.0)
+      json5: 2.2.3
+      reduce-configs: 1.0.0
+      webpack: 5.95.0
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -7664,32 +7623,6 @@ packages:
       '@rsbuild/core': 1.0.14
     dev: true
 
-  /@rsbuild/shared@0.7.10(@swc/helpers@0.5.3):
-    resolution: {integrity: sha512-FwTm11DP7KxQKT2mWLvwe80O5KpikgMSlqnw9CQhBaIHSYEypdJU9ZotbNsXsHdML3xcqg+S9ae3bpovC7KlwQ==}
-    dependencies:
-      '@rspack/core': 0.7.5(@swc/helpers@0.5.3)
-      caniuse-lite: 1.0.30001669
-      html-webpack-plugin: /html-rspack-plugin@5.7.2(@rspack/core@0.7.5)
-      postcss: 8.4.45
-    optionalDependencies:
-      fsevents: 2.3.3
-    transitivePeerDependencies:
-      - '@swc/helpers'
-    dev: true
-
-  /@rsbuild/shared@0.7.5(@swc/helpers@0.5.3):
-    resolution: {integrity: sha512-DHFSketZ1OfyaSM0OacfSU5JCZgmzXiAAamiZ7d6Mw4O8B2U7rPz12LCEPWb7JV8wSsbABBQmP1v0Y0a20RObw==}
-    dependencies:
-      '@rspack/core': 0.7.2(@swc/helpers@0.5.3)
-      caniuse-lite: 1.0.30001669
-      html-webpack-plugin: /html-rspack-plugin@5.7.2(@rspack/core@0.7.2)
-      postcss: 8.4.41
-    optionalDependencies:
-      fsevents: 2.3.3
-    transitivePeerDependencies:
-      - '@swc/helpers'
-    dev: true
-
   /@rsbuild/webpack@1.0.11(@rsbuild/core@1.0.14)(esbuild@0.17.19):
     resolution: {integrity: sha512-2x/QqNUEKEt7eao8FnYwlrwQUYSbuM9ihiI1RpSuKbi/ZZuHxrFA3fwnO7k1v/Xbs5mCQR+ni+da5dakypFktg==}
     peerDependencies:
@@ -7709,22 +7642,6 @@ packages:
       - webpack-cli
     dev: true
 
-  /@rspack/binding-darwin-arm64@0.7.2:
-    resolution: {integrity: sha512-9301P6edDkITJ5+RIe5Gd0uCFJEl1ZnCe7KDKH0yBdiaPi1knnDJQbpGZ6qOXq98jhOHREeRMBJOMRKFX7yjOw==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-darwin-arm64@0.7.5:
-    resolution: {integrity: sha512-mNBIm36s1BA7v4SL/r4f3IXIsjyH5CZX4eXMRPE52lBc3ClVuUB7d/8zk8dkyjJCMAj8PsZSnAJ3cfXnn7TN4g==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rspack/binding-darwin-arm64@1.0.0:
     resolution: {integrity: sha512-ZHQk9YK+swlTG48kJTgzFUW9T26KjhLXRok5la7t2AMoiuHyhGHHgC5iQfPJLZ62XzcJ/rfqs2rwakl97151jQ==}
     cpu: [arm64]
@@ -7739,17 +7656,9 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-darwin-x64@0.7.2:
-    resolution: {integrity: sha512-qvmBoO1VRN1aXivicEPZoed2rTVgKh+rXQu8heMLcDzAaFBdBQXfYC3yxc1XJKofy+XO53titJw9LmPEJwN7dw==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-darwin-x64@0.7.5:
-    resolution: {integrity: sha512-teLK0TB1x0CsvaaiCopsFx4EvJe+/Hljwii6R7C9qOZs5zSOfbT/LQ202eA0sAGodCncARCGaXVrsekbrRYqeA==}
-    cpu: [x64]
+  /@rspack/binding-darwin-arm64@1.1.1:
+    resolution: {integrity: sha512-BnvGPWObGZ2ZVnxe4K3NKwAWxYubOJvfwporXWD3NgkzeV5xJqGBFWRDnr/nfsFpgCTI8goxK5db/wb7NVzLqg==}
+    cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
@@ -7769,18 +7678,10 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-linux-arm64-gnu@0.7.2:
-    resolution: {integrity: sha512-Urg2tI8F2cTp9CaM8uLtrTMlsYwCPMb1IJxqdLaQjQ0Qbrsh7HpetgCRq//uYtk0zZIH10KIUwV64vZnC5tyyQ==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-linux-arm64-gnu@0.7.5:
-    resolution: {integrity: sha512-/24UytJXrK+7CsucDb30GCKYIJ8nG6ceqbJyOtsJv9zeArNLHkxrYGSyjHJIpQfwVN17BPP4RNOi+yIZ3ZgDyA==}
-    cpu: [arm64]
-    os: [linux]
+  /@rspack/binding-darwin-x64@1.1.1:
+    resolution: {integrity: sha512-aiwJRkPGAg99vCrG/C9I87Fh9TShOAkzpf2yeJEZL4gwTj9A8wrc/xlrCFn1BDkbPnGYz62oCR7z6JLIDgYLuA==}
+    cpu: [x64]
+    os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
@@ -7799,16 +7700,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-linux-arm64-musl@0.7.2:
-    resolution: {integrity: sha512-2P8lv707ap/tjeNUWLNQ6w6xkdXmM3yQQ1foA6sU6mvh9G6hU6nEbNM2PKYMqMZtr1JE9GcZSol32ooHTQaXtA==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-linux-arm64-musl@0.7.5:
-    resolution: {integrity: sha512-6RcxG42mLM01Pa6UYycACu/Nu9qusghAPUJumb8b8x5TRIDEtklYC5Ck6Rmagm+8E0ucMude2E/D4rMdIFcS3A==}
+  /@rspack/binding-linux-arm64-gnu@1.1.1:
+    resolution: {integrity: sha512-2Z8YxH4+V0MiNhVQ2IFELDIFtykIdKgmOmGr/PuRQMHMxSn8AKo5uqBD30sZqe0+gryplZwK3hyrBETHOmSltQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -7829,17 +7722,9 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-linux-x64-gnu@0.7.2:
-    resolution: {integrity: sha512-i213AJbi5H56NlZoU0CI+7fH+RFuRyYxTPmCOZlNeLifqz2n2IGlRGf1kwnUAaB0ASSENyOXIWcCvN7xcIZ4+A==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-linux-x64-gnu@0.7.5:
-    resolution: {integrity: sha512-R0Lu4CJN2nWMW7WzPBuCIju80cQPpcaqwKJDj/quwQySpJJZ6c5qGwB8mntqjxIzZDrNH6u0OkpiUTbvWZj8ww==}
-    cpu: [x64]
+  /@rspack/binding-linux-arm64-musl@1.1.1:
+    resolution: {integrity: sha512-l+cJd3wAxBt523Min7qN+G5s3SU0rif9Yq2AFWWl+R6IvmnMlMq6sAAyiyogUidFmJ5XIKSJJBTBnvLF3g4ezg==}
+    cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -7859,16 +7744,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-linux-x64-musl@0.7.2:
-    resolution: {integrity: sha512-T5uN76HrrH+829DjqzPywFrBQ+ffdLJinK51GwlDzj4BRmU7pvW8nvmo6l3MQZ1yLJpHn2jXuS1qwFpNTKVRtg==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-linux-x64-musl@0.7.5:
-    resolution: {integrity: sha512-dDgi/ThikMy1m4llxPeEXDCA2I8F8ezFS/eCPLZGU2/J1b4ALwDjuRsMmo+VXSlFCKgIt98V6h1woeg7nu96yg==}
+  /@rspack/binding-linux-x64-gnu@1.1.1:
+    resolution: {integrity: sha512-goaDDrXNulR7FcvUfj8AjhF3g7IXUttjQ4QsfY2xz7s20tDETlq5HpcM2A8GEI6lqkPAv/ITU0AynLK7bfyr4A==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -7889,18 +7766,10 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-win32-arm64-msvc@0.7.2:
-    resolution: {integrity: sha512-YD2xWwWAchCtkVuIXzJfm7liOGHIjgllgO1lZdJchomD0AsiL826auNaMvOHt/wwIdIlPHLDyXJvMmT6MdNSSQ==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-win32-arm64-msvc@0.7.5:
-    resolution: {integrity: sha512-nEF4cUdLfgEK6FrgJSJhUlr2/7LY1tmqBNQCFsCjtDtUkQbJIEo1b8edT94G9tJcQoFE4cD+Re30yBYbQO2Thg==}
-    cpu: [arm64]
-    os: [win32]
+  /@rspack/binding-linux-x64-musl@1.1.1:
+    resolution: {integrity: sha512-T4RRn9ycxUHAfZJpfNRy+DdfevTXIZqox+NNg/N3d+Pqj5QS3zqpHBfPLC2mIIN1dw55BoshRIP2C1hUG0Fk6g==}
+    cpu: [x64]
+    os: [linux]
     requiresBuild: true
     dev: true
     optional: true
@@ -7919,17 +7788,9 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-win32-ia32-msvc@0.7.2:
-    resolution: {integrity: sha512-tcojWiDOAHMoV77bLgqZT4BJyWNtdAlRHocjuv7MTbOd8ihZDn4WzI6YZb+BOBwNBsFvRQ/P7IRUSd0GUcv6SQ==}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-win32-ia32-msvc@0.7.5:
-    resolution: {integrity: sha512-hEcHRwJIzpZsePr+5x6V/7TGhrPXhSZYG4sIhsrem1za9W+qqCYYLZ7KzzbRODU07QaAH2RxjcA1bf8F2QDYAQ==}
-    cpu: [ia32]
+  /@rspack/binding-win32-arm64-msvc@1.1.1:
+    resolution: {integrity: sha512-FHIPpueFc/+vWdZeVWRYWW0Z0IsDIHy+WhWxITeLjOVGsUN4rhaztYOausD7WsOlOhmR0SddeOYtRs/BR35wig==}
+    cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
@@ -7949,17 +7810,9 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-win32-x64-msvc@0.7.2:
-    resolution: {integrity: sha512-zYMdojvbNHVfy3jqo6h8qk/W93dd7vCDlQDr70JrhRRaN8SsxKzF0RKVsMQE5Iw1aozTfhO91VxK3Xd9bc8mGw==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-win32-x64-msvc@0.7.5:
-    resolution: {integrity: sha512-PpVpP6J5/2b4T10hzSUwjLvmdpAOj3ozARl1Nrf/lsbYwhiXivoB8Gvoy/xe/Xpgr732Dk9VCeeW8rreWOOUVQ==}
-    cpu: [x64]
+  /@rspack/binding-win32-ia32-msvc@1.1.1:
+    resolution: {integrity: sha512-pgXE45ATK/Iil/oXlqaGoWZ0x3SoQk4dAjJGK7TzQuek6UEoJbLQL+W1ufe/iUxz67ICAmUvq5NH2ftOhEE2SA==}
+    cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
@@ -7979,33 +7832,13 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rspack/binding@0.7.2:
-    resolution: {integrity: sha512-DQ/vvW6tQwImF8FCCZ9zUcsVKhZGciFki3aSEZ1BZ3GxjPSd999psFXysGFzS42yAI7Vgs9ZwiLGLewlMVWcNQ==}
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.7.2
-      '@rspack/binding-darwin-x64': 0.7.2
-      '@rspack/binding-linux-arm64-gnu': 0.7.2
-      '@rspack/binding-linux-arm64-musl': 0.7.2
-      '@rspack/binding-linux-x64-gnu': 0.7.2
-      '@rspack/binding-linux-x64-musl': 0.7.2
-      '@rspack/binding-win32-arm64-msvc': 0.7.2
-      '@rspack/binding-win32-ia32-msvc': 0.7.2
-      '@rspack/binding-win32-x64-msvc': 0.7.2
+  /@rspack/binding-win32-x64-msvc@1.1.1:
+    resolution: {integrity: sha512-z/kdbB+uhMi+H4podjTE7bfUpahACUuPOZPUtAAA6PMgRyiigBTK5UFYN35D30MONwZP4yNiLvPjurwiLw7EpA==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
     dev: true
-
-  /@rspack/binding@0.7.5:
-    resolution: {integrity: sha512-XcdOvaCz1mWWwr5vmEY9zncdInrjINEh60EWkYdqtCA67v7X7rB1fe6n4BeAI1+YLS2Eacj+lytlr+n7I+DYVg==}
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.7.5
-      '@rspack/binding-darwin-x64': 0.7.5
-      '@rspack/binding-linux-arm64-gnu': 0.7.5
-      '@rspack/binding-linux-arm64-musl': 0.7.5
-      '@rspack/binding-linux-x64-gnu': 0.7.5
-      '@rspack/binding-linux-x64-musl': 0.7.5
-      '@rspack/binding-win32-arm64-msvc': 0.7.5
-      '@rspack/binding-win32-ia32-msvc': 0.7.5
-      '@rspack/binding-win32-x64-msvc': 0.7.5
-    dev: true
+    optional: true
 
   /@rspack/binding@1.0.0:
     resolution: {integrity: sha512-eLyqSEM1h/exJYn98k+9MRktP8AYDB13x5oVn8hoxVucuhk0TubFqQSX8h9SQcZp1O3j/Z8eWWwOaNPe3JU40Q==}
@@ -8033,6 +7866,20 @@ packages:
       '@rspack/binding-win32-ia32-msvc': 1.0.14
       '@rspack/binding-win32-x64-msvc': 1.0.14
 
+  /@rspack/binding@1.1.1:
+    resolution: {integrity: sha512-BRFliHbErqWrUo9X9bdik9WTRi6EgrJSQbbUiVeIYgW4gzYdfHUohgTkWo2Byu36LZolKrEjq/Uq2A8q/tc0YA==}
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.1.1
+      '@rspack/binding-darwin-x64': 1.1.1
+      '@rspack/binding-linux-arm64-gnu': 1.1.1
+      '@rspack/binding-linux-arm64-musl': 1.1.1
+      '@rspack/binding-linux-x64-gnu': 1.1.1
+      '@rspack/binding-linux-x64-musl': 1.1.1
+      '@rspack/binding-win32-arm64-msvc': 1.1.1
+      '@rspack/binding-win32-ia32-msvc': 1.1.1
+      '@rspack/binding-win32-x64-msvc': 1.1.1
+    dev: true
+
   /@rspack/cli@1.0.0(@rspack/core@1.0.0)(webpack@5.95.0):
     resolution: {integrity: sha512-J6S/7xPR3n042mFurxa527w8DQMaTd3eWrIFmltCRXzGi4K/1VgUUyE1X0K1pKhvtgUUkFW/m+EC8bjpzNrPeg==}
     hasBin: true
@@ -8057,40 +7904,6 @@ packages:
       - utf-8-validate
       - webpack
       - webpack-cli
-    dev: true
-
-  /@rspack/core@0.7.2(@swc/helpers@0.5.3):
-    resolution: {integrity: sha512-DAQMOidKdQfjoT7KYS0eLiLXaHGk2F0Y6UrXnlQPtgfCHlx7E1c7i4lKyOkom/vmRO+s9aemNyT2f36CWEAcRQ==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-    dependencies:
-      '@module-federation/runtime-tools': 0.1.6
-      '@rspack/binding': 0.7.2
-      '@swc/helpers': 0.5.3
-      caniuse-lite: 1.0.30001669
-      tapable: 2.2.1
-      webpack-sources: 3.2.3
-    dev: true
-
-  /@rspack/core@0.7.5(@swc/helpers@0.5.3):
-    resolution: {integrity: sha512-zVTe4WCyc3qsLPattosiDYZFeOzaJ32/BYukPP2I1VJtCVFa+PxGVRPVZhSoN6fXw5oy48yHg9W9v1T8CaEFhw==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-    dependencies:
-      '@module-federation/runtime-tools': 0.1.6
-      '@rspack/binding': 0.7.5
-      '@swc/helpers': 0.5.3
-      caniuse-lite: 1.0.30001669
-      tapable: 2.2.1
-      webpack-sources: 3.2.3
     dev: true
 
   /@rspack/core@1.0.0(@swc/helpers@0.5.12):
@@ -8123,6 +7936,22 @@ packages:
       '@swc/helpers': 0.5.13
       caniuse-lite: 1.0.30001669
 
+  /@rspack/core@1.1.1(@swc/helpers@0.5.15):
+    resolution: {integrity: sha512-khYNAho2evyc7N5mYk4K6B587ou/dN1CDCqWrSDeZZNFFQHtuEp5T3kL1ntsKY7agObQhI60osCYaxFUPs0yww==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+    dependencies:
+      '@module-federation/runtime-tools': 0.5.1
+      '@rspack/binding': 1.1.1
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001669
+    dev: true
+
   /@rspack/dev-server@1.0.0(@rspack/core@1.0.0)(webpack@5.95.0):
     resolution: {integrity: sha512-ORrF+p31/jLS7tmXp7VLAX654NVpO0jNc9VM9ueG5LAyvf4d+Bo6zhFQTWsoW30uh/Xd1EZjfu+9zu4jn8Zv4Q==}
     peerDependencies:
@@ -8154,28 +7983,6 @@ packages:
   /@rspack/lite-tapable@1.0.1:
     resolution: {integrity: sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==}
     engines: {node: '>=16.0.0'}
-
-  /@rspack/plugin-react-refresh@0.7.2(react-refresh@0.14.2):
-    resolution: {integrity: sha512-ZnSKuRbzp3mPLRFUgeD2CX6Vs5Mfx5t4tSoP9+pvfx6vr5Cu4xnpgsJeKNnW/9jHTgPoNegdIxGidwxzwh/rlg==}
-    peerDependencies:
-      react-refresh: '>=0.10.0 <1.0.0'
-    peerDependenciesMeta:
-      react-refresh:
-        optional: true
-    dependencies:
-      react-refresh: 0.14.2
-    dev: true
-
-  /@rspack/plugin-react-refresh@0.7.5(react-refresh@0.14.2):
-    resolution: {integrity: sha512-ROI9lrmfIH+Z9lbBaP3YMhbD2R3rlm9SSzi/9WzzkQU6KK911S1D+sL2ByeJ7ipZafbHvMPWTmC2aQEvjhwQig==}
-    peerDependencies:
-      react-refresh: '>=0.10.0 <1.0.0'
-    peerDependenciesMeta:
-      react-refresh:
-        optional: true
-    dependencies:
-      react-refresh: 0.14.2
-    dev: true
 
   /@rspack/plugin-react-refresh@1.0.0(react-refresh@0.14.2):
     resolution: {integrity: sha512-WvXkLewW5G0Mlo5H1b251yDh5FFiH4NDAbYlFpvFjcuXX2AchZRf9zdw57BDE/ADyWsJgA8kixN/zZWBTN3iYA==}
@@ -8598,10 +8405,10 @@ packages:
     dependencies:
       tslib: 2.7.0
 
-  /@swc/helpers@0.5.3:
-    resolution: {integrity: sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==}
+  /@swc/helpers@0.5.15:
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
     dev: true
 
   /@swc/plugin-styled-components@2.0.11:
@@ -9791,6 +9598,19 @@ packages:
       '@babel/core': 7.25.8
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
+      webpack: 5.95.0(esbuild@0.17.19)
+    dev: true
+
+  /babel-loader@9.1.3(@babel/core@7.26.0)(webpack@5.95.0):
+    resolution: {integrity: sha512-xG3ST4DglodGf8qSwv0MdeWLhrDsw/32QMdTO5T1ZIp9gQur0HkCyFs7Awskr10JKXFXwpAhiCuYX5oGXnRGbw==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      '@babel/core': ^7.12.0
+      webpack: '>=5'
+    dependencies:
+      '@babel/core': 7.26.0
+      find-cache-dir: 4.0.0
+      schema-utils: 4.2.0
       webpack: 5.95.0
     dev: true
 
@@ -10754,11 +10574,6 @@ packages:
     requiresBuild: true
     dev: true
 
-  /core-js@3.36.1:
-    resolution: {integrity: sha512-BTvUrwxVBezj5SZ3f10ImnX2oRByMxql3EimVqMysepbC9EeMUOpLwdy6Eoili2x6E4kf+ZUB5k/+Jv55alPfA==}
-    requiresBuild: true
-    dev: true
-
   /core-js@3.37.1:
     resolution: {integrity: sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==}
     requiresBuild: true
@@ -10772,6 +10587,11 @@ packages:
   /core-js@3.38.1:
     resolution: {integrity: sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==}
     requiresBuild: true
+
+  /core-js@3.39.0:
+    resolution: {integrity: sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==}
+    requiresBuild: true
+    dev: true
 
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -13309,30 +13129,6 @@ packages:
       void-elements: 3.1.0
     dev: true
 
-  /html-rspack-plugin@5.7.2(@rspack/core@0.7.2):
-    resolution: {integrity: sha512-uVXGYq19bcsX7Q/53VqXQjCKXw0eUMHlFGDLTaqzgj/ckverfhZQvXyA6ecFBaF9XUH16jfCTCyALYi0lJcagg==}
-    engines: {node: '>=10.13.0'}
-    peerDependencies:
-      '@rspack/core': 0.x || 1.x
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
-    dependencies:
-      '@rspack/core': 0.7.2(@swc/helpers@0.5.3)
-    dev: true
-
-  /html-rspack-plugin@5.7.2(@rspack/core@0.7.5):
-    resolution: {integrity: sha512-uVXGYq19bcsX7Q/53VqXQjCKXw0eUMHlFGDLTaqzgj/ckverfhZQvXyA6ecFBaF9XUH16jfCTCyALYi0lJcagg==}
-    engines: {node: '>=10.13.0'}
-    peerDependencies:
-      '@rspack/core': 0.x || 1.x
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
-    dependencies:
-      '@rspack/core': 0.7.5(@swc/helpers@0.5.3)
-    dev: true
-
   /html-tags@3.3.1:
     resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
     engines: {node: '>=8'}
@@ -13575,6 +13371,10 @@ packages:
 
   /immutable@4.3.7:
     resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
+
+  /immutable@5.0.2:
+    resolution: {integrity: sha512-1NU7hWZDkV7hJ4PJ9dur9gTNQ4ePNPN4k9/0YhwjzykTi/+3Q5pF93YU5QoVj8BuOnhLgaY8gs0U2pj4kSYVcw==}
+    dev: true
 
   /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -16588,15 +16388,6 @@ packages:
       picocolors: 1.1.0
       source-map-js: 1.2.0
 
-  /postcss@8.4.45:
-    resolution: {integrity: sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.1.0
-      source-map-js: 1.2.1
-    dev: true
-
   /postcss@8.4.47:
     resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -18259,16 +18050,6 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  /sass-embedded-android-arm64@1.77.8:
-    resolution: {integrity: sha512-EmWHLbEx0Zo/f/lTFzMeH2Du+/I4RmSRlEnERSUKQWVp3aBSO04QDvdxfFezgQ+2Yt/ub9WMqBpma9P/8MPsLg==}
-    engines: {node: '>=14.0.0'}
-    cpu: [arm64]
-    os: [android]
-    hasBin: true
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /sass-embedded-android-arm64@1.79.5:
     resolution: {integrity: sha512-pq1RJTENkRmEUMLiVuSGYwuLk8zXovWzrjQxlWZTF/Jn5F7Ypi/3v5huMmgJF5n+etsxjio1PN1idaQ5tPLBmg==}
     engines: {node: '>=14.0.0'}
@@ -18277,12 +18058,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-android-arm@1.77.8:
-    resolution: {integrity: sha512-GpGL7xZ7V1XpFbnflib/NWbM0euRzineK0iwoo31/ntWKAXGj03iHhGzkSiOwWSFcXgsJJi3eRA5BTmBvK5Q+w==}
+  /sass-embedded-android-arm64@1.80.7:
+    resolution: {integrity: sha512-Gwl/OY80uEA14MLm7efJvc1ErgGT51SvAv4/kIpTziOJpkk+999/nrEJHQ6YAJ7r5DuQcKvC3lHipcENUIpP9A==}
     engines: {node: '>=14.0.0'}
-    cpu: [arm]
+    cpu: [arm64]
     os: [android]
-    hasBin: true
     requiresBuild: true
     dev: true
     optional: true
@@ -18295,12 +18075,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-android-ia32@1.77.8:
-    resolution: {integrity: sha512-+GjfJ3lDezPi4dUUyjQBxlNKXNa+XVWsExtGvVNkv1uKyaOxULJhubVo2G6QTJJU0esJdfeXf5Ca5/J0ph7+7w==}
+  /sass-embedded-android-arm@1.80.7:
+    resolution: {integrity: sha512-pMxJ70yOGXYGmfoGlAMKqnr/nuP/UgKV3jc7v5kpmWGpPPMF2u63DM2QkvTqM32FyfwyxSycVaNFNT+gPomTiw==}
     engines: {node: '>=14.0.0'}
-    cpu: [ia32]
+    cpu: [arm]
     os: [android]
-    hasBin: true
     requiresBuild: true
     dev: true
     optional: true
@@ -18313,6 +18092,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /sass-embedded-android-ia32@1.80.7:
+    resolution: {integrity: sha512-CJccGPgBePPYiXhyQWvgHF8AqjIDSGf+mcC4Ac/f5upRd9Z/vhQVrJfsDxt4c4tV0HGEfbQpT9xOCYF1Z6luZQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [ia32]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /sass-embedded-android-riscv64@1.79.5:
     resolution: {integrity: sha512-OLbdmDSM/eOjO01PUYbS54BQOCM/HHHHWk/4M8HHdxwF3ojy5eqQaA63R1YQ3IJvLEE7dnudofOXmL01B5+yvQ==}
     engines: {node: '>=14.0.0'}
@@ -18321,12 +18109,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-android-x64@1.77.8:
-    resolution: {integrity: sha512-YZbFDzGe5NhaMCygShqkeCWtzjhkWxGVunc7ULR97wmxYPQLPeVyx7XFQZc84Aj0lKAJBJS4qRZeqphMqZEJsQ==}
+  /sass-embedded-android-riscv64@1.80.7:
+    resolution: {integrity: sha512-kIGcyuhNes9NUDzJ9VHy/ZGKdADCCt7JAwiC7lFSc6/xs5rJtGRn6hZ+mcG7gQWAezb5oK/VMQl8ps7HBFUEXw==}
     engines: {node: '>=14.0.0'}
-    cpu: [x64]
+    cpu: [riscv64]
     os: [android]
-    hasBin: true
     requiresBuild: true
     dev: true
     optional: true
@@ -18339,12 +18126,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-darwin-arm64@1.77.8:
-    resolution: {integrity: sha512-aifgeVRNE+i43toIkDFFJc/aPLMo0PJ5s5hKb52U+oNdiJE36n65n2L8F/8z3zZRvCa6eYtFY2b7f1QXR3B0LA==}
+  /sass-embedded-android-x64@1.80.7:
+    resolution: {integrity: sha512-oLMQiFpbSczOrGZSWlZvVJ1T9L6nDjS2u8PTxfT0MFX/FT3EhaxylHeiYKrmtY4epRufNCC/G96DMVqnSNa1QQ==}
     engines: {node: '>=14.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-    hasBin: true
+    cpu: [x64]
+    os: [android]
     requiresBuild: true
     dev: true
     optional: true
@@ -18357,12 +18143,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-darwin-x64@1.77.8:
-    resolution: {integrity: sha512-/VWZQtcWIOek60Zj6Sxk6HebXA1Qyyt3sD8o5qwbTgZnKitB1iEBuNunyGoAgMNeUz2PRd6rVki6hvbas9hQ6w==}
+  /sass-embedded-darwin-arm64@1.80.7:
+    resolution: {integrity: sha512-Vi5BbTWd9OO0tC60CPw5IY7w3Tccr1/Gy2DdkfE4qP6Rc368WmUis5ceG8ehAye0IT7aoRXpw8XTzWyXAZHbfw==}
     engines: {node: '>=14.0.0'}
-    cpu: [x64]
+    cpu: [arm64]
     os: [darwin]
-    hasBin: true
     requiresBuild: true
     dev: true
     optional: true
@@ -18375,12 +18160,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-linux-arm64@1.77.8:
-    resolution: {integrity: sha512-6iIOIZtBFa2YfMsHqOb3qake3C9d/zlKxjooKKnTSo+6g6z+CLTzMXe1bOfayb7yxeenElmFoK1k54kWD/40+g==}
+  /sass-embedded-darwin-x64@1.80.7:
+    resolution: {integrity: sha512-yeANclgSHJ7K/XLG4Lnk7aQ5dk7K+oqIOtoOP0bjXgWsdPbes9V7k1ZJ9mZGl+f/XAPaRRPqjKs4WHU9s8m8MA==}
     engines: {node: '>=14.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    hasBin: true
+    cpu: [x64]
+    os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
@@ -18393,12 +18177,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-linux-arm@1.77.8:
-    resolution: {integrity: sha512-2edZMB6jf0whx3T0zlgH+p131kOEmWp+I4wnKj7ZMUeokiY4Up05d10hSvb0Q63lOrSjFAWu6P5/pcYUUx8arQ==}
+  /sass-embedded-linux-arm64@1.80.7:
+    resolution: {integrity: sha512-Idb5K9LHHWklN7A/kqWUd6sktA36V70bSjZ/gvCDu/5CBJBkMsVNdrxcdpGzrZe7pYV4XUTkMZOwf91owEywtQ==}
     engines: {node: '>=14.0.0'}
-    cpu: [arm]
+    cpu: [arm64]
     os: [linux]
-    hasBin: true
     requiresBuild: true
     dev: true
     optional: true
@@ -18411,12 +18194,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-linux-ia32@1.77.8:
-    resolution: {integrity: sha512-63GsFFHWN5yRLTWiSef32TM/XmjhCBx1DFhoqxmj+Yc6L9Z1h0lDHjjwdG6Sp5XTz5EmsaFKjpDgnQTP9hJX3Q==}
+  /sass-embedded-linux-arm@1.80.7:
+    resolution: {integrity: sha512-ZttC6H2Z9YXUVFlprqZ0AgXuHdzqhvhUWsG7UUqkND9JSHvyFSwRij4h90aOK3gKg3PBGI4yG5tonLq2yV525A==}
     engines: {node: '>=14.0.0'}
-    cpu: [ia32]
+    cpu: [arm]
     os: [linux]
-    hasBin: true
     requiresBuild: true
     dev: true
     optional: true
@@ -18429,10 +18211,10 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-linux-musl-arm64@1.77.8:
-    resolution: {integrity: sha512-j8cgQxNWecYK+aH8ESFsyam/Q6G+9gg8eJegiRVpA9x8yk3ykfHC7UdQWwUcF22ZcuY4zegrjJx8k+thsgsOVA==}
+  /sass-embedded-linux-ia32@1.80.7:
+    resolution: {integrity: sha512-xKnWWEFz1jFc9xDAG7nMcjPBCTuiJbqvTmEtwQoWj79hQrzVdkLM6SiUGVbGa1c2s2fJMS3Bg2fkDJBK6/BcuQ==}
     engines: {node: '>=14.0.0'}
-    cpu: [arm64]
+    cpu: [ia32]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -18446,10 +18228,10 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-linux-musl-arm@1.77.8:
-    resolution: {integrity: sha512-nFkhSl3uu9btubm+JBW7uRglNVJ8W8dGfzVqh3fyQJKS1oyBC3vT3VOtfbT9YivXk28wXscSHpqXZwY7bUuopA==}
+  /sass-embedded-linux-musl-arm64@1.80.7:
+    resolution: {integrity: sha512-7+GCYIh+c1BG4ot/PbTvVXUxd2GxDWcMxV7i3sARStQBDpTZFfohWdjUytLyqGxQgJIrbq0Q60Ucrw6HUJtJ9A==}
     engines: {node: '>=14.0.0'}
-    cpu: [arm]
+    cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -18463,10 +18245,10 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-linux-musl-ia32@1.77.8:
-    resolution: {integrity: sha512-oWveMe+8TFlP8WBWPna/+Ec5TV0CE+PxEutyi0ltSruBds2zxRq9dPVOqrpPcDN9QUx50vNZC0Afgch0aQEd0g==}
+  /sass-embedded-linux-musl-arm@1.80.7:
+    resolution: {integrity: sha512-gJLfSFiiuGaqWjaj0bcuhOlQ+t1jS9StuzXnW1b9gy2I6Y0uCprgbbELgtRVPSZlCG2BBolR76YCGQTB85M43Q==}
     engines: {node: '>=14.0.0'}
-    cpu: [ia32]
+    cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -18480,6 +18262,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /sass-embedded-linux-musl-ia32@1.80.7:
+    resolution: {integrity: sha512-Iw2E6P1lha335C5tGNgPjLD7Oll7OdLBJ7uPKaU+I7KbiOPk7ELsxUL9AYIrKO0/MLtgxGqOWWfTo/5cvU8xSA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /sass-embedded-linux-musl-riscv64@1.79.5:
     resolution: {integrity: sha512-wrc6s8YQt95koSkaLoP5HtvAAKxTPWqYZVxnoqp2bHgkKWlr4ymJll9vMcdU3//VxTgJbuH83U5ajzNCtHd0NQ==}
     engines: {node: '>=14.0.0'}
@@ -18488,10 +18279,10 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-linux-musl-x64@1.77.8:
-    resolution: {integrity: sha512-2NtRpMXHeFo9kaYxuZ+Ewwo39CE7BTS2JDfXkTjZTZqd8H+8KC53eBh516YQnn2oiqxSiKxm7a6pxbxGZGwXOQ==}
+  /sass-embedded-linux-musl-riscv64@1.80.7:
+    resolution: {integrity: sha512-gd92dkDVpTh4xJb2hpX82E6el30h4MxCb7VJLwtbQSrQuxOlZgaDX4plMSZifsNTLvOsafdLCYyI+QsZRr8bkA==}
     engines: {node: '>=14.0.0'}
-    cpu: [x64]
+    cpu: [riscv64]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -18505,6 +18296,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /sass-embedded-linux-musl-x64@1.80.7:
+    resolution: {integrity: sha512-i5udU+i0LZrL3dhHAgIfK7LBaHtScwAceiykndNIHyRXc1TY2DX3lG0EolVUvPyWFUNnvGCgxZF8oUToPzJ+pw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /sass-embedded-linux-riscv64@1.79.5:
     resolution: {integrity: sha512-G45UKRAUgvxXhLROowTgVmyIVyGtRZoCMVH1vPi0EG5SePy43AkhjQVaUb6Ol6lfRRNpQqBFKw3UabxaMCM0Ow==}
     engines: {node: '>=14.0.0'}
@@ -18513,12 +18313,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-linux-x64@1.77.8:
-    resolution: {integrity: sha512-ND5qZLWUCpOn7LJfOf0gLSZUWhNIysY+7NZK1Ctq+pM6tpJky3JM5I1jSMplNxv5H3o8p80n0gSm+fcjsEFfjQ==}
+  /sass-embedded-linux-riscv64@1.80.7:
+    resolution: {integrity: sha512-DvnXvu019c6THNQnSWfy2eY/HFWZ2ogGUjRkdKAxj7U7i/YD+bsDIxdDQHZ48qzOguzx8n2aRa/clriM0HQPUA==}
     engines: {node: '>=14.0.0'}
-    cpu: [x64]
+    cpu: [riscv64]
     os: [linux]
-    hasBin: true
     requiresBuild: true
     dev: true
     optional: true
@@ -18531,12 +18330,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-win32-arm64@1.77.8:
-    resolution: {integrity: sha512-7L8zT6xzEvTYj86MvUWnbkWYCNQP+74HvruLILmiPPE+TCgOjgdi750709BtppVJGGZSs40ZuN6mi/YQyGtwXg==}
+  /sass-embedded-linux-x64@1.80.7:
+    resolution: {integrity: sha512-nQB+IZwCzVPpPkP5L9zV416/AGPLky7L2GGPWtvxG2CEeTV1Rzet+gkhzk2eYEdbh+3py/w9YVRTaQuZ3QV0vQ==}
     engines: {node: '>=14.0.0'}
-    cpu: [arm64]
-    os: [win32]
-    hasBin: true
+    cpu: [x64]
+    os: [linux]
     requiresBuild: true
     dev: true
     optional: true
@@ -18549,12 +18347,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-win32-ia32@1.77.8:
-    resolution: {integrity: sha512-7Buh+4bP0WyYn6XPbthkIa3M2vtcR8QIsFVg3JElVlr+8Ng19jqe0t0SwggDgbMX6AdQZC+Wj4F1BprZSok42A==}
+  /sass-embedded-win32-arm64@1.80.7:
+    resolution: {integrity: sha512-Q6Rh/CM30m8txoKK5SIVamnwPXs028Mvfq4Ol4saHgSYro9kY/HTrrWlG/RPd6sPvYBCYIm1mX8oBteDUMCajQ==}
     engines: {node: '>=14.0.0'}
-    cpu: [ia32]
+    cpu: [arm64]
     os: [win32]
-    hasBin: true
     requiresBuild: true
     dev: true
     optional: true
@@ -18567,12 +18364,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded-win32-x64@1.77.8:
-    resolution: {integrity: sha512-rZmLIx4/LLQm+4GW39sRJW0MIlDqmyV0fkRzTmhFP5i/wVC7cuj8TUubPHw18rv2rkHFfBZKZJTCkPjCS5Z+SA==}
+  /sass-embedded-win32-ia32@1.80.7:
+    resolution: {integrity: sha512-VZMRp81KWUZZDqNwkL3yTDT+VRxB7ScJKUJD1M8fq6P1nyJP35+r1byXLF4UQMoNgpC5B16txxMvqdkv43OqAA==}
     engines: {node: '>=14.0.0'}
-    cpu: [x64]
+    cpu: [ia32]
     os: [win32]
-    hasBin: true
     requiresBuild: true
     dev: true
     optional: true
@@ -18585,35 +18381,14 @@ packages:
     requiresBuild: true
     optional: true
 
-  /sass-embedded@1.77.8:
-    resolution: {integrity: sha512-WGXA6jcaoBo5Uhw0HX/s6z/sl3zyYQ7ZOnLOJzqwpctFcFmU4L07zn51e2VSkXXFpQZFAdMZNqOGz/7h/fvcRA==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      '@bufbuild/protobuf': 1.10.0
-      buffer-builder: 0.2.0
-      immutable: 4.3.7
-      rxjs: 7.8.1
-      supports-color: 8.1.1
-      varint: 6.0.0
-    optionalDependencies:
-      sass-embedded-android-arm: 1.77.8
-      sass-embedded-android-arm64: 1.77.8
-      sass-embedded-android-ia32: 1.77.8
-      sass-embedded-android-x64: 1.77.8
-      sass-embedded-darwin-arm64: 1.77.8
-      sass-embedded-darwin-x64: 1.77.8
-      sass-embedded-linux-arm: 1.77.8
-      sass-embedded-linux-arm64: 1.77.8
-      sass-embedded-linux-ia32: 1.77.8
-      sass-embedded-linux-musl-arm: 1.77.8
-      sass-embedded-linux-musl-arm64: 1.77.8
-      sass-embedded-linux-musl-ia32: 1.77.8
-      sass-embedded-linux-musl-x64: 1.77.8
-      sass-embedded-linux-x64: 1.77.8
-      sass-embedded-win32-arm64: 1.77.8
-      sass-embedded-win32-ia32: 1.77.8
-      sass-embedded-win32-x64: 1.77.8
+  /sass-embedded-win32-x64@1.80.7:
+    resolution: {integrity: sha512-4p+GzOJJ1KqxPKrkIkKisod4YAcC70fj4WMRLrQLLuUW+MzAvtKgX2+ZJf90D50CozSdgETGBvdPSj3VLjBzZw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
     dev: true
+    optional: true
 
   /sass-embedded@1.79.5:
     resolution: {integrity: sha512-QFdalnjGFkbNvb6/uQGmP4OIN+GQ5/R77eu0PsXduDB1YP5JW5DSWFVDAyK6l6C54P+3J3eXkjuPYC0mcwX+AA==}
@@ -18648,6 +18423,42 @@ packages:
       sass-embedded-win32-arm64: 1.79.5
       sass-embedded-win32-ia32: 1.79.5
       sass-embedded-win32-x64: 1.79.5
+
+  /sass-embedded@1.80.7:
+    resolution: {integrity: sha512-OwF0QvpDUjW2udPCvxgaObU0tQHycpsIgCDtHBVHuOqZ2LN0OkkY+uxSO7bOaw9wD7vXtt+1V+jiIZDTxiSRVQ==}
+    engines: {node: '>=16.0.0'}
+    hasBin: true
+    dependencies:
+      '@bufbuild/protobuf': 2.1.0
+      buffer-builder: 0.2.0
+      colorjs.io: 0.5.2
+      immutable: 5.0.2
+      rxjs: 7.8.1
+      supports-color: 8.1.1
+      sync-child-process: 1.0.2
+      varint: 6.0.0
+    optionalDependencies:
+      sass-embedded-android-arm: 1.80.7
+      sass-embedded-android-arm64: 1.80.7
+      sass-embedded-android-ia32: 1.80.7
+      sass-embedded-android-riscv64: 1.80.7
+      sass-embedded-android-x64: 1.80.7
+      sass-embedded-darwin-arm64: 1.80.7
+      sass-embedded-darwin-x64: 1.80.7
+      sass-embedded-linux-arm: 1.80.7
+      sass-embedded-linux-arm64: 1.80.7
+      sass-embedded-linux-ia32: 1.80.7
+      sass-embedded-linux-musl-arm: 1.80.7
+      sass-embedded-linux-musl-arm64: 1.80.7
+      sass-embedded-linux-musl-ia32: 1.80.7
+      sass-embedded-linux-musl-riscv64: 1.80.7
+      sass-embedded-linux-musl-x64: 1.80.7
+      sass-embedded-linux-riscv64: 1.80.7
+      sass-embedded-linux-x64: 1.80.7
+      sass-embedded-win32-arm64: 1.80.7
+      sass-embedded-win32-ia32: 1.80.7
+      sass-embedded-win32-x64: 1.80.7
+    dev: true
 
   /sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
@@ -19389,6 +19200,18 @@ packages:
       csso: 5.0.5
       picocolors: 1.1.0
 
+  /sync-child-process@1.0.2:
+    resolution: {integrity: sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      sync-message-port: 1.1.3
+    dev: true
+
+  /sync-message-port@1.1.3:
+    resolution: {integrity: sha512-GTt8rSKje5FilG+wEdfCkOcLL7LWqpMlr2c3LRuKt/YXxcJ52aGSbGBAdI4L3aaqfrBt6y711El53ItyH1NWzg==}
+    engines: {node: '>=16.0.0'}
+    dev: true
+
   /table@6.8.2:
     resolution: {integrity: sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==}
     engines: {node: '>=10.0.0'}
@@ -19742,6 +19565,10 @@ packages:
 
   /tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
+  /tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+    dev: true
 
   /tsm@2.3.0:
     resolution: {integrity: sha512-++0HFnmmR+gMpDtKTnW3XJ4yv9kVGi20n+NfyQWB9qwJvTaIWY9kBmzek2YUQK5APTQ/1DTrXmm4QtFPmW9Rzw==}

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -24,7 +24,7 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rspack/core": "1.0.14",
+    "@rspack/core": "^1.1.1",
     "@types/lodash": "^4.17.13",
     "@types/node": "^16",
     "lodash": "^4.17.21",


### PR DESCRIPTION
## Summary

- Bump all Rsbuild related packages from v0.7 to v1.1.
- Bump all Rspack related packages from v1.0 to v1.1.
- Fix the `scriptSrcs` RegExp to allow it match `<script defer src="*">`
