### PR TITLE
fix(client): eliminate Sass deprecation warning

### DIFF
--- a/packages/client/src/common/styles/base.scss
+++ b/packages/client/src/common/styles/base.scss
@@ -1,5 +1,6 @@
-@import "normalize.css";
-@import "./theme.scss";
+@use 'sass:meta';
+@import 'normalize.css';
+@include meta.load-css('./theme.scss');
 
 .body {
   font-size: 12px;


### PR DESCRIPTION
## Summary

Eliminate a Sass deprecation warning:

<img width="1363" alt="Screenshot 2024-11-15 at 16 48 30" src="https://github.com/user-attachments/assets/07f9530c-4085-477a-adc4-81b9797e336d">

## Related Links

See: https://sass-lang.com/documentation/breaking-changes/import/
