### PR TITLE
chore(deps): update socket.io

### DIFF
--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -23,7 +23,7 @@
     "@rsdoctor/types": "workspace:*",
     "@rsdoctor/utils": "workspace:*",
     "lodash": "^4.17.21",
-    "socket.io": "4.7.2",
+    "socket.io": "4.8.1",
     "source-map": "^0.7.4"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.17.21",
     "open": "^8.4.2",
     "serve-static": "1.16.2",
-    "socket.io": "4.7.2",
+    "socket.io": "4.8.1",
     "source-map": "^0.7.4",
     "tapable": "2.2.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -939,8 +939,8 @@ importers:
         specifier: 1.16.2
         version: 1.16.2
       socket.io:
-        specifier: 4.7.2
-        version: 4.7.2
+        specifier: 4.8.1
+        version: 4.8.1
       source-map:
         specifier: ^0.7.4
         version: 0.7.4
@@ -10628,11 +10628,6 @@ packages:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
     dev: true
 
-  /cookie@0.4.2:
-    resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
-    engines: {node: '>= 0.6'}
-    dev: false
-
   /cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
@@ -11126,6 +11121,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: true
 
   /debug@4.3.7(supports-color@5.5.0):
     resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
@@ -11538,26 +11534,6 @@ packages:
   /engine.io-parser@5.2.3:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
-    dev: false
-
-  /engine.io@6.5.5:
-    resolution: {integrity: sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==}
-    engines: {node: '>=10.2.0'}
-    dependencies:
-      '@types/cookie': 0.4.1
-      '@types/cors': 2.8.17
-      '@types/node': 16.18.104
-      accepts: 1.3.8
-      base64id: 2.0.0
-      cookie: 0.4.2
-      cors: 2.8.5
-      debug: 4.3.6
-      engine.io-parser: 5.2.3
-      ws: 8.17.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
     dev: false
 
   /engine.io@6.6.2:
@@ -15354,6 +15330,7 @@ packages:
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: true
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -18806,23 +18783,6 @@ packages:
       debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
-
-  /socket.io@4.7.2:
-    resolution: {integrity: sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==}
-    engines: {node: '>=10.2.0'}
-    dependencies:
-      accepts: 1.3.8
-      base64id: 2.0.0
-      cors: 2.8.5
-      debug: 4.3.6
-      engine.io: 6.5.5
-      socket.io-adapter: 2.5.5
-      socket.io-parser: 4.2.4
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: false
 
   /socket.io@4.8.1:
     resolution: {integrity: sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,8 +825,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       socket.io:
-        specifier: 4.7.2
-        version: 4.7.2
+        specifier: 4.8.1
+        version: 4.8.1
       source-map:
         specifier: ^0.7.4
         version: 0.7.4
@@ -10643,6 +10643,11 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
+  /cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /copy-anything@2.0.6:
     resolution: {integrity: sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==}
     dependencies:
@@ -11547,6 +11552,26 @@ packages:
       cookie: 0.4.2
       cors: 2.8.5
       debug: 4.3.6
+      engine.io-parser: 5.2.3
+      ws: 8.17.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /engine.io@6.6.2:
+    resolution: {integrity: sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==}
+    engines: {node: '>=10.2.0'}
+    dependencies:
+      '@types/cookie': 0.4.1
+      '@types/cors': 2.8.17
+      '@types/node': 16.18.104
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.5
+      debug: 4.3.7(supports-color@5.5.0)
       engine.io-parser: 5.2.3
       ws: 8.17.1
     transitivePeerDependencies:
@@ -18751,7 +18776,7 @@ packages:
   /socket.io-adapter@2.5.5:
     resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
     dependencies:
-      debug: 4.3.6
+      debug: 4.3.7(supports-color@5.5.0)
       ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
@@ -18791,6 +18816,23 @@ packages:
       cors: 2.8.5
       debug: 4.3.6
       engine.io: 6.5.5
+      socket.io-adapter: 2.5.5
+      socket.io-parser: 4.2.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /socket.io@4.8.1:
+    resolution: {integrity: sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==}
+    engines: {node: '>=10.2.0'}
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.5
+      debug: 4.3.7(supports-color@5.5.0)
+      engine.io: 6.6.2
       socket.io-adapter: 2.5.5
       socket.io-parser: 4.2.4
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

The package `@rsdoctor/graph` currently depends on a vulnerable version of `socket.io`.

```bash
# npm audit report

cookie  <0.7.0
cookie accepts cookie name, path, and domain with out of bounds characters - https://github.com/advisories/GHSA-pxg6-pf52-xh8x
No fix available
node_modules/engine.io/node_modules/cookie
  engine.io  1.8.0 - 6.6.1
  Depends on vulnerable versions of cookie
  node_modules/engine.io
    socket.io  1.6.0 - 4.7.5
    Depends on vulnerable versions of engine.io
    node_modules/socket.io
      @rsdoctor/graph  *
      Depends on vulnerable versions of socket.io
      node_modules/@rsdoctor/graph
        @rsdoctor/core  *
        Depends on vulnerable versions of @rsdoctor/graph
        Depends on vulnerable versions of @rsdoctor/sdk
        node_modules/@rsdoctor/core
        @rsdoctor/rspack-plugin  *
        Depends on vulnerable versions of @rsdoctor/core
        Depends on vulnerable versions of @rsdoctor/graph
        Depends on vulnerable versions of @rsdoctor/sdk
        node_modules/@rsdoctor/rspack-plugin
        @rsdoctor/webpack-plugin  *
        Depends on vulnerable versions of @rsdoctor/core
        Depends on vulnerable versions of @rsdoctor/graph
        Depends on vulnerable versions of @rsdoctor/sdk
        node_modules/@rsdoctor/webpack-plugin
      @rsdoctor/sdk  *
      Depends on vulnerable versions of @rsdoctor/graph
      Depends on vulnerable versions of socket.io
      node_modules/@rsdoctor/sdk
```

```bash
npm ls cooke
@rsdoctor/rspack-plugin@0.4.11
│ └─┬ @rsdoctor/graph@0.4.11
│   └─┬ socket.io@4.7.2
│     └─┬ engine.io@6.5.5
│       └── cookie@0.4.2
```

The newer versions of `socket.io` have already updated cookie to `~1.0.2`.

**Note**: I was not able to run the e2e tests since I'm on arch linux and even with an ubuntu docker image it did not work.
