### PR TITLE
perf: reduce the bundle size of client

### DIFF
--- a/packages/client/rsbuild.config.ts
+++ b/packages/client/rsbuild.config.ts
@@ -146,6 +146,7 @@ export default defineConfig(({ env }) => {
                     ids: true,
                     version: true,
                     entrypoints: true,
+                    optimizationBailout: true,
                   });
                   await fs.promises.writeFile(
                     WebpackStatsFilePath,
@@ -161,13 +162,6 @@ export default defineConfig(({ env }) => {
           chainConfig.plugin('rsdoctor').use(RsdoctorRspackPlugin, [
             {
               disableClientServer: !ENABLE_CLIENT_SERVER,
-              features: {
-                loader: true,
-                plugins: true,
-                resolver: true,
-                bundle: true,
-                treeShaking: true,
-              },
             },
           ]);
         }

--- a/packages/components/src/pages/TreeShaking/table.tsx
+++ b/packages/components/src/pages/TreeShaking/table.tsx
@@ -1,5 +1,5 @@
 import { SDK } from '@rsdoctor/types';
-import {
+import type {
   Module,
   ModuleGraph,
   Statement,

--- a/packages/components/src/pages/TreeShaking/utils.tsx
+++ b/packages/components/src/pages/TreeShaking/utils.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
 import path from 'path-browserify';
 import { escape, get } from 'lodash-es';
-import { Module, ModuleGraph, Statement, Variable } from '@rsdoctor/graph';
+import type { ModuleGraph, Statement, Variable } from '@rsdoctor/graph';
+import { Module } from '@rsdoctor/graph';
 import { Tag, Space } from 'antd';
 import { Range } from './range';
 import type { editor, Range as RangeClass } from 'monaco-editor';

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -22,14 +22,14 @@
   "dependencies": {
     "@rsdoctor/types": "workspace:*",
     "@rsdoctor/utils": "workspace:*",
-    "lodash": "^4.17.21",
+    "lodash.unionby": "^4.8.0",
     "socket.io": "4.8.1",
     "source-map": "^0.7.4"
   },
   "devDependencies": {
     "@types/body-parser": "1.19.5",
     "@types/estree": "1.0.5",
-    "@types/lodash": "^4.17.13",
+    "@types/lodash.unionby": "^4.8.9",
     "@types/node": "^16",
     "fs-extra": "^11.1.1",
     "tslib": "2.8.1",

--- a/packages/graph/src/graph/module-graph/module.ts
+++ b/packages/graph/src/graph/module-graph/module.ts
@@ -1,6 +1,6 @@
 import { SDK } from '@rsdoctor/types';
 import path from 'path';
-import { isNumber } from 'lodash';
+import { Lodash } from '@rsdoctor/utils/common';
 import type { SourceMapConsumer } from 'source-map';
 import type { Program } from 'estree';
 import { Dependency } from './dependency';
@@ -263,7 +263,7 @@ export class Module implements SDK.ModuleInstance {
       bias: 1,
     });
 
-    if (isNumber(startInSource.line)) {
+    if (Lodash.isNumber(startInSource.line)) {
       source.start = {
         line: startInSource.line,
         column: startInSource.column ?? undefined,
@@ -278,7 +278,7 @@ export class Module implements SDK.ModuleInstance {
         // bias: 2,
       });
 
-      if (isNumber(endInSource.line)) {
+      if (Lodash.isNumber(endInSource.line)) {
         source.end = {
           line: endInSource.line,
           column: endInSource.column ?? undefined,

--- a/packages/graph/src/graph/module-graph/utils.ts
+++ b/packages/graph/src/graph/module-graph/utils.ts
@@ -1,5 +1,5 @@
 import type { SDK } from '@rsdoctor/types';
-import { last, isUndefined, isNil } from 'lodash';
+import { Lodash } from '@rsdoctor/utils/common';
 
 export function isSamePosition(
   po1: SDK.SourcePosition,
@@ -13,11 +13,11 @@ export function isSameRange(po1: SDK.SourceRange, po2: SDK.SourceRange) {
     return false;
   }
 
-  if (!isNil(po1.end) && !isNil(po2.end)) {
+  if (!Lodash.isNil(po1.end) && !Lodash.isNil(po2.end)) {
     return isSamePosition(po1.end, po2.end);
   }
 
-  return isUndefined(po1.end) && isUndefined(po2.end);
+  return Lodash.isUndefined(po1.end) && Lodash.isUndefined(po2.end);
 }
 
 /**
@@ -44,7 +44,7 @@ export function getModuleName(name?: string) {
   }
 
   if (NAME_WITH_LOADERS.test(name)) {
-    const normalizedName = last(name.split(NAME_WITH_LOADERS));
+    const normalizedName = Lodash.last(name.split(NAME_WITH_LOADERS));
 
     if (normalizedName?.trim()) {
       return normalizedName;

--- a/packages/graph/src/graph/package-graph/graph.ts
+++ b/packages/graph/src/graph/package-graph/graph.ts
@@ -1,5 +1,5 @@
-import { unionBy } from 'lodash';
-import { dirname, join, resolve } from 'path';
+import unionBy from 'lodash.unionby';
+import { resolve } from 'path';
 import { SDK } from '@rsdoctor/types';
 import type { ModuleGraph, Module } from '../module-graph';
 import { Package } from './package';

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -88,7 +88,6 @@
     "get-port": "5.1.1",
     "json-stream-stringify": "3.0.1",
     "lines-and-columns": "2.0.4",
-    "lodash": "^4.17.21",
     "rslog": "^1.2.3",
     "strip-ansi": "^6.0.1"
   },
@@ -98,7 +97,6 @@
     "@types/deep-eql": "4.0.2",
     "@types/envinfo": "7.8.4",
     "@types/fs-extra": "^11.0.4",
-    "@types/lodash": "^4.17.13",
     "@types/node": "^16",
     "tslib": "2.8.1",
     "typescript": "^5.2.2"

--- a/packages/utils/src/common/index.ts
+++ b/packages/utils/src/common/index.ts
@@ -13,3 +13,4 @@ export * as Data from './data';
 export * as Alerts from './alerts';
 export * as Rspack from './rspack';
 export * as Package from './package';
+export * as Lodash from './lodash';

--- a/packages/utils/src/common/lodash.ts
+++ b/packages/utils/src/common/lodash.ts
@@ -1,0 +1,37 @@
+// Replace lodash's isUndefined function
+export function isUndefined(value: unknown): value is undefined {
+  return typeof value === 'undefined';
+}
+
+// Replace lodash's isNumber function
+export function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && !Number.isNaN(value);
+}
+
+export function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+// Replace lodash's isEmpty function
+export function isEmpty(value: unknown): boolean {
+  return (
+    value == null || // Check for null or undefined
+    (Array.isArray(value) && value.length === 0) || // Check for empty array
+    (typeof value === 'object' && Object.keys(value).length === 0) // Check for empty object
+  );
+}
+
+// Replace lodash's last function
+export function last<T>(array: T[]): T | undefined {
+  return array[array.length - 1];
+}
+
+// Replace lodash's compact function
+export function compact<T>(array: (T | null | undefined)[]): T[] {
+  return array.filter((item): item is T => item != null || !item); // Filter out null and undefined
+}
+
+// Replace lodash's isNil function
+export function isNil(value: unknown): value is null | undefined {
+  return value === null || value === undefined;
+}

--- a/packages/utils/src/common/package.ts
+++ b/packages/utils/src/common/package.ts
@@ -1,5 +1,5 @@
 import { SDK } from '@rsdoctor/types';
-import { isEmpty, last, compact } from 'lodash';
+import { compact, isEmpty, last } from './lodash';
 
 /**
  * The following code is modified based on

--- a/packages/utils/src/error/error.ts
+++ b/packages/utils/src/error/error.ts
@@ -2,10 +2,10 @@ import { codeFrameColumns } from '@babel/code-frame';
 import { Err, Rule } from '@rsdoctor/types';
 import { Chalk, Instance } from 'chalk';
 import deepEql from 'deep-eql';
-import { isNil } from 'lodash';
 import stripAnsi from 'strip-ansi';
 import { transform } from './transform';
 import { insertSpace, toLevel } from './utils';
+import { isNil } from 'src/common/lodash';
 
 let id = 1;
 

--- a/packages/utils/src/rule-utils/document/document.ts
+++ b/packages/utils/src/rule-utils/document/document.ts
@@ -1,6 +1,6 @@
 import { LinesAndColumns } from 'lines-and-columns';
-import { isUndefined, isNumber } from 'lodash';
 import { Range, OffsetRange, Position, DocumentEditData } from './types';
+import { isNumber, isUndefined } from 'src/common/lodash';
 
 /** Document Catalogue */
 export class Document {

--- a/packages/utils/src/rule-utils/parser/asserts.ts
+++ b/packages/utils/src/rule-utils/parser/asserts.ts
@@ -1,4 +1,4 @@
-import { isObject } from 'lodash';
+import { isObject } from 'src/common/lodash';
 import { Node } from './types';
 
 function isSyntaxNode(node: unknown): node is Node.SyntaxNode {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -821,9 +821,9 @@ importers:
       '@rsdoctor/utils':
         specifier: workspace:*
         version: link:../utils
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
+      lodash.unionby:
+        specifier: ^4.8.0
+        version: 4.8.0
       socket.io:
         specifier: 4.8.1
         version: 4.8.1
@@ -837,9 +837,9 @@ importers:
       '@types/estree':
         specifier: 1.0.5
         version: 1.0.5
-      '@types/lodash':
-        specifier: ^4.17.13
-        version: 4.17.13
+      '@types/lodash.unionby':
+        specifier: ^4.8.9
+        version: 4.8.9
       '@types/node':
         specifier: ^16
         version: 16.18.104
@@ -1051,9 +1051,6 @@ importers:
       lines-and-columns:
         specifier: 2.0.4
         version: 2.0.4
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
       rslog:
         specifier: ^1.2.3
         version: 1.2.3
@@ -1076,9 +1073,6 @@ importers:
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
-      '@types/lodash':
-        specifier: ^4.17.13
-        version: 4.17.13
       '@types/node':
         specifier: ^16
         version: 16.18.104
@@ -8713,6 +8707,12 @@ packages:
       '@types/lodash': 4.17.13
     dev: true
 
+  /@types/lodash.unionby@4.8.9:
+    resolution: {integrity: sha512-mhu+q4xOl7nwf1EJi0jknjrOMBbKip54kW6rlvu7/gna5zqOIdwJjBfiMa26n6oPb5Bjbcz08tC2oz62p6EqyQ==}
+    dependencies:
+      '@types/lodash': 4.17.13
+    dev: true
+
   /@types/lodash@4.17.13:
     resolution: {integrity: sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==}
 
@@ -14240,6 +14240,10 @@ packages:
   /lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
     dev: true
+
+  /lodash.unionby@4.8.0:
+    resolution: {integrity: sha512-e60kn4GJIunNkw6v9MxRnUuLYI/Tyuanch7ozoCtk/1irJTYBj+qNTxr5B3qVflmJhwStJBv387Cb+9VOfABMg==}
+    dev: false
 
   /lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}


### PR DESCRIPTION
## Summary
perf: reduce the bundle size of client

reduce lodash package, client bundle size from: 2.77 MB -> 2.75 MB


## Related Links

<!--- Provide links of related issues or pages -->
