### PR TITLE
chore(CI): correct permissions for issue labeler

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.en-US.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.en-US.yml
@@ -2,7 +2,6 @@ name: "🐞 Bug Report"
 description: Report a Bug to Rsdoctor
 title: "[Bug]: "
 type: Bug
-labels: ["🐞 bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2-feature-request.en-US.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.en-US.yml
@@ -2,7 +2,6 @@ name: "💡 Feature Request"
 description: Submit a new feature request to Rsdoctor
 title: "[Feature]: "
 type: Enhancement
-labels: ["💡 feature"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -7,7 +7,7 @@ on:
       - edited
 
 permissions:
-  issues: write
+  pull-requests: write
   contents: read
 
 jobs:


### PR DESCRIPTION
## Summary

1. Since the `pr-labeler` workflow adds labels to pull requests, it needs the `pull-requests: write` permission.

![image](https://github.com/user-attachments/assets/72577dba-728f-464a-b567-201f5510daca)

2. The GitHub issue types work well and we can remove the issue label to reduce duplicated information.

## Related Links

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#overview

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
