### PR TITLE
fix(UI): failed to render `font-family-code` in macOS

### DIFF
--- a/packages/components/src/pages/Overall/index.module.scss
+++ b/packages/components/src/pages/Overall/index.module.scss
@@ -1,5 +1,5 @@
 :root {
-  --font-family-code: Roboto, Roboto Mono, 'Segoe UI', 'Segoe UI Symbol',
+  --font-family-code: Roboto, Roboto Mono, Menlo, 'Segoe UI', 'Segoe UI Symbol',
     'Noto Color Emoji';
 }
 


### PR DESCRIPTION
## Summary

- before:

![image](https://github.com/user-attachments/assets/ee40fd65-ac19-4f81-9aba-bdc44eeb021e)

- after:

![image](https://github.com/user-attachments/assets/1d613357-6459-489d-8a5c-729fada4825d)
