### PR TITLE
fix(UI): correct versions and title alignment

### DIFF
--- a/packages/components/src/components/Alerts/collapse.tsx
+++ b/packages/components/src/components/Alerts/collapse.tsx
@@ -151,7 +151,7 @@ export const AlertCollapse = (props: {
                       <Typography.Text strong>
                         {versions.length}
                       </Typography.Text>
-                      <Typography.Text> versions was found</Typography.Text>
+                      <Typography.Text> versions found</Typography.Text>
                     </Space>
                     <Tabs
                       size="middle"
@@ -161,7 +161,7 @@ export const AlertCollapse = (props: {
                           return {
                             label: (
                               <Space className={styles.drawerLabelTitle}>
-                                <div>v.{target.version}</div>
+                                <div>v{target.version}</div>
                                 <Tag className={styles.drawerLabelSize}>
                                   {formatSize(targetSize.sourceSize)}
                                 </Tag>

--- a/packages/components/src/components/Overall/help-center.module.scss
+++ b/packages/components/src/components/Overall/help-center.module.scss
@@ -1,5 +1,6 @@
 .title {
   display: flex;
+  align-items: center;
   justify-content: space-between;
 }
 


### PR DESCRIPTION
## Summary

### Correct versions

- before:

![image](https://github.com/user-attachments/assets/4a66ccaf-9432-4117-968a-98714c7d8364)


- after:

![image](https://github.com/user-attachments/assets/6553697b-d8d5-40fe-a491-b711f549843e)

### Correct title alignment

- before:

![image](https://github.com/user-attachments/assets/cf27275f-7ef6-4038-922d-a0dc15c68153)

- after:

![image](https://github.com/user-attachments/assets/25c5b980-82d1-4e1a-9925-4b938d921b12)



## Related Links

<!--- Provide links of related issues or pages -->
