### PR TITLE
fix: bump @babel/code-frame v7.26.2 to reduce dependencies

### DIFF
--- a/packages/components/src/components/Alerts/collapse.tsx
+++ b/packages/components/src/components/Alerts/collapse.tsx
@@ -74,7 +74,7 @@ export const AlertCollapse = (props: {
                         style={{ fontSize: '18px' }}
                         component={VersionSvg}
                       />
-                      <span className={styles.data}>v.{version}</span>
+                      <span className={styles.data}>v{version}</span>
                     </div>
                   </div>
                   <div>

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -73,7 +73,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@babel/code-frame": "7.25.7",
+    "@babel/code-frame": "7.26.2",
     "@rsdoctor/types": "workspace:*",
     "@types/estree": "1.0.5",
     "acorn": "^8.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1016,8 +1016,8 @@ importers:
   packages/utils:
     dependencies:
       '@babel/code-frame':
-        specifier: 7.25.7
-        version: 7.25.7
+        specifier: 7.26.2
+        version: 7.26.2
       '@rsdoctor/types':
         specifier: workspace:*
         version: link:../types
@@ -1473,13 +1473,6 @@ packages:
       '@ast-grep/napi-win32-x64-msvc': 0.16.0
     dev: true
 
-  /@babel/code-frame@7.25.7:
-    resolution: {integrity: sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/highlight': 7.25.7
-      picocolors: 1.1.0
-
   /@babel/code-frame@7.26.2:
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
@@ -1497,7 +1490,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.25.7
+      '@babel/code-frame': 7.26.2
       '@babel/generator': 7.26.2
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.25.2)
@@ -1895,10 +1888,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/helper-validator-identifier@7.25.7:
-    resolution: {integrity: sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==}
-    engines: {node: '>=6.9.0'}
-
   /@babel/helper-validator-identifier@7.25.9:
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
@@ -1932,15 +1921,6 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: false
-
-  /@babel/highlight@7.25.7:
-    resolution: {integrity: sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.25.7
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
 
   /@babel/parser@7.25.3:
     resolution: {integrity: sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==}
@@ -4259,7 +4239,7 @@ packages:
     resolution: {integrity: sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.25.7
+      '@babel/code-frame': 7.26.2
       '@babel/parser': 7.26.2
       '@babel/types': 7.26.0
 
@@ -4275,7 +4255,7 @@ packages:
     resolution: {integrity: sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.25.7
+      '@babel/code-frame': 7.26.2
       '@babel/generator': 7.26.2
       '@babel/parser': 7.26.2
       '@babel/template': 7.25.9
@@ -4290,7 +4270,7 @@ packages:
     resolution: {integrity: sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.25.7
+      '@babel/code-frame': 7.26.2
       '@babel/generator': 7.25.7
       '@babel/parser': 7.26.2
       '@babel/template': 7.25.7
@@ -12620,7 +12600,7 @@ packages:
       typescript: '>3.6.0'
       webpack: ^5.11.0
     dependencies:
-      '@babel/code-frame': 7.25.7
+      '@babel/code-frame': 7.26.2
       chalk: 4.1.2
       chokidar: 3.6.0
       cosmiconfig: 8.3.6(typescript@5.5.4)
@@ -15911,7 +15891,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.25.7
+      '@babel/code-frame': 7.26.2
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -19699,7 +19679,7 @@ packages:
       '@rspack/core':
         optional: true
     dependencies:
-      '@babel/code-frame': 7.25.7
+      '@babel/code-frame': 7.26.2
       '@rspack/lite-tapable': 1.0.1
       chokidar: 3.6.0
       memfs: 4.15.3


### PR DESCRIPTION
## Summary

-  bump @babel/code-frame v7.26.2 to reduce dependencies
- Correct version display (the same as https://github.com/web-infra-dev/rsdoctor/pull/666)

### @babel/code-frame@7.25.7

```
  '@babel/code-frame@7.25.7':
    dependencies:
      '@babel/highlight': 7.25.9
      picocolors: 1.1.1

  '@babel/highlight@7.25.9':
    dependencies:
      '@babel/helper-validator-identifier': 7.25.9
      chalk: 2.4.2
      js-tokens: 4.0.0
      picocolors: 1.1.1
```

### @babel/code-frame@7.26.2

```
  '@babel/code-frame@7.26.2':
    dependencies:
      '@babel/helper-validator-identifier': 7.25.9
      js-tokens: 4.0.0
      picocolors: 1.1.1
```
