### PR TITLE
fix: the module api error in rspack 1.2.0-alpha

### DIFF
--- a/packages/core/src/build-utils/build/module-graph/treeShaking.ts
+++ b/packages/core/src/build-utils/build/module-graph/treeShaking.ts
@@ -25,7 +25,7 @@ import {
   getDeclarationIdentifier,
   getExportIdentifierStatement,
 } from './utils';
-import { isWebpack5orRspack } from '@/build-utils/common/module-graph';
+import { hasModuleGraphApi, isRspack } from '@/build-utils/common/module-graph';
 
 type ExportData = Map<WebExportInfo, ExportInfo>;
 
@@ -161,7 +161,8 @@ export function appendTreeShaking(
   moduleGraph: ModuleGraph,
   compilation: Plugin.BaseCompilation,
 ) {
-  if (!isWebpack5orRspack(compilation)) {
+  // TODO: Rspack does not support tree shaking analysis for the time being. After subsequent verification.
+  if (!hasModuleGraphApi(compilation) || isRspack(compilation)) {
     return moduleGraph;
   }
 

--- a/packages/core/src/build-utils/build/module-graph/webpack/transform.ts
+++ b/packages/core/src/build-utils/build/module-graph/webpack/transform.ts
@@ -18,6 +18,7 @@ import {
   getImportKind,
   isImportDependency,
   removeNoImportStyle,
+  isRspack,
 } from '@/build-utils/common/module-graph';
 import { hasSetEsModuleStatement } from '../parser';
 import { isFunction } from 'lodash';
@@ -146,6 +147,7 @@ async function appendModuleData(
   wbFs: WebpackFs,
   features?: Plugin.RsdoctorWebpackPluginFeatures,
   context?: TransformContext,
+  isRapck?: Boolean,
 ) {
   const module = graph.getModuleByWebpackId(getWebpackModuleId(origin));
 
@@ -218,8 +220,8 @@ async function appendModuleData(
     module.meta.strictHarmonyModule =
       origin.buildMeta?.strictHarmonyModule ?? false;
     module.meta.packageData = packageData;
-
-    if (!features?.lite && origin?.dependencies) {
+    // TODO: Rspack does not appendDependencies current. After subsequent verification.
+    if (!features?.lite && origin?.dependencies && !isRapck) {
       // lite bundle Mode don't have dependency；
       // Record dependent data.
       Array.from(origin.dependencies)
@@ -261,6 +263,7 @@ export async function appendModuleGraphByCompilation(
           fileSystemInfo,
           features,
           context,
+          isRspack(compilation),
         );
       }),
     );

--- a/packages/core/src/build-utils/build/utils/plugin.ts
+++ b/packages/core/src/build-utils/build/utils/plugin.ts
@@ -1,5 +1,5 @@
 import type { Common } from '@rsdoctor/types';
-import { isWebpack5orRspack } from '@/build-utils/common/module-graph/compatible';
+import { hasModuleGraphApi } from '@/build-utils/common/module-graph/compatible';
 import { Plugin } from '@rsdoctor/types';
 
 export type IHook =
@@ -49,7 +49,7 @@ export function interceptCompilationHooks(
      * Compilation.hooks.normalModuleLoader is deprecated
      *   MIGRATION: Use NormalModule.getCompilationHooks(compilation).loader instead
      */
-    if (hook === 'normalModuleLoader' && isWebpack5orRspack(compilation)) {
+    if (hook === 'normalModuleLoader' && hasModuleGraphApi(compilation)) {
       return;
     }
 

--- a/packages/core/src/build-utils/common/module-graph/compatible.ts
+++ b/packages/core/src/build-utils/common/module-graph/compatible.ts
@@ -46,8 +46,15 @@ export function getPositionByStatsLocation(
   }
 }
 
-export function isWebpack5orRspack(
+export function hasModuleGraphApi(
   compilation: Plugin.BaseCompilation,
 ): Boolean {
   return 'moduleGraph' in compilation && Boolean(compilation.moduleGraph);
+}
+
+export function isRspack(compilation: Plugin.BaseCompilation): Boolean {
+  return (
+    'rspackVersion' in compilation.compiler.webpack &&
+    Boolean(compilation.compiler.webpack?.rspackVersion)
+  );
 }


### PR DESCRIPTION
## Summary
fix: the module api error in rspack 1.2.0-alpha

<img width="1542" alt="image" src="https://github.com/user-attachments/assets/f5cb2c38-90aa-4b57-89f8-4cc4b4f2594f" />

## Related Links
#678
<!--- Provide links of related issues or pages -->
