### PR TITLE
perf: replace `serve-static` with `sirv`

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -38,14 +38,13 @@
     "@types/node": "^16",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
-    "@types/serve-static": "1.15.7",
     "antd": "5.15.3",
     "normalize.css": "8.0.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-error-boundary": "^4.1.2",
     "react-router-dom": "6.4.3",
-    "serve-static": "1.16.2",
+    "sirv": "2.0.4",
     "typescript": "^5.2.2"
   },
   "publishConfig": {

--- a/packages/client/rsbuild.config.ts
+++ b/packages/client/rsbuild.config.ts
@@ -4,7 +4,7 @@ import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
 import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import type { Rspack, RsbuildConfig } from '@rsbuild/core';
 import { pluginSass } from '@rsbuild/plugin-sass';
-import serve from 'serve-static';
+import serve from 'sirv';
 import path from 'path';
 import fs from 'fs';
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -33,7 +33,7 @@
     "json-cycle": "^1.5.0",
     "lodash": "^4.17.21",
     "open": "^8.4.2",
-    "serve-static": "1.16.2",
+    "sirv": "2.0.4",
     "socket.io": "4.8.1",
     "source-map": "^0.7.4",
     "tapable": "2.2.1"
@@ -43,7 +43,6 @@
     "@types/cors": "2.8.17",
     "@types/lodash": "^4.17.14",
     "@types/node": "^16",
-    "@types/serve-static": "1.15.7",
     "tslib": "2.8.1",
     "typescript": "^5.2.2"
   },

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -1,6 +1,6 @@
 import { Common, SDK, Thirdparty, Client } from '@rsdoctor/types';
 import { Server } from '@rsdoctor/utils/build';
-import serve from 'serve-static';
+import serve from 'sirv';
 import { Bundle } from '@rsdoctor/utils/common';
 import assert from 'assert';
 import bodyParser from 'body-parser';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,9 +546,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.5
         version: 18.3.5(@types/react@18.3.18)
-      '@types/serve-static':
-        specifier: 1.15.7
-        version: 1.15.7
       antd:
         specifier: 5.15.3
         version: 5.15.3(react-dom@18.3.1)(react@18.3.1)
@@ -567,9 +564,9 @@ importers:
       react-router-dom:
         specifier: 6.4.3
         version: 6.4.3(react-dom@18.3.1)(react@18.3.1)
-      serve-static:
-        specifier: 1.16.2
-        version: 1.16.2
+      sirv:
+        specifier: 2.0.4
+        version: 2.0.4
       typescript:
         specifier: ^5.2.2
         version: 5.5.4
@@ -944,9 +941,9 @@ importers:
       open:
         specifier: ^8.4.2
         version: 8.4.2
-      serve-static:
-        specifier: 1.16.2
-        version: 1.16.2
+      sirv:
+        specifier: 2.0.4
+        version: 2.0.4
       socket.io:
         specifier: 4.8.1
         version: 4.8.1
@@ -969,9 +966,6 @@ importers:
       '@types/node':
         specifier: ^16
         version: 16.18.104
-      '@types/serve-static':
-        specifier: 1.15.7
-        version: 1.15.7
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -11538,10 +11532,6 @@ packages:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
 
-  /encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
-    engines: {node: '>= 0.8'}
-
   /end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
@@ -12216,6 +12206,7 @@ packages:
   /etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+    dev: true
 
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -12659,6 +12650,7 @@ packages:
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+    dev: true
 
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -15352,7 +15344,6 @@ packages:
   /mrmime@2.0.0:
     resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
     engines: {node: '>=10'}
-    dev: false
 
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -16836,6 +16827,7 @@ packages:
   /range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+    dev: true
 
   /raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
@@ -18764,26 +18756,6 @@ packages:
       - supports-color
     dev: true
 
-  /send@0.19.0:
-    resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      mime: 1.6.0
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   /serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
     dependencies:
@@ -18819,17 +18791,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /serve-static@1.16.2:
-    resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 0.19.0
-    transitivePeerDependencies:
-      - supports-color
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -18948,7 +18909,6 @@ packages:
       '@polka/url': 1.0.0-next.25
       mrmime: 2.0.0
       totalist: 3.0.1
-    dev: false
 
   /size-sensor@1.0.2:
     resolution: {integrity: sha512-2NCmWxY7A9pYKGXNBfteo4hy14gWu47rg5692peVMst6lQLPKrVjhY+UTEsPI5ceFRJSl3gVgMYaUi/hKuaiKw==}
@@ -19649,7 +19609,6 @@ packages:
   /totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
-    dev: false
 
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}


### PR DESCRIPTION
## Summary

[sirv](https://www.npmjs.com/package/sirv?activeTab=readme) is a very fast and lightweight alternative to [serve-static](https://www.npmjs.com/package/serve-static).

And Rsbuild already uses `sirv` to serve static assets: https://github.com/search?q=repo%3Aweb-infra-dev%2Frsbuild%20sirv&type=code

> Note that `sirv@3` requires Node 18, so I use the 2.x version for Rsdoctor.

## Related Links

https://www.npmjs.com/package/sirv
