### PR TITLE
fix: failed to call `getResolvedModule` in Rspack

### DIFF
--- a/packages/core/src/build-utils/build/module-graph/webpack/transform.ts
+++ b/packages/core/src/build-utils/build/module-graph/webpack/transform.ts
@@ -59,9 +59,9 @@ function appendDependency(
   webpackGraph: Webpack.ModuleGraph,
   graph: ModuleGraph,
 ) {
-  const resolvedWebpackModule = webpackGraph.getResolvedModule(
-    webpackDep,
-  ) as Webpack.NormalModule;
+  const resolvedWebpackModule = webpackGraph.getResolvedModule
+    ? (webpackGraph.getResolvedModule(webpackDep) as Webpack.NormalModule)
+    : undefined;
   if (!resolvedWebpackModule) {
     return;
   }

--- a/packages/core/src/build-utils/build/module-graph/webpack/transform.ts
+++ b/packages/core/src/build-utils/build/module-graph/webpack/transform.ts
@@ -59,12 +59,15 @@ function appendDependency(
   webpackGraph: Webpack.ModuleGraph,
   graph: ModuleGraph,
 ) {
+  // Rspack does not support `getResolvedModule` yet.
   const resolvedWebpackModule = webpackGraph?.getResolvedModule
     ? (webpackGraph.getResolvedModule(webpackDep) as Webpack.NormalModule)
     : undefined;
+
   if (!resolvedWebpackModule) {
     return;
   }
+
   const rawRequest = getWebpackDependencyRequest(
     webpackDep,
     resolvedWebpackModule,

--- a/packages/core/src/build-utils/build/module-graph/webpack/transform.ts
+++ b/packages/core/src/build-utils/build/module-graph/webpack/transform.ts
@@ -59,7 +59,7 @@ function appendDependency(
   webpackGraph: Webpack.ModuleGraph,
   graph: ModuleGraph,
 ) {
-  const resolvedWebpackModule = webpackGraph.getResolvedModule
+  const resolvedWebpackModule = webpackGraph?.getResolvedModule
     ? (webpackGraph.getResolvedModule(webpackDep) as Webpack.NormalModule)
     : undefined;
   if (!resolvedWebpackModule) {


### PR DESCRIPTION
## Summary

Fix failed to call `getResolvedModule` in Rspack. Rspack does not support the `getResolvedModule` yet.

## Related Links

https://github.com/web-infra-dev/rsdoctor/pull/684