### PR TITLE
fix(deps): replace deprecated acorn-import-assertions

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -77,7 +77,7 @@
     "@rsdoctor/types": "workspace:*",
     "@types/estree": "1.0.5",
     "acorn": "^8.10.0",
-    "acorn-import-assertions": "1.9.0",
+    "acorn-import-attributes": "^1.9.5",
     "acorn-walk": "8.3.4",
     "chalk": "^4.1.2",
     "connect": "3.7.0",

--- a/packages/utils/src/rule-utils/parser/parser.ts
+++ b/packages/utils/src/rule-utils/parser/parser.ts
@@ -1,6 +1,6 @@
 import { Parser as AcornParser, Options, Position } from 'acorn';
 // @ts-ignore
-import { importAssertions } from 'acorn-import-assertions';
+import { importAttributes } from 'acorn-import-attributes';
 import * as walk from 'acorn-walk';
 import { asserts } from './asserts';
 import * as utils from './utils';
@@ -17,12 +17,12 @@ export interface ParseError extends Error {
 /**
  * parser for internal
  */
-const acornParserInternal = AcornParser.extend(importAssertions);
+const acornParserInternal = AcornParser.extend(importAttributes);
 
 /**
  * parser for developers
  */
-let acornParserExport = AcornParser.extend(importAssertions);
+let acornParserExport = AcornParser.extend(importAttributes);
 
 export const parser = {
   /** AST iterator */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1027,9 +1027,9 @@ importers:
       acorn:
         specifier: ^8.10.0
         version: 8.14.0
-      acorn-import-assertions:
-        specifier: 1.9.0
-        version: 1.9.0(acorn@8.14.0)
+      acorn-import-attributes:
+        specifier: ^1.9.5
+        version: 1.9.5(acorn@8.14.0)
       acorn-walk:
         specifier: 8.3.4
         version: 8.3.4
@@ -7284,21 +7284,12 @@ packages:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  /acorn-import-assertions@1.9.0(acorn@8.14.0):
-    resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
-    peerDependencies:
-      acorn: ^8
-    dependencies:
-      acorn: 8.14.0
-    dev: false
-
   /acorn-import-attributes@1.9.5(acorn@8.14.0):
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
       acorn: ^8
     dependencies:
       acorn: 8.14.0
-    dev: true
 
   /acorn-jsx@5.3.2(acorn@8.14.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}


### PR DESCRIPTION
## Summary

Replace the deprecated `acorn-import-assertions` with `acorn-import-attributes`.

See: https://www.npmjs.com/package/acorn-import-assertions

![image](https://github.com/user-attachments/assets/c930698e-713d-407f-9f7c-b3b601ff933e)
