### PR TITLE
refactor: support compressJson option and refactor the reportDir & reportCodeType

### DIFF
--- a/packages/core/src/inner-plugins/plugins/ensureModulesChunkGraph.ts
+++ b/packages/core/src/inner-plugins/plugins/ensureModulesChunkGraph.ts
@@ -104,7 +104,7 @@ export const ensureModulesChunksGraphFn = (
               ChunksBuildUtils.TileGraphReportName,
             ),
             reportTitle: 'bundle-analyzer',
-            reportDir: _this.options.reportDir,
+            reportDir: _this.options.output.reportDir,
           },
           compiler.outputPath,
         );

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -40,7 +40,7 @@ export interface RsdoctorWebpackPluginOptions<
   mode?: keyof typeof SDK.IMode;
 
   /**
-   * configuration of the interceptor for webpack loaders.
+   * configuration of the interceptor for webpack loaders. TODO: delete this options.
    * @description worked when the `features.loader === true`.
    */
   loaderInterceptorOptions?: {
@@ -54,8 +54,9 @@ export interface RsdoctorWebpackPluginOptions<
    * @default false
    */
   disableClientServer?: boolean;
+
   /**
-   * sdk instance of outside
+   * sdk instance of outside. TODO: delete this options
    */
   sdkInstance?: RsdoctorSDK;
 
@@ -63,16 +64,6 @@ export interface RsdoctorWebpackPluginOptions<
    * Whether to turn on some characteristic analysis capabilities, such as: the support for the BannerPlugin.
    */
   supports?: ISupport;
-
-  /**
-   * The directory where the report files will be output.
-   */
-  reportDir?: string;
-
-  /**
-   * Control the Rsdoctor reporter codes records.
-   */
-  reportCodeType?: IReportCodeType | undefined;
 
   /**
    * The port of the Rsdoctor server.
@@ -90,16 +81,34 @@ export interface RsdoctorWebpackPluginOptions<
   brief?: SDK.BriefConfig;
 
   /**
-   * control the Rsdoctor upload data to TOS, used by inner-rsdoctor.
+   * control the Rsdoctor upload data to TOS, used by inner-rsdoctor. TODO: delete this options
    * @default false
    */
   disableTOSUpload?: boolean;
 
   /**
-   * The name of inner rsdoctor's client package, used by inner-rsdoctor.
+   * The name of inner rsdoctor's client package, used by inner-rsdoctor. TODO: delete this options
    * @default false
    */
   innerClientPath?: string;
+
+  output?: {
+    /**
+     * The directory where the report files will be output.
+     */
+    reportDir?: string;
+
+    /**
+     * Control the Rsdoctor reporter codes records.
+     */
+    reportCodeType?: IReportCodeType | undefined;
+
+    /**
+     * Configure whether to compress data.
+     * @default false
+     */
+    compressData?: boolean;
+  };
 }
 
 export interface RsdoctorMultiplePluginOptions<
@@ -123,19 +132,18 @@ export interface RsdoctorPluginOptionsNormalized<
 > extends Common.DeepRequired<
     Omit<
       RsdoctorWebpackPluginOptions<Rules>,
-      | 'sdkInstance'
-      | 'linter'
-      | 'reportCodeType'
-      | 'supports'
-      | 'port'
-      | 'brief'
+      'sdkInstance' | 'linter' | 'output' | 'supports' | 'port' | 'brief'
     >
   > {
   features: Common.DeepRequired<Plugin.RsdoctorWebpackPluginFeatures>;
   linter: Required<LinterType.Options<Rules, InternalRules>>;
   sdkInstance?: RsdoctorSDK;
+  output: {
+    reportCodeType: SDK.ToDataType;
+    reportDir: string;
+    compressData: boolean;
+  };
   port?: number;
-  reportCodeType: SDK.ToDataType;
   supports: ISupport;
   brief: SDK.BriefConfig;
 }

--- a/packages/rspack-plugin/src/multiple.ts
+++ b/packages/rspack-plugin/src/multiple.ts
@@ -36,7 +36,7 @@ export class RsdoctorRspackMultiplePlugin<
         mode: normallizedOptions.mode ? normallizedOptions.mode : undefined,
         brief: normallizedOptions.brief,
       },
-      type: normallizedOptions.reportCodeType,
+      type: normallizedOptions.output.reportCodeType,
     });
 
     super({

--- a/packages/rspack-plugin/src/plugin.ts
+++ b/packages/rspack-plugin/src/plugin.ts
@@ -72,13 +72,14 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
         port: this.options.port,
         name: pluginTapName,
         root: process.cwd(),
-        type: this.options.reportCodeType,
+        type: this.options.output.reportCodeType,
         config: {
           disableTOSUpload: this.options.disableTOSUpload,
           innerClientPath: this.options.innerClientPath,
           printLog: this.options.printLog,
           mode: this.options.mode ? this.options.mode : undefined,
           brief: this.options.brief,
+          compressData: this.options.output.compressData,
         },
       });
     this.outsideInstance = Boolean(this.options.sdkInstance);
@@ -191,7 +192,7 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
     if (this.outsideInstance && 'parent' in this.sdk) {
       this.sdk.parent.master.setOutputDir(
         path.resolve(
-          this.options.reportDir || compiler.outputPath,
+          this.options.output.reportDir || compiler.outputPath,
           `./${Constants.RsdoctorOutputFolder}`,
         ),
       );
@@ -199,7 +200,7 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
 
     this.sdk.setOutputDir(
       path.resolve(
-        this.options.reportDir || compiler.outputPath,
+        this.options.output.reportDir || compiler.outputPath,
         `./${Constants.RsdoctorOutputFolder}`,
       ),
     );
@@ -251,7 +252,7 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
 
     this.sdk.setOutputDir(
       path.resolve(
-        this.options.reportDir || compiler.outputPath,
+        this.options.output.reportDir || compiler.outputPath,
         `./${Constants.RsdoctorOutputFolder}`,
       ),
     );

--- a/packages/sdk/src/sdk/sdk/core.ts
+++ b/packages/sdk/src/sdk/sdk/core.ts
@@ -17,7 +17,7 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
 
   protected hash!: string;
 
-  extraConfig: SDK.SDKOptionsType | undefined;
+  public extraConfig: SDK.SDKOptionsType | undefined;
 
   public readonly root: string;
 
@@ -155,11 +155,19 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
 
       if (Array.isArray(jsonStr)) {
         const urls = jsonStr.map((str, index) => {
-          return this.writeToFolder(str, outputDir, key, index + 1);
+          return this.writeToFolder(
+            str,
+            outputDir,
+            key,
+            this.extraConfig,
+            index + 1,
+          );
         });
         urlsPromiseList.push(...urls);
       } else {
-        urlsPromiseList.push(this.writeToFolder(jsonStr, outputDir, key));
+        urlsPromiseList.push(
+          this.writeToFolder(jsonStr, outputDir, key, this.extraConfig),
+        );
       }
     }
 
@@ -212,9 +220,13 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
     jsonStr: string,
     dir: string,
     key: string,
+    extraConfig: SDK.SDKOptionsType | undefined,
     index?: number,
   ): Promise<DataWithUrl> {
-    const sharding = new File.FileSharding(Algorithm.compressText(jsonStr));
+    const { compressData } = extraConfig || { compressData: true };
+    const sharding = compressData
+      ? new File.FileSharding(Algorithm.compressText(jsonStr))
+      : new File.FileSharding(jsonStr);
     const folder = path.resolve(dir, key);
     const writer = sharding.writeStringToFolder(folder, '', index);
     return writer.then((item) => {

--- a/packages/types/src/sdk/instance.ts
+++ b/packages/types/src/sdk/instance.ts
@@ -128,6 +128,7 @@ export type SDKOptionsType = {
   printLog?: IPrintLog;
   mode?: keyof typeof IMode;
   brief?: BriefConfig;
+  compressData?: boolean;
 };
 
 /**

--- a/packages/webpack-plugin/src/multiple.ts
+++ b/packages/webpack-plugin/src/multiple.ts
@@ -35,8 +35,9 @@ export class RsdoctorWebpackMultiplePlugin<
         printLog: normallizedOptions.printLog,
         mode: normallizedOptions.mode ? normallizedOptions.mode : undefined,
         brief: normallizedOptions.brief,
+        compressData: normallizedOptions.output.compressData,
       },
-      type: normallizedOptions.reportCodeType,
+      type: normallizedOptions.output.reportCodeType,
     });
 
     super({

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -58,15 +58,17 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
         port: this.options.port,
         name: pluginTapName,
         root: process.cwd(),
-        type: this.options.reportCodeType,
+        type: this.options.output.reportCodeType,
         config: {
           disableTOSUpload: this.options.disableTOSUpload,
           innerClientPath: this.options.innerClientPath,
           printLog: this.options.printLog,
-          mode: this.options.mode ? this.options.mode : undefined,
+          mode: this.options.mode,
           brief: this.options.brief,
+          compressData: this.options.output.compressData,
         },
       });
+
     this.modulesGraph = new ModuleGraph();
     this.chunkGraph = new ChunkGraph();
     this.isRsdoctorPlugin = true;
@@ -163,7 +165,7 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
 
     this.sdk.setOutputDir(
       path.resolve(
-        this.options.reportDir || compiler.outputPath,
+        this.options.output.reportDir || compiler.outputPath,
         `./${Constants.RsdoctorOutputFolder}`,
       ),
     );


### PR DESCRIPTION
## Summary
refactor: support compressJson option and refactor the reportDir & reportCodeType

This pull request introduces several changes to the `Rsdoctor` plugin configuration and usage, focusing on consolidating and restructuring the configuration options. The most important changes include moving the `reportDir` and `reportCodeType` options into a new `output` object, adding the `compressData` option, and updating the corresponding plugin classes and types to reflect these changes.

These changes improve the configuration structure and provide more flexibility in handling output options for the `Rsdoctor` plugin.
## Related Links

<!--- Provide links of related issues or pages -->
