### PR TITLE
fix(UI): overall cards font overflow problem

### DIFF
--- a/packages/components/src/components/Overall/bundle.module.scss
+++ b/packages/components/src/components/Overall/bundle.module.scss
@@ -16,6 +16,10 @@
 }
 
 .description {
+  @media (max-width: 1500px) {
+    font-size: 16px;
+  }
+
   font-size: 20px;
   font-weight: 500;
   line-height: 32px;


### PR DESCRIPTION
## Summary
- before:
<img width="527" alt="image" src="https://github.com/user-attachments/assets/a0e0acce-a517-4712-88e7-3bd6d75a9ef9" />

- after:
<img width="561" alt="image" src="https://github.com/user-attachments/assets/da2f58d2-2040-401e-a787-d1a8ed72e048" />

## Related Links

<!--- Provide links of related issues or pages -->
