### PR TITLE
fix: banner plugin switch condition

### DIFF
--- a/e2e/cases/doctor-rspack/banner-plugin.test.ts
+++ b/e2e/cases/doctor-rspack/banner-plugin.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
+import { Utils } from '@rsdoctor/core/build-utils';
 import { getSDK, setSDK } from '@rsdoctor/core/plugins';
-import { compileByRspack } from '@scripts/test-helper';
 import { BannerPlugin, Compiler } from '@rspack/core';
+import { compileByRspack } from '@scripts/test-helper';
 import path from 'path';
 import { createRsdoctorPlugin } from './test-utils';
-import { parseBundle } from '../../node_modules/@rsdoctor/core/dist/build-utils/build/utils/parseBundle';
 
 let reportLoaderStartOrEndTimes = 0;
 
@@ -118,7 +118,7 @@ test('rspack banner plugin', async () => {
   const sdk = getSDK();
 
   // @ts-ignore
-  const bundle = parseBundle(
+  const bundle = Utils.parseBundle(
     path.join(__dirname, './fixtures/rspack-banner-plugin.js'),
     // @ts-ignore
     sdk.getStoreData().moduleGraph.modules,

--- a/e2e/cases/doctor-rspack/tag-plugin-without-banner.test.ts
+++ b/e2e/cases/doctor-rspack/tag-plugin-without-banner.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
 import { getSDK, setSDK } from '@rsdoctor/core/plugins';
 import { compileByRspack } from '@scripts/test-helper';
+import { Utils } from '@rsdoctor/core/build-utils';
 import { Compiler } from '@rspack/core';
 import path from 'path';
 import { createRsdoctorPlugin } from './test-utils';
-import { parseBundle } from '../../node_modules/@rsdoctor/core/dist/build-utils/build/utils/parseBundle';
 
 let reportLoaderStartOrEndTimes = 0;
 
@@ -108,7 +108,7 @@ test('rspack banner plugin', async () => {
   const sdk = getSDK();
 
   // @ts-ignore
-  const bundle = parseBundle(
+  const bundle = Utils.parseBundle(
     path.join(__dirname, './fixtures/rspack-banner-plugin.js'),
     // @ts-ignore
     sdk.getStoreData().moduleGraph.modules,

--- a/packages/core/src/inner-plugins/plugins/bundleTagPlugin.ts
+++ b/packages/core/src/inner-plugins/plugins/bundleTagPlugin.ts
@@ -19,7 +19,13 @@ export class InternalBundleTagPlugin<
             stage: -2000,
           },
           async () => {
-            if (supportBannerPlugin === false) {
+            if (
+              (!compilation.options.plugins
+                .map((p) => p && p.constructor.name)
+                .includes('BannerPlugin') &&
+                supportBannerPlugin !== true) ||
+              supportBannerPlugin === false
+            ) {
               return;
             }
             logger.info(

--- a/packages/core/src/inner-plugins/plugins/bundleTagPlugin.ts
+++ b/packages/core/src/inner-plugins/plugins/bundleTagPlugin.ts
@@ -19,12 +19,7 @@ export class InternalBundleTagPlugin<
             stage: -2000,
           },
           async () => {
-            if (
-              !compilation.options.plugins
-                .map((p) => p && p.constructor.name)
-                .includes('BannerPlugin') ||
-              supportBannerPlugin === false
-            ) {
+            if (supportBannerPlugin === false) {
               return;
             }
             logger.info(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17378,7 +17378,7 @@ packages:
       '@babel/code-frame': 7.26.2
       '@rspack/lite-tapable': 1.0.1
       chokidar: 3.6.0
-      memfs: 4.15.3
+      memfs: 4.17.0
       minimatch: 9.0.5
       picocolors: 1.1.1
       typescript: 5.7.3


### PR DESCRIPTION
## Summary

Change the InternalBundleTagPlugin to turn on the logic, when "supports. Banner' is true, or the BannerPlugin plug-in is used by default and supports. When banner' is not false, the InternalBundleTagPlugin analysis ability will be turned on.
————————————————————————————————————————————————————————————
更改 InternalBundleTagPlugin 开启逻辑，当 `supports.banner` 为 true，或默认使用了 BannerPlugin 插件且 `supports.banner` 不为 false 时，会开启 InternalBundleTagPlugin 分析能力。

## Related Links

<!--- Provide links of related issues or pages -->
