### PR TITLE
fix: failed to call `module.getExportsType` method

### DIFF
--- a/packages/core/src/build-utils/common/webpack/compatible.ts
+++ b/packages/core/src/build-utils/common/webpack/compatible.ts
@@ -61,7 +61,7 @@ export function getDependencyPosition(
 ): SDK.StatementInstance | undefined {
   const { loc: depLoc } = dep;
 
-  if (!('start' in depLoc)) {
+  if (depLoc === undefined || !('start' in depLoc)) {
     return;
   }
 


### PR DESCRIPTION
## Summary

Fix failed to call `module.getExportsType` method:

<img width="1254" alt="Screenshot 2025-01-25 at 19 47 53" src="https://github.com/user-attachments/assets/064f66c0-5a2f-46df-ac9d-3f4d0ea6da68" />

Rspack does not support `getExportsType` yet, so we need to add back some compatibility code.

The compatibility code is similar to this method:  https://github.com/web-infra-dev/rsdoctor/commit/417d63fe0c7faa4d9075de734c8db29a26aa78d9#diff-f56b842e05e9c881a3ecc025330e4dfbb62bbe887c46e27e63de815cff386684L77

## Related Links

<!--- Provide links of related issues or pages -->
