### PR TITLE
fix(UI): invalid font family for loader analysis text

### DIFF
--- a/packages/components/src/components/Loader/Analysis/style.module.scss
+++ b/packages/components/src/components/Loader/Analysis/style.module.scss
@@ -42,7 +42,6 @@
   .text {
     font-size: 12px;
     font-weight: 400;
-    font-family: 'Roboto';
   }
 }
 


### PR DESCRIPTION
## Summary

Fix invalid font family for loader analysis text, we can remove `font-family: 'Roboto'` and inherit the parent font family (which is `var(--font-family-code)`).

- before:

![20250126-141741](https://github.com/user-attachments/assets/986bccea-29e3-4d8c-ab48-92873271ce09)

- after:

![image](https://github.com/user-attachments/assets/1f63a851-f0fc-4a2c-aedc-7892750988b0)

