### PR TITLE
docs: update "getting started" guide section for Rsbuild

### DIFF
--- a/packages/document/docs/en/guide/start/quick-start-shared.mdx
+++ b/packages/document/docs/en/guide/start/quick-start-shared.mdx
@@ -25,29 +25,7 @@ module.exports = {
 
 ### Rsbuild
 
-Initialize the RsdoctorRspackPlugin in the [tools.rspack](https://rsbuild.dev/config/tools/rspack) of `rsbuild.config.ts`:
-
-```js title="rsbuild.config.ts"
-import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
-
-export default {
-  // ...
-  tools: {
-    rspack(config, { appendPlugins }) {
-      // Only register the plugin when RSDOCTOR is true, as the plugin will increase the build time.
-      if (process.env.RSDOCTOR) {
-        appendPlugins(
-          new RsdoctorRspackPlugin({
-            // plugin options
-          }),
-        );
-      }
-    },
-  },
-};
-```
-
-- **Options:** The plugin provides some configurations, please refer to [Options](../../config/options/options).
+Rsbuild has built-in support for Rsdoctor, so you don't need to manually register plugins. See [Rsbuild - Use Rsdoctor](https://rsbuild.dev/guide/debug/rsdoctor) for more details.
 
 ### Webpack
 

--- a/packages/document/docs/zh/guide/start/quick-start-shared.mdx
+++ b/packages/document/docs/zh/guide/start/quick-start-shared.mdx
@@ -25,29 +25,7 @@ module.exports = {
 
 ### Rsbuild 项目
 
-在 `rsbuild.config.ts` 的 [tools.rspack](https://rsbuild.dev/config/tools/rspack) 中初始化 RsdoctorRspackPlugin 插件，参考：
-
-```js title="rsbuild.config.ts"
-import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
-
-export default {
-  // ...
-  tools: {
-    rspack(config, { appendPlugins }) {
-      // 仅在 RSDOCTOR 为 true 时注册插件，因为插件会增加构建耗时
-      if (process.env.RSDOCTOR) {
-        appendPlugins(
-          new RsdoctorRspackPlugin({
-            // 插件选项
-          }),
-        );
-      }
-    },
-  },
-};
-```
-
-- **Options:** 插件提供了一些配置项，请参考 [Options](../../config/options/options)。
+Rsbuild 内置了对 Rsdoctor 的支持，不需要手动注册插件。详见 [Rsbuild - 使用 Rsdoctor](https://rsbuild.dev/zh/guide/debug/rsdoctor)。
 
 ### Webpack 项目
 


### PR DESCRIPTION
## Summary

Update "getting started" guide section for Rsbuild to align usage with the Rsbuild documentation.

## Related Links

resolve https://github.com/web-infra-dev/rsdoctor/issues/398
