### PR TITLE
fix(rspack-plugin): correct the dist types directory

### DIFF
--- a/packages/rspack-plugin/tsconfig.json
+++ b/packages/rspack-plugin/tsconfig.json
@@ -2,9 +2,10 @@
   "extends": "@rsdoctor/tsconfig/base",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "src"
   },
-  "include": ["src", "tests"],
+  "include": ["src"],
   "exclude": ["**/node_modules"],
   "references": [
     {


### PR DESCRIPTION
## Summary

Correct the dist types directory for `@rsdoctor/rspack-plugin`:

- before:

<img width="396" alt="Screenshot 2025-02-02 at 16 53 06" src="https://github.com/user-attachments/assets/0c3454d5-c3a8-4ce0-9f88-ea304ebe6ef7" />

- after:

<img width="386" alt="Screenshot 2025-02-02 at 16 55 30" src="https://github.com/user-attachments/assets/207ef68b-8ab1-48bc-98b7-9f03ad307591" />
