### PR TITLE
ci(corepack): fix corepack key id mismatch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,9 @@ jobs:
           fetch-depth: 1
 
       - name: Install Pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest --force
+          corepack enable
 
       - name: Setup Node.js 18.x
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,9 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
 
       - name: Install Pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest --force
+          corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4.1.0
@@ -46,7 +48,9 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest --force
+          corepack enable
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -35,7 +35,9 @@ jobs:
           fetch-depth: 10
 
       - name: Install Pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest --force
+          corepack enable
 
       - name: Check skip CI
         run: echo "RESULT=$(node ./scripts/skipCI.js)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -40,7 +40,9 @@ jobs:
           fetch-depth: 10
 
       - name: Install Pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest --force
+          corepack enable
 
       - name: Check skip CI
         shell: bash


### PR DESCRIPTION
## Summary

Add `npm install -g corepack@latest --force` before `corepack enable` to fix corepack key id mismatch issue.

> `--force` to prevent windows install error

![image](https://github.com/user-attachments/assets/47a73c6c-240e-4c15-bf7b-1e23f8b1c54d)

## Related Links

https://github.com/nodejs/corepack/issues/612

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
