### PR TITLE
fix: expriments.backCompat problem

### DIFF
--- a/e2e/cases/doctor-webpack/experiments.test.ts
+++ b/e2e/cases/doctor-webpack/experiments.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test';
+import { getSDK } from '@rsdoctor/core/plugins';
+import path from 'path';
+import { compileByWebpack5 } from '@scripts/test-helper';
+import { createRsdoctorPlugin } from './test-utils';
+
+async function webpack(compile: typeof compileByWebpack5) {
+  const file = path.resolve(__dirname, './fixtures/b.js');
+  const loader = path.resolve(__dirname, './fixtures/loaders/comment.js');
+  const res = await compile(file, {
+    module: {
+      rules: [
+        {
+          test: /\.js/,
+          use: loader,
+        },
+      ],
+    },
+    experiments: {
+      backCompat: false,
+    },
+    optimization: {
+      minimize: true,
+    },
+    plugins: [createRsdoctorPlugin({})],
+  });
+  return res;
+}
+
+test('webpack5', async () => {
+  await webpack(compileByWebpack5);
+  const sdk = getSDK();
+  const { configs } = sdk.getStoreData();
+
+  expect(configs[0]).toBeInstanceOf(Object);
+  expect(configs[0].name).toEqual('webpack');
+});

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -3,7 +3,8 @@
   "name": "@rsdoctor/e2e",
   "version": "0.0.1",
   "scripts": {
-    "test": "playwright test"
+    "test": "playwright test",
+    "test:local": "npx playwright install chromium && playwright test"
   },
   "dependencies": {
     "devcert": "1.2.2",

--- a/packages/core/src/build-utils/build/utils/plugin.ts
+++ b/packages/core/src/build-utils/build/utils/plugin.ts
@@ -7,18 +7,18 @@ export type IHook =
 
 export function shouldInterceptPluginHook<T extends IHook>(hook: T) {
   // webpack5 use fakehook for deprecated hook.
-  if ((hook as Common.PlainObject)._fakeHook) {
+  if (hook && (hook as Common.PlainObject)._fakeHook) {
     return false;
   }
 
   // Hook
-  if (typeof hook.isUsed === 'function') {
+  if (hook?.isUsed && typeof hook.isUsed === 'function') {
     return hook.isUsed();
   }
 
   // HookMap
   if (
-    (hook as Common.PlainObject)._map &&
+    (hook as Common.PlainObject)?._map &&
     ((hook as Common.PlainObject)._map as Map<string, unknown>).size === 0
   ) {
     return false;

--- a/packages/core/src/inner-plugins/utils/plugin.ts
+++ b/packages/core/src/inner-plugins/utils/plugin.ts
@@ -40,7 +40,7 @@ export function interceptPluginHook(
   name: string,
   hook: IHook,
 ) {
-  if (!hook.intercept) {
+  if (!hook?.intercept) {
     return;
   }
 


### PR DESCRIPTION
## Summary
### Fix the expriments.backCompat problem
If the `experiments.backCompat: false' is set,the repo will have this problem:

```
TypeError: Cannot read properties of undefined (reading '_fakeHook')
    at shouldInterceptPluginHook (/Users/d.kholstinin/projects/tramvai/node_modules/@rsdoctor/core/dist/build-utils/build/utils/plugin.js:28:12)

```

This pull request includes a small change to the `interceptPluginHook` function in the `packages/core/src/inner-plugins/utils/plugin.ts` file. The change adds a safe navigation operator to ensure that the `intercept` property is accessed safely.

* [`packages/core/src/inner-plugins/utils/plugin.ts`](diffhunk://#diff-023b84789a4a53582840c427fd946f3abe4eacda4e30a4637511dd5abfb28f02L43-R43): Modified the `interceptPluginHook` function to use the safe navigation operator when accessing the `intercept` property of the `hook` parameter.
## Related Links
closes: #717

<!--- Provide links of related issues or pages -->
