### PR TITLE
fix(sdk): the error of websocket

### DIFF
--- a/packages/components/src/utils/socket.ts
+++ b/packages/components/src/utils/socket.ts
@@ -7,6 +7,10 @@ const defaultSocketUrl =
   process.env.NODE_ENV === 'development'
     ? `${socketProtocol}://${location.hostname}:${process.env.LOCAL_CLI_PORT}`
     : `${socketProtocol}://${location.host}`;
+
+const ipv4Pattern =
+  /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+
 function ensureSocket(socketUrl: string = defaultSocketUrl) {
   if (!map.has(socketUrl)) {
     const socket = io(socketUrl, {});
@@ -42,7 +46,9 @@ export function formatURL({
     url.port = String(port);
     url.hostname = hostname;
     url.protocol = location.protocol.includes('https') ? 'wss' : 'ws';
-    return url.toString();
+    return ipv4Pattern.test(hostname)
+      ? url.toString()
+      : `${protocol}//${hostname}`;
   }
 
   // compatible with IE11

--- a/packages/components/src/utils/socket.ts
+++ b/packages/components/src/utils/socket.ts
@@ -46,7 +46,7 @@ export function formatURL({
     url.port = String(port);
     url.hostname = hostname;
     url.protocol = location.protocol.includes('https') ? 'wss' : 'ws';
-    return ipv4Pattern.test(hostname)
+    return ipv4Pattern.test(hostname) || hostname.includes('localhost')
       ? url.toString()
       : `${protocol}//${hostname}`;
   }


### PR DESCRIPTION
## Summary

- Problem
When hostname is url name, `url.toString()` will include the port, like: `http://urlHostName:port/`.

- Fix codes:
This pull request includes changes to the `packages/components/src/utils/socket.ts` file to enhance URL formatting and validation. The most important changes are the addition of an IPv4 pattern for hostname validation and the modification of the `formatURL` function to use this pattern.

## Related Links

<!--- Provide links of related issues or pages -->
