### PR TITLE
fix: summary loader consuming time of dirs

### DIFF
--- a/packages/components/src/components/Loader/Analysis/files.tsx
+++ b/packages/components/src/components/Loader/Analysis/files.tsx
@@ -1,10 +1,9 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { get, sumBy } from 'lodash-es';
+import { get } from 'lodash-es';
 import {
   Tag,
   Card,
   Col,
-  Descriptions,
   Divider,
   Drawer,
   Row,
@@ -351,26 +350,6 @@ export const LoaderFiles: React.FC<{
                         },
                       ]}
                       dataSource={tableData!}
-                      footer={() => (
-                        <Descriptions
-                          title="Total"
-                          bordered
-                          layout="vertical"
-                          size="small"
-                        >
-                          <Descriptions.Item label="loaders">
-                            {tableData!.length}
-                          </Descriptions.Item>
-                          <Descriptions.Item label="files">
-                            {sumBy(tableData, (e) => e.files)}
-                          </Descriptions.Item>
-                          <Descriptions.Item label="duration">
-                            <Typography.Text strong>
-                              {formatCosts(sumBy(tableData, (e) => e.costs))}
-                            </Typography.Text>
-                          </Descriptions.Item>
-                        </Descriptions>
-                      )}
                     />
                   )}
                 </ServerAPIProvider>


### PR DESCRIPTION
## Summary
fix: summary loader consuming time of dirs.

1. Modify the time consumption calculation algorithm for Loaders in a specific folder:
   After the change, the logic is to count the time consumption by loader. If the loader has overlapping time consumption, as shown in the situation below, it will only be counted once. However, since there will be overlapping time issues between different loaders, the total time consumption for different loaders will no longer be displayed.
Example for loader blocked:

   | ---- |
 --  |-----|

2. Modify the time consumption logic for a single file in the Rust loader of rspack:
   Because the JS side loader operates in a single thread, it can directly exclude overlapping time consumption based on the PID, with overlapping time being blocking time. However, since the Rust side is multi-threaded, it should not only be calculated based on the PID. For now, we will calculate time consumption using the formula end - start, and later we need to add thread IDs on the Rust side to calculate more precise time consumption.
   
 —————————————————————————————————————————————————————————— 
1. 修改计算某个文件夹中的 Loader 耗时算法：
更改后逻辑：按照 loader 进行耗时统计，如果 loader 有耗时重叠，如下情况，则重叠耗时只计算一次。
但因为不同 loader 之间会有时间重叠问题，所以不再展示不同 loader 加和总耗时。
Example for loader blocked:

   | ---- |
 --  |-----|

2. 修改 rspack 的 rust loader 单个文件耗时逻辑：
因为 JS 侧 loader 是单线程，所以可以直接按照 pid 进行重叠耗时的排除，重叠耗时为阻塞耗时。
而 rust 侧为多线程，不该只按 pid 来计算，目前先按照 end - start 来计算耗时，后续需要在 rust 侧增加线程 id 来计算更精确的耗时。

## Related Links
related: #752 
<!--- Provide links of related issues or pages -->
