### PR TITLE
fix: optimize the display of loader name

### DIFF
--- a/packages/components/src/components/Loader/Analysis/style.module.scss
+++ b/packages/components/src/components/Loader/Analysis/style.module.scss
@@ -28,7 +28,7 @@
 }
 
 .textBox {
-  max-width: 220px;
+  max-width: 320px;
   color: rgba(0, 0, 0, 0.85);
   height: 22px;
   border: 1px #d9d9d9 solid;

--- a/packages/utils/src/common/loader.ts
+++ b/packages/utils/src/common/loader.ts
@@ -156,7 +156,7 @@ export function getLoaderChartData(
     item.loaders.forEach((el) => {
       res.push({
         layer: item.resource.layer,
-        loader: el.loader,
+        loader: getLoadrName(el.loader),
         isPitch: el.isPitch,
         startAt: el.startAt,
         endAt: el.endAt,
@@ -183,7 +183,7 @@ export function getLoaderFileTree(
       loaders: arr.map((l) => {
         return {
           key: l.path,
-          loader: l.loader,
+          loader: getLoadrName(l.loader),
           path: l.path,
           errors: l.errors,
           costs: getLoaderCosts(l, list),
@@ -210,6 +210,7 @@ export function getLoaderFileDetails(
     loaders: data.loaders.map((el) => {
       return {
         ...el,
+        loader: getLoadrName(el.loader),
         costs: getLoaderCosts(el, list),
       };
     }),
@@ -333,4 +334,11 @@ export const isVue = (compiler: Plugin.BaseCompiler) => {
     return false;
   });
   return hasVueRule;
+};
+
+const getLoadrName = (loader: string) => {
+  const regResults = loader.includes('node_modules')
+    ? loader.split('node_modules')
+    : null;
+  return regResults ? regResults[regResults.length - 1] : loader;
 };


### PR DESCRIPTION
## Summary
Fix the loader page ui problem：optimize the display of loader name.

- before

![image](https://github.com/user-attachments/assets/8a9d2161-489e-413a-8ce8-88699ff1421b)
![image](https://github.com/user-attachments/assets/0c3133cb-eb69-4f15-95ec-3d71bfa565aa)


- after


![image](https://github.com/user-attachments/assets/154df6d8-164b-4ecb-8278-b23a1c3aa952)
![image](https://github.com/user-attachments/assets/d115a1f8-2144-4a31-aa94-487e516ca424)




## Related Links

<!--- Provide links of related issues or pages -->
