### PR TITLE
Fix(ui): The file tree elements have problems with keyword searches.

### DIFF
--- a/packages/components/src/components/Loader/Analysis/files.tsx
+++ b/packages/components/src/components/Loader/Analysis/files.tsx
@@ -105,10 +105,7 @@ export const LoaderFiles: React.FC<{
               }}
             >
               <div className={styles.keywords}>
-                <Keyword
-                  text={basename.replace(/\[.*?\]/g, '')}
-                  keyword={props.filename}
-                />
+                <Keyword text={basename.replace(/\[.*?\]/g, '')} keyword={''} />
               </div>
               <div className={styles.dividerDiv}>
                 <Divider className={styles.divider} dashed />
@@ -209,7 +206,7 @@ export const LoaderFiles: React.FC<{
         );
       },
       dirTitle(_dir, defaultTitle) {
-        return <Keyword text={defaultTitle} keyword={props.filename} />;
+        return <Keyword text={defaultTitle} keyword={''} />;
       },
     });
   }, [filteredFiles]);

--- a/packages/components/src/pages/BundleSize/components/asset.tsx
+++ b/packages/components/src/pages/BundleSize/components/asset.tsx
@@ -396,7 +396,7 @@ export const AssetDetail: React.FC<{
           <div className={styles['bundle-tree']}>
             <div className={styles.box}>
               <div className={styles.keywords}>
-                <Keyword ellipsis text={basename} keyword={moduleKeyword} />
+                <Keyword ellipsis text={basename} keyword={''} />
               </div>
 
               <div className={styles.dividerDiv}>
@@ -563,7 +563,7 @@ export const AssetDetail: React.FC<{
       <Card
         className={styles.bundle}
         title={`Modules of "${asset.path}"`}
-        bodyStyle={{ overflow: 'scroll', height }}
+        bodyStyle={{ minHeight: height }}
         size="small"
       >
         {includeModules.length ? (
@@ -610,7 +610,8 @@ export const AssetDetail: React.FC<{
                   }
                   treeData={fileStructures as AntdDataNode[]}
                   rootStyle={{
-                    minHeight: '800px',
+                    maxHeight: '500px',
+                    overflow: 'auto',
                     border: '1px solid rgba(235, 237, 241)',
                     padding: '14px 20px',
                   }}

--- a/packages/components/src/pages/BundleSize/components/index.tsx
+++ b/packages/components/src/pages/BundleSize/components/index.tsx
@@ -38,7 +38,7 @@ import { GraphType } from '../constants';
 
 const { Option } = Select;
 
-const cardBodyHeight = 410;
+const cardBodyHeight = 600;
 
 const largeCardBodyHeight = 800;
 
@@ -241,11 +241,7 @@ export const WebpackModulesOverallBase: React.FC<
               setAssetPath(path);
             }}
           >
-            <Keyword
-              text={basename}
-              keyword={inputAssetName}
-              className={styles.fileText}
-            />
+            <Keyword text={basename} keyword={''} className={styles.fileText} />
             <Space size="small" className={styles.assetsTag}>
               <Divider type="vertical" />
               <Typography.Text style={{ color: '#4FD233' }}>

--- a/packages/core/src/rules/rules/duplicate-package/index.ts
+++ b/packages/core/src/rules/rules/duplicate-package/index.ts
@@ -41,7 +41,11 @@ export const rule = defineRule<typeof title, Config>(() => ({
             gt(_packA.version, _packB.version) ? 1 : -1,
           );
       })
-      .filter((pkgs) => pkgs.length > 1);
+      .filter(
+        (pkgs) =>
+          pkgs.length > 1 &&
+          pkgs.filter((pkg) => pkg.getSize().parsedSize > 0).length > 1,
+      );
 
     for (const pkg of packages) {
       const message = getErrorMsg(pkg, root);


### PR DESCRIPTION
## Summary
Fix some UI problems:
1. Adjust the scroll area: the scrollable area can be adjusted from the entire modules box to only scroll for fileTree

![image](https://github.com/user-attachments/assets/f3cbfc65-90f5-49c4-b75b-f7cdd9160b0a)


2. Fix the display problem caused by fileTree searching for keywords
- before
![image](https://github.com/user-attachments/assets/8bf4c152-a639-4481-8887-e3659cc24beb)

- after
<img width="1305" alt="image" src="https://github.com/user-attachments/assets/7197e812-ce2f-4196-813c-c15bcd50f70d" />



## Related Links

<!--- Provide links of related issues or pages -->
