### PR TITLE
docs: add experiments enableNativePlugin option

### DIFF
--- a/packages/document/docs/en/config/options/options.mdx
+++ b/packages/document/docs/en/config/options/options.mdx
@@ -107,6 +107,27 @@ interface BriefConfig {
 
 Whether to automatically open the Rsdoctor report page. If you do not need to view the analysis report provided by Rsdoctor in the browser, you can enable this configuration item.
 
+### experiments
+
+<Badge text="Version: 1.0.0" type="warning" />
+
+#### enableNativePlugin
+
+- Type: `boolean`
+- Optional: true
+- Default: false
+- Description
+
+  - Whether to enable the Rspack native plugin, enabling it can significantly reduce the analysis time of Rsdoctor itself.
+
+- Example
+
+```js
+new RsdoctorRspackPlugin({
+  experiments: { enableNativePlugin: true }
+}),
+```
+
 ### features
 
 - **Type:** [RsdoctorWebpackPluginFeatures](#rsdoctorwebpackpluginfeatures) | [Array\<keyof RsdoctorWebpackPluginFeatures\>](#rsdoctorwebpackpluginfeatures) | [RsdoctorRspackPluginFeatures](#rsdoctorrspackpluginfeatures) | [Array\<keyof RsdoctorRspackPluginFeatures\>](#rsdoctorrspackpluginfeatures)

--- a/packages/document/docs/zh/config/options/options.mdx
+++ b/packages/document/docs/zh/config/options/options.mdx
@@ -186,6 +186,27 @@ interface BriefConfig {
 }
 ```
 
+### experiments
+
+<Badge text="Version: 1.0.0" type="warning" />
+
+#### enableNativePlugin
+
+- Type: `boolean`
+- Optional: true
+- Default: false
+- Description
+
+  - 是否开启 Rspack 原生插件，开启后可大幅降低 Rsdoctor 自身的分析耗时。
+
+- Example
+
+```js
+new RsdoctorRspackPlugin({
+  experiments: { enableNativePlugin: true }
+}),
+```
+
 ### output
 
 <Badge text="Version: 1.0.0" type="warning" />


### PR DESCRIPTION
## Summary

This pull request includes changes to the documentation files to introduce a new configuration option for enabling the Rspack native plugin. The changes add details about this new option in both the English and Chinese versions of the documentation.

Documentation updates:

* [`packages/document/docs/en/config/options/options.mdx`](diffhunk://#diff-1ed900ad28402e2526bc18d04eb8524c77658f9966f91760de11e90860151bc4R110-R130): Added a new section under `experiments` for the `enableNativePlugin` option, including its type, default value, description, and an example of how to configure it.
* [`packages/document/docs/zh/config/options/options.mdx`](diffhunk://#diff-b001fe80cc79d90e4be01c2d4e67bd5d9b3deb5bacb941c5ccab39f5bba14439R189-R209): Added a new section under `experiments` for the `enableNativePlugin` option, including its type, default value, description, and an example of how to configure it, translated into Chinese.

## Related Links

<!--- Provide links of related issues or pages -->
