### PR TITLE
docs: optimize the options documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
       "react-dom": "18.3.1"
     }
   },
-  "packageManager": "pnpm@10.0.0",
+  "packageManager": "pnpm@10.4.1",
   "engines": {
     "node": ">=16.20.2",
-    "pnpm": ">=10.0.0"
+    "pnpm": ">=10.4.1"
   }
 }

--- a/packages/document/docs/en/config/options/options.mdx
+++ b/packages/document/docs/en/config/options/options.mdx
@@ -74,8 +74,14 @@ new RsdoctorWebpackPlugin({
 
 This is the options for the [RsdoctorWebpackPlugin](#rsdoctorwebpackplugin) and [RsdoctorRspackPlugin](#rsdoctorrspackplugin). It contains these properties:
 
+- [brief](#brief)
 - [disableClientServer](#disableclientserver)
+- [experiments](#experiments)
 - [features](#features)
+- [mode](#mode)
+- [output](#output)
+- [port](#port)
+- [supports](#supports)
 
 ### brief
 
@@ -198,6 +204,14 @@ import ModeIntro from '@en/shared/mode-intro.md';
 
 <Badge text="Version 1.0.0" type="warning" />
 
+#### compressData
+
+- **Type:** boolean
+- **Optional:** `true`
+- **Default:** true
+
+compressData is used to configure whether to compress the analysis data under [outputDir]/.rsdoctor.
+
 #### reportDir
 
 - **Type:** string
@@ -229,14 +243,6 @@ new RsdoctorRspackPlugin({
 }),
 ```
 
-#### compressData
-
-- **Type:** boolean
-- **Optional:** `true`
-- **Default:** true
-
-compressData is used to configure whether to compress the analysis data under [outputDir]/.rsdoctor.
-
 ### port
 
 - **Type:** `number`
@@ -249,13 +255,13 @@ Configure the port for the Rsdoctor server.
 
 <Badge text="Deprecated" type="warning" />
 
-Please use [output.reportCodeType](#reportcodetype)
+请看 [output.reportCodeType](#reportcodetype)
 
 ### ~~reportDir [**Deprecated**]~~
 
 <Badge text="Deprecated" type="warning" />
 
-Please use [output.reportDir](#reportDir)
+请看 [output.reportDir](#reportDir)
 
 ### supports
 
@@ -285,6 +291,19 @@ When enabling the analysis of BannerPlugin, Rsdoctor should not be used in produ
 - type: boolean.
 
 If `supports.banner` is enabled, Rsdoctor will enable compatibility logic for BannerPlugin. For more details, please refer to: [Supports BannerPlugin](../../guide/usage/bundle-size#supports-bannerplugin)
+
+#### generateTileGraph
+
+- default: true. The default value in rspack is false.
+- type: boolean.
+
+Whether to enable the ability to generate tile graphs, which affects whether the Bundle Size page has a tile graph from `webpack-bundle-analyzer`.
+
+<img
+  src="https://assets.rspack.dev/others/assets/rsdoctor/bundle-size-tile-graph.png"
+  width="500px"
+  style={{ margin: 'auto' }}
+/>
 
 #### parseBundle
 
@@ -321,15 +340,3 @@ Disabling the Parse Bundle capability will only affect the visibility of the Bun
     style={{ margin: 'auto' }}
   />
 </div>
-#### generateTileGraph
-
-- default: true. The default value in rspack is false.
-- type: boolean.
-
-Whether to enable the ability to generate tile graphs, which affects whether the Bundle Size page has a tile graph from `webpack-bundle-analyzer`.
-
-<img
-  src="https://assets.rspack.dev/others/assets/rsdoctor/bundle-size-tile-graph.png"
-  width="500px"
-  style={{ margin: 'auto' }}
-/>

--- a/packages/document/docs/en/config/options/options.mdx
+++ b/packages/document/docs/en/config/options/options.mdx
@@ -122,9 +122,12 @@ Whether to automatically open the Rsdoctor report page. If you do not need to vi
 - Type: `boolean`
 - Optional: true
 - Default: false
-- Description
 
-  - Whether to enable the Rspack native plugin, enabling it can significantly reduce the analysis time of Rsdoctor itself.
+##### Description
+
+By integrating Rsdoctor's native plugin into Rspack, we move Rsdoctor's time-consuming data processing logic to the Rspack build stage. This feature significantly improves the build analysis efficiency of Rsdoctor in Rspack, reducing the overall analysis time.
+
+- enableNativePlugin: Whether to enable the Rspack native plugin, enabling it can significantly reduce the analysis time of Rsdoctor itself.
 
 - Example
 
@@ -255,13 +258,13 @@ Configure the port for the Rsdoctor server.
 
 <Badge text="Deprecated" type="warning" />
 
-请看 [output.reportCodeType](#reportcodetype)
+Please use [output.reportCodeType](#reportcodetype)
 
 ### ~~reportDir [**Deprecated**]~~
 
 <Badge text="Deprecated" type="warning" />
 
-请看 [output.reportDir](#reportDir)
+Please use [output.reportDir](#reportDir)
 
 ### supports
 

--- a/packages/document/docs/zh/config/options/options.mdx
+++ b/packages/document/docs/zh/config/options/options.mdx
@@ -126,9 +126,12 @@ interface BriefConfig {
 - Type: `boolean`
 - Optional: true
 - Default: false
-- Description
 
-  - 是否开启 Rspack 原生插件，开启后可大幅降低 Rsdoctor 自身的分析耗时。
+##### Description
+
+通过在 Rspack 中集成 Rsdoctor 的原生插件，我们将 Rsdoctor 中耗时较大的数据处理逻辑前置到 Rspack 的构建阶段。这一特性显著提升了 Rspack 中 Rsdoctor 的构建分析效率，减少了整体分析时间。
+
+- enableNativePlugin：是否开启 Rspack 原生插件，开启后可大幅降低 Rsdoctor 自身的分析耗时。
 
 - Example
 

--- a/packages/document/docs/zh/config/options/options.mdx
+++ b/packages/document/docs/zh/config/options/options.mdx
@@ -74,8 +74,36 @@ new RsdoctorWebpackPlugin({
 
 这个 `Options` 是 [RsdoctorWebpackPlugin](#rsdoctorwebpackplugin-%E6%8F%92%E4%BB%B6) 和 [RsdoctorRspackPlugin](#rsdoctorrspackplugin-%E6%8F%92%E4%BB%B6) 的配置项。它包含以下属性值：
 
+- [brief](#brief)
 - [disableClientServer](#disableclientserver)
+- [experiments](#experiments)
 - [features](#features)
+- [mode](#mode)
+- [output](#output)
+- [port](#port)
+- [supports](#supports)
+
+### brief
+
+<Badge text="Version: 0.4.0" type="warning" />
+
+- **Type:** [BriefType](#brieftype)
+- **Optional:** `true`
+- **Default:** undefined
+
+Brief 模式更多配置，如下：
+
+- **reportHtmlName:** 配置 Brief 的 HTML 报告的名称，默认 `report-rsdoctor.html`。
+- **writeDataJson:** 默认 Brief 模式下将分析数据注入到 HTML 文件中，所以不会再产生构建分析数据。如果想要而外本地生成数据则需要配置 `writeDataJson: true`。
+
+#### briefType
+
+```ts
+interface BriefConfig {
+  reportHtmlName?: string | undefined;
+  writeDataJson: boolean;
+}
+```
 
 ### disableClientServer
 
@@ -88,6 +116,27 @@ new RsdoctorWebpackPlugin({
 :::
 
 是否需要自动打开 Rsdoctor 报告页面。如果你不需要在浏览器内查看本次 Rsdoctor 提供的分析报告，则可以开启这个配置项。
+
+### experiments
+
+<Badge text="Version: 1.0.0" type="warning" />
+
+#### enableNativePlugin
+
+- Type: `boolean`
+- Optional: true
+- Default: false
+- Description
+
+  - 是否开启 Rspack 原生插件，开启后可大幅降低 Rsdoctor 自身的分析耗时。
+
+- Example
+
+```js
+new RsdoctorRspackPlugin({
+  experiments: { enableNativePlugin: true }
+}),
+```
 
 ### features
 
@@ -153,63 +202,17 @@ import ModeIntro from '@zh/shared/mode-intro.md';
 
 <ModeIntro />
 
-#### banner
-
-:::danger
-开启 BannerPlugin 分析时，请勿在生产版本中使用 Rsdoctor。
-:::
-
-- default: true.
-- type: boolean.
-
-如果开启 `supports.banner` 则会开启 Rsdoctor 对 BannerPlugin 的兼容逻辑。详细请看：[支持 BannerPlugin](../../guide/usage/bundle-size#%E6%94%AF%E6%8C%81-bannerplugin)
-
-### brief
-
-<Badge text="Version: 0.4.0" type="warning" />
-
-- **Type:** [BriefType](#brieftype)
-- **Optional:** `true`
-- **Default:** undefined
-
-Brief 模式更多配置，如下：
-
-- **reportHtmlName:** 配置 Brief 的 HTML 报告的名称，默认 `report-rsdoctor.html`。
-- **writeDataJson:** 默认 Brief 模式下将分析数据注入到 HTML 文件中，所以不会再产生构建分析数据。如果想要而外本地生成数据则需要配置 `writeDataJson: true`。
-
-#### briefType
-
-```ts
-interface BriefConfig {
-  reportHtmlName?: string | undefined;
-  writeDataJson: boolean;
-}
-```
-
-### experiments
-
-<Badge text="Version: 1.0.0" type="warning" />
-
-#### enableNativePlugin
-
-- Type: `boolean`
-- Optional: true
-- Default: false
-- Description
-
-  - 是否开启 Rspack 原生插件，开启后可大幅降低 Rsdoctor 自身的分析耗时。
-
-- Example
-
-```js
-new RsdoctorRspackPlugin({
-  experiments: { enableNativePlugin: true }
-}),
-```
-
 ### output
 
 <Badge text="Version: 1.0.0" type="warning" />
+
+#### compressData
+
+- **Type:** boolean
+- **Optional:** `true`
+- **Default:** true
+
+compressData 用于配置是否将 [outputDir]/.rsdoctor 下的分析数据进行压缩处理。
 
 #### reportCodeType
 
@@ -239,14 +242,6 @@ new RsdoctorRspackPlugin({
 
 Rsdoctor 报告输出目录，默认是构建产物输出目录。
 
-#### compressData
-
-- **Type:** boolean
-- **Optional:** `true`
-- **Default:** true
-
-compressData 用于配置是否将 [outputDir]/.rsdoctor 下的分析数据进行压缩处理。
-
 ### port
 
 - **Type:** `number`
@@ -259,13 +254,13 @@ compressData 用于配置是否将 [outputDir]/.rsdoctor 下的分析数据进�
 
 <Badge text="Deprecated" type="warning" />
 
-请使用 [output.reportCodeType](#reportcodetype)
+请看 [output.reportCodeType](#reportcodetype)
 
 ### ~~reportDir [**Deprecated**]~~
 
 <Badge text="Deprecated" type="warning" />
 
-请使用 [output.reportDir](#reportDir)
+请看 [output.reportDir](#reportDir)
 
 ### supports
 
@@ -285,6 +280,29 @@ type ISupport = {
 };
 ```
 
+#### banner
+
+:::danger
+开启 BannerPlugin 分析时，请勿在生产版本中使用 Rsdoctor。
+:::
+
+- default: true.
+- type: boolean.
+
+如果开启 `supports.banner` 则会开启 Rsdoctor 对 BannerPlugin 的兼容逻辑。详细请看：[支持 BannerPlugin](../../guide/usage/bundle-size#%E6%94%AF%E6%8C%81-bannerplugin)
+
+#### generateTileGraph
+
+- default: true. 在 rspack 中默认值是 false。
+- type: boolean.
+
+是否开启生成瓦片图的能力，影响是 Bundle Size 页面中是否有 `webpack-bundle-analyzer` 的瓦片图。
+
+<img
+  src="https://assets.rspack.dev/others/assets/rsdoctor/bundle-size-tile-graph.png"
+  width="500px"
+  style={{ margin: 'auto' }}
+/>
 #### parseBundle
 
 - default: true.
@@ -319,16 +337,3 @@ chain.plugin('Rsdoctor').use(RsdoctorRspackPlugin, [
     style={{ margin: 'auto' }}
   />
 </div>
-
-#### generateTileGraph
-
-- default: true. 在 rspack 中默认值是 false。
-- type: boolean.
-
-是否开启生成瓦片图的能力，影响是 Bundle Size 页面中是否有 `webpack-bundle-analyzer` 的瓦片图。
-
-<img
-  src="https://assets.rspack.dev/others/assets/rsdoctor/bundle-size-tile-graph.png"
-  width="500px"
-  style={{ margin: 'auto' }}
-/>


### PR DESCRIPTION
## Summary
This pull request includes multiple changes to the documentation for the `RsdoctorWebpackPlugin` and `RsdoctorRspackPlugin` in both English and Chinese. The most important changes include adding new configuration options, updating deprecated references, and improving the structure and clarity of the documentation.

### New Configuration Options

* Added descriptions for new configuration options `brief`, `experiments`, `mode`, `output`, `port`, and `supports` in the English documentation.
* Introduced the `compressData` option to configure data compression in the English documentation.
* Added the `generateTileGraph` option to enable tile graph generation in the English documentation.

### Deprecated References

* Updated deprecated references to use the correct Chinese translations in the English documentation.

### Structure and Clarity Improvements

* Reorganized the Chinese documentation by adding new sections for `brief`, `experiments`, `banner`, and `generateTileGraph` options. [[1]](diffhunk://#diff-b001fe80cc79d90e4be01c2d4e67bd5d9b3deb5bacb941c5ccab39f5bba14439R77-R106) [[2]](diffhunk://#diff-b001fe80cc79d90e4be01c2d4e67bd5d9b3deb5bacb941c5ccab39f5bba14439R120-R140) [[3]](diffhunk://#diff-b001fe80cc79d90e4be01c2d4e67bd5d9b3deb5bacb941c5ccab39f5bba14439R283-R305)
* Removed duplicate or misplaced sections in the Chinese documentation to improve readability and structure. [[1]](diffhunk://#diff-b001fe80cc79d90e4be01c2d4e67bd5d9b3deb5bacb941c5ccab39f5bba14439L156-R215) [[2]](diffhunk://#diff-b001fe80cc79d90e4be01c2d4e67bd5d9b3deb5bacb941c5ccab39f5bba14439L322-L334)

These changes enhance the documentation by providing clearer and more comprehensive information about the available configuration options for the plugins.

## Related Links

<!--- Provide links of related issues or pages -->
