### PR TITLE
fix: eco ci pnpm error when install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
       "react-dom": "18.3.1"
     }
   },
-  "packageManager": "pnpm@10.0.0",
+  "packageManager": "pnpm@10.4.1",
   "engines": {
     "node": ">=16.20.2",
-    "pnpm": ">=10.0.0"
+    "pnpm": ">=10.4.1"
   }
 }


### PR DESCRIPTION
## Summary
![image](https://github.com/user-attachments/assets/fdf180f6-2353-4868-bc16-6ff00133044e)

This pull request includes an update to the `package.json` file to ensure compatibility with the latest version of the `pnpm` package manager.

* Updated the `packageManager` field to use `pnpm@10.4.1` instead of `pnpm@10.0.0`.
* Updated the `engines` field to require `pnpm` version `>=10.4.1` instead of `>=10.0.0`.
https://github.com/rspack-contrib/rsbuild-ecosystem-ci/actions/runs/12802982226/job/35694933171

Reference: https://github.com/pnpm/pnpm/issues/8978

## Related Links

<!--- Provide links of related issues or pages -->
