### PR TITLE
chore(examples): fix the indentation used in `webpack-minimal`

### DIFF
--- a/examples/webpack-minimal/webpack.config.ts
+++ b/examples/webpack-minimal/webpack.config.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'path';
 import { Configuration } from 'webpack';
 import { RsdoctorWebpackPlugin } from '@rsdoctor/webpack-plugin';
-import svgToMiniDataURI from "mini-svg-data-uri";
+import svgToMiniDataURI from 'mini-svg-data-uri';
 
 const data: Configuration = {
   entry: './src/index.ts',
@@ -13,29 +13,29 @@ const data: Configuration = {
         loader: 'ts-loader',
       },
       {
-				test: /\.css$/,
-				loader: "css-loader"
-			},
+        test: /\.css$/,
+        loader: 'css-loader',
+      },
       {
-				test: /\.(png|jpg)$/,
-				type: "asset"
-			},
-			{
-				test: /\.svg$/,
-				type: "asset",
-				generator: {
-					dataUrl: (content: any) => {
-						if (typeof content !== "string") {
-							content = content.toString();
-						}
+        test: /\.(png|jpg)$/,
+        type: 'asset',
+      },
+      {
+        test: /\.svg$/,
+        type: 'asset',
+        generator: {
+          dataUrl: (content: any) => {
+            if (typeof content !== 'string') {
+              content = content.toString();
+            }
 
-						return svgToMiniDataURI(content);
-					}
-				}
-			}
+            return svgToMiniDataURI(content);
+          },
+        },
+      },
     ],
   },
-  
+
   resolve: {
     mainFields: ['browser', 'module', 'main'],
     extensions: ['.ts', '.js', '.json', '.wasm'],
@@ -62,7 +62,12 @@ const data: Configuration = {
     ids: true,
   },
   devtool: 'source-map',
-  plugins: [new RsdoctorWebpackPlugin({ disableClientServer: !process.env.ENABLE_CLIENT_SERVER, features: ['bundle', 'plugins', 'loader', 'resolver'] })],
+  plugins: [
+    new RsdoctorWebpackPlugin({
+      disableClientServer: !process.env.ENABLE_CLIENT_SERVER,
+      features: ['bundle', 'plugins', 'loader', 'resolver'],
+    }),
+  ],
 };
 
 export default data;


### PR DESCRIPTION
## Summary

While reading through examples, I realized [`examples/webpack-minimal/webpack.config.ts`](https://github.com/web-infra-dev/rsdoctor/blob/main/examples/webpack-minimal/webpack.config.ts) was using multiple indentations that weren't matching with other files. Let's fix that with Prettier.

## Related Links

<!--- Provide links of related issues or pages -->
