### PR TITLE
fix(ui): add spacing before the modules count

### DIFF
--- a/packages/components/src/pages/BundleSize/components/asset.tsx
+++ b/packages/components/src/pages/BundleSize/components/asset.tsx
@@ -433,7 +433,7 @@ export const AssetDetail: React.FC<{
                   title={
                     <Space>
                       <Typography.Text style={{ color: 'inherit' }}>
-                        this is a concatenated module, it contains
+                        this is a concatenated module, it contains{' '}
                         {mod.modules?.length} modules
                       </Typography.Text>
                     </Space>


### PR DESCRIPTION
## Summary

| Before | After |
| - | - |
| <img width="271" alt="Screenshot 2025-03-04 at 2 08 39 PM" src="https://github.com/user-attachments/assets/42fb309c-2c25-4f1f-afb7-2fa8549c3424" /> | <img width="281" alt="Screenshot 2025-03-04 at 2 11 11 PM" src="https://github.com/user-attachments/assets/95ce69f0-40f2-4c7e-a05f-1564769b17fd" /> |

## Related Links

<!--- Provide links of related issues or pages -->
