### PR TITLE
fix(ui): add spacing between tile graph disabled and the link

### DIFF
--- a/packages/components/src/pages/BundleSize/components/index.tsx
+++ b/packages/components/src/pages/BundleSize/components/index.tsx
@@ -310,7 +310,7 @@ export const WebpackModulesOverallBase: React.FC<
                 <Empty
                   description={
                     <div>
-                      Tile graph is disabled,
+                      Tile graph is disabled,{' '}
                       <a href="https://rsdoctor.dev/config/options/options#generatetilegraph">
                         see the documentation to learn how to enable.
                       </a>


### PR DESCRIPTION
## Summary

| Before | After |
| - | - |
| <img width="523" alt="Screenshot 2025-03-04 at 3 22 47 PM" src="https://github.com/user-attachments/assets/e59ed9dd-8cba-4711-8b3a-9fe2e5abe34f" /> | <img width="516" alt="Screenshot 2025-03-04 at 3 30 02 PM" src="https://github.com/user-attachments/assets/9228b2bf-435d-4cc2-b0c5-ba1f73e1ac72" /> |

## Related Links

<!--- Provide links of related issues or pages -->
