### PR TITLE
fix: parsing module failed in lynx projects

### DIFF
--- a/packages/core/src/build-utils/build/utils/parseBundle.ts
+++ b/packages/core/src/build-utils/build/utils/parseBundle.ts
@@ -41,8 +41,8 @@ export const parseBundle: ParseBundle = (
     const tagMatchResult = getStringBetween(
       content,
       0,
-      /([a-z|A-Z]+\.[a-z]+)\(\SRSDOCTOR_START::(.*?);/,
-      /([a-z|A-Z]+\.[a-z]+)\(\SRSDOCTOR_END::(.*?)\)/,
+      /([a-z|A-Z|_]+\.[a-z]+)\(\SRSDOCTOR_START::(.*?);/,
+      /([a-z|A-Z|_]+\.[a-z]+)\(\SRSDOCTOR_END::(.*?)\)/,
     );
     content = tagMatchResult.result?.trim() || content;
     tagCache.set(bundlePath, tagMatchResult.loc);


### PR DESCRIPTION
## Summary
fix: parsing module failed in lynx projects

background.js will be compressed again, lead to the parse bundle error, console.log -> _.log

![image](https://github.com/user-attachments/assets/c14bbda7-5810-4bc7-8bac-b44dc5c47592)



## Related Links

<!--- Provide links of related issues or pages -->
