### PR TITLE
fix: update `supports.banner` logs

### DIFF
--- a/packages/core/src/inner-plugins/plugins/bundleTagPlugin.ts
+++ b/packages/core/src/inner-plugins/plugins/bundleTagPlugin.ts
@@ -29,8 +29,8 @@ export class InternalBundleTagPlugin<
               return;
             }
             logger.info(
-              chalk.bgMagenta(
-                'Rsdoctor BannerTagPlugin has open. Do not use Rsdoctor on production version.',
+              chalk.magenta(
+                "Rsdoctor's `supports.banner` option is enabled, this is for debugging only. Do not use it for production.",
               ),
             );
 

--- a/packages/document/docs/en/config/options/options.mdx
+++ b/packages/document/docs/en/config/options/options.mdx
@@ -287,7 +287,7 @@ type ISupport = {
 #### banner
 
 :::danger
-When enabling the analysis of BannerPlugin, Rsdoctor should not be used in production versions.
+`supports.banner` option is only used for debugging, do not use it in production.
 :::
 
 - default: false.

--- a/packages/document/docs/en/guide/usage/bundle-size.mdx
+++ b/packages/document/docs/en/guide/usage/bundle-size.mdx
@@ -141,7 +141,7 @@ Click the **"Bundle Analyzer Graph"** button on the **"Bundle Size"** page to vi
 ## Supports BannerPlugin
 
 :::danger
-When enabling the BannerPlugin analysis, do not use Rsdoctor in the production version.
+`supports.banner` option is only used for debugging, do not use it in production.
 :::
 
 Both Rspack and webpack support the [BannerPlugin](https://www.rspack.dev/plugins/webpack/banner-plugin#bannerplugin), which is a built-in plugin that allows you to add specific content at the top or bottom of the generated chunks.

--- a/packages/document/docs/zh/config/options/options.mdx
+++ b/packages/document/docs/zh/config/options/options.mdx
@@ -286,7 +286,7 @@ type ISupport = {
 #### banner
 
 :::danger
-开启 BannerPlugin 分析时，请勿在生产版本中使用 Rsdoctor。
+`supports.banner` 分析仅用于调试，请勿将其用于生产。
 :::
 
 - **类型：** `boolean`

--- a/packages/document/docs/zh/guide/usage/bundle-size.mdx
+++ b/packages/document/docs/zh/guide/usage/bundle-size.mdx
@@ -132,7 +132,7 @@
 ## 支持 BannerPlugin
 
 :::danger
-开启 BannerPlugin 分析时，请勿在生产版本中使用 Rsdoctor。
+`supports.banner` 选项仅用于调试，请勿将其用于生产。
 :::
 
 由于 Rspack 和 webpack 都支持 [BannerPlugin](https://www.rspack.dev/plugins/webpack/banner-plugin#bannerplugin)，BannerPlugin 是可在生成的 chunk 顶部或尾部添加一段指定的内容的内置插件。


### PR DESCRIPTION
## Summary

Updating the messaging related to the `supports.banner` option to clarify that it is intended for debugging purposes only and should not be used in production. 

- before:
<img width="904" alt="Screenshot 2025-03-20 at 11 59 25" src="https://github.com/user-attachments/assets/23596221-08f2-473d-941b-b3952cbc0bf0" />

- after:
<img width="1224" alt="Screenshot 2025-03-20 at 11 59 03" src="https://github.com/user-attachments/assets/83dcbf60-2248-4d39-a002-d6af14d33d3d" />
