### PR TITLE
docs: cleanup README files

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,19 +1,10 @@
-# Rsdoctor CLI
+# @rsdoctor/cli
 
-This is the cli package of Rsdoctor, you can use the capabilities of this package to open the analysis page without building.
+This is the CLI of Rsdoctor, you can use the capabilities of this package to open the analysis page without building.
 
-```
-
+```bash
 npx @rsdoctor/cli analyze --profile [.rsdoctor/manifest.json filepath]
-
 ```
-
-## features
-
-- Rsdoctor is a one-stop tool for diagnosing and analyzing the build process and build artifacts.
-- Rsdoctor is a tool that supports Webpack and Rspack build analysis.
-- Rsdoctor is an analysis tool that can display the time-consuming and behavioral details of the compilation.
-- Rsdoctor is a tool that provides bundle Diff and other anti-degradation capabilities simultaneously.
 
 ## Documentation
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,13 +1,6 @@
-# Rsdoctor client
+# @rsdoctor/client
 
 This package is the Rsdoctor reporting platform.
-
-## features
-
-- Rsdoctor is a one-stop tool for diagnosing and analyzing the build process and build artifacts.
-- Rsdoctor is a tool that supports Webpack and Rspack build analysis.
-- Rsdoctor is an analysis tool that can display the time-consuming and behavioral details of the compilation.
-- Rsdoctor is a tool that provides bundle Diff and other anti-degradation capabilities simultaneously.
 
 ## Documentation
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,13 +1,6 @@
-# Rsdoctor components
+# @rsdoctor/components
 
 This package is the Rsdoctor reporting platform’s components.
-
-## features
-
-- Rsdoctor is a one-stop tool for diagnosing and analyzing the build process and build artifacts.
-- Rsdoctor is a tool that supports Webpack and Rspack build analysis.
-- Rsdoctor is an analysis tool that can display the time-consuming and behavioral details of the compilation.
-- Rsdoctor is a tool that provides bundle Diff and other anti-degradation capabilities simultaneously.
 
 ## Documentation
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,13 +1,6 @@
-# Rsdoctor core
+# @rsdoctor/core
 
 This is the core package of Rsdoctor, providing core tools and analysis capabilities for Rsdoctor plugins.
-
-## features
-
-- Rsdoctor is a one-stop tool for diagnosing and analyzing the build process and build artifacts.
-- Rsdoctor is a tool that supports Webpack and Rspack build analysis.
-- Rsdoctor is an analysis tool that can display the time-consuming and behavioral details of the compilation.
-- Rsdoctor is a tool that provides bundle Diff and other anti-degradation capabilities simultaneously.
 
 ## Documentation
 

--- a/packages/graph/README.md
+++ b/packages/graph/README.md
@@ -1,13 +1,6 @@
-# Rsdoctor graph
+# @rsdoctor/graph
 
 This package is the intermediate data layer of Rsdoctor.
-
-## features
-
-- Rsdoctor is a one-stop tool for diagnosing and analyzing the build process and build artifacts.
-- Rsdoctor is a tool that supports Webpack and Rspack build analysis.
-- Rsdoctor is an analysis tool that can display the time-consuming and behavioral details of the compilation.
-- Rsdoctor is a tool that provides bundle Diff and other anti-degradation capabilities simultaneously.
 
 ## Documentation
 

--- a/packages/rspack-plugin/README.md
+++ b/packages/rspack-plugin/README.md
@@ -1,34 +1,6 @@
-# Rsdoctor plugin
+# @rsdoctor/rspack-plugin
 
-This Rsdoctor plugin is an analysis plugin for the Rspack builder.
-
-## features
-
-- Rsdoctor is a one-stop tool for diagnosing and analyzing the build process and build artifacts.
-- Rsdoctor is a tool that supports Webpack and Rspack build analysis.
-- Rsdoctor is an analysis tool that can display the time-consuming and behavioral details of the compilation.
-- Rsdoctor is a tool that provides bundle Diff and other anti-degradation capabilities simultaneously.
-
-## Note
-
-This plugin is used by the `Rspack` repo to open Rsdoctor, [Quick Start](https://rsdoctor.dev/guide/start/quick-start).
-
-Initialize the RsdoctorRspackPlugin in the [plugins](https://www.rspack.dev/config/plugins.html#plugins) of `rspack.config.js`:
-
-```js title="rspack.config.js"
-const { RsdoctorRspackPlugin } = require('@rsdoctor/rspack-plugin');
-
-module.exports = {
-  // ...
-  plugins: [
-    // Only register the plugin when RSDOCTOR is true, as the plugin will increase the build time.
-    process.env.RSDOCTOR &&
-      new RsdoctorRspackPlugin({
-        // plugin options
-      }),
-  ].filter(Boolean),
-};
-```
+An Rspack plugin for integrating Rsdoctor.
 
 ## Documentation
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,13 +1,6 @@
-# Rsdoctor SDK
+# @rsdoctor/sdk
 
 This package is the intermediate data layer of Rsdoctor.
-
-## features
-
-- Rsdoctor is a one-stop tool for diagnosing and analyzing the build process and build artifacts.
-- Rsdoctor is a tool that supports Webpack and Rspack build analysis.
-- Rsdoctor is an analysis tool that can display the time-consuming and behavioral details of the compilation.
-- Rsdoctor is a tool that provides bundle Diff and other anti-degradation capabilities simultaneously.
 
 ## Documentation
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,13 +1,6 @@
-# Rsdoctor types
+# @rsdoctor/types
 
-This package is the Rsdoctor‘s types package.
-
-## features
-
-- Rsdoctor is a one-stop tool for diagnosing and analyzing the build process and build artifacts.
-- Rsdoctor is a tool that supports Webpack and Rspack build analysis.
-- Rsdoctor is an analysis tool that can display the time-consuming and behavioral details of the compilation.
-- Rsdoctor is a tool that provides bundle Diff and other anti-degradation capabilities simultaneously.
+This package is the Rsdoctor's types package.
 
 ## Documentation
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,13 +1,6 @@
-# Rsdoctor utils
+# @rsdoctor/utils
 
-This package is the Rsdoctor‘s tools package.
-
-## features
-
-- Rsdoctor is a one-stop tool for diagnosing and analyzing the build process and build artifacts.
-- Rsdoctor is a tool that supports Webpack and Rspack build analysis.
-- Rsdoctor is an analysis tool that can display the time-consuming and behavioral details of the compilation.
-- Rsdoctor is a tool that provides bundle Diff and other anti-degradation capabilities simultaneously.
+This package is the Rsdoctor's tools package.
 
 ## Documentation
 

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -1,33 +1,6 @@
-# Rsdoctor plugin
+# @rsdoctor/webpack-plugin
 
-This Rsdoctor plugin is an analysis plugin for the Webpack builder.
-
-## features
-
-- Rsdoctor is a one-stop tool for diagnosing and analyzing the build process and build artifacts.
-- Rsdoctor is a tool that supports Webpack and Rspack build analysis.
-- Rsdoctor is an analysis tool that can display the time-consuming and behavioral details of the compilation.
-- Rsdoctor is a tool that provides bundle Diff and other anti-degradation capabilities simultaneously.
-
-## Note
-
-This plugin is used by the `Webpack` repo to open Rsdoctor, [Quick Start](https://rsdoctor.dev/guide/start/quick-start).
-
-Initialize the RsdoctorWebpackPlugin plugin in the [plugins](https://webpack.js.org/configuration/plugins/#plugins) section of the `webpack.config.js` file, as shown below:
-
-```js title="webpack.config.js"
-const { RsdoctorWebpackPlugin } = require('@rsdoctor/webpack-plugin');
-
-module.exports = {
-  // ...
-  plugins: [
-    process.env.RSDOCTOR &&
-      new RsdoctorWebpackPlugin({
-        // options
-      }),
-  ].filter(Boolean),
-};
-```
+A webpack plugin for integrating Rsdoctor.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Clean up outdated features descriptions and usage examples in each pacakge's README.

Users should check https://rsdoctor.dev/ for the latest introduction and guides.


