### PR TITLE
feat: add assets gzipsize

### DIFF
--- a/packages/core/src/build-utils/common/chunks/assetsContent.ts
+++ b/packages/core/src/build-utils/common/chunks/assetsContent.ts
@@ -1,4 +1,6 @@
 import { SDK } from '@rsdoctor/types';
+const COMPRESSIBLE_REGEX =
+  /\.(?:js|css|html|json|svg|txt|xml|xhtml|wasm|manifest)$/i;
 
 export function assetsContents(
   assetMap: Map<string, { content: string }>,
@@ -8,5 +10,8 @@ export function assetsContents(
   assets.forEach((asset) => {
     const { content = '' } = assetMap.get(asset.path) || {};
     asset.content = content;
+    if (COMPRESSIBLE_REGEX.test(asset.path)) {
+      asset.setGzipSize(content);
+    }
   });
 }

--- a/packages/graph/src/graph/chunk-graph/asset.ts
+++ b/packages/graph/src/graph/chunk-graph/asset.ts
@@ -1,5 +1,5 @@
 import { SDK } from '@rsdoctor/types';
-
+import { gzipSync } from 'node:zlib';
 let id = 1;
 
 export class Asset implements SDK.AssetInstance {
@@ -12,6 +12,7 @@ export class Asset implements SDK.AssetInstance {
   size: number;
   content: string;
   chunks: SDK.ChunkInstance[];
+  gzipSize: number | undefined;
 
   constructor(
     path: string,
@@ -31,6 +32,7 @@ export class Asset implements SDK.AssetInstance {
       id: this.id,
       path: this.path,
       size: this.size,
+      gzipSize: this.gzipSize,
       chunks: this.chunks?.map((ck) => ck.id),
       content:
         types === SDK.ToDataType.NoSourceAndAssets ||
@@ -47,5 +49,9 @@ export class Asset implements SDK.AssetInstance {
 
   setId(id: number): void {
     this.id = id;
+  }
+
+  setGzipSize(content: string) {
+    this.gzipSize = gzipSync(content, { level: 9 }).length;
   }
 }

--- a/packages/types/src/sdk/chunk.ts
+++ b/packages/types/src/sdk/chunk.ts
@@ -9,10 +9,12 @@ export interface AssetInstance {
   chunks: ChunkInstance[];
   /** File resource content */
   content: string;
+  gzipSize: number | undefined;
   /** Generate data */
   toData(type: ToDataType): AssetData;
   setId(id: number): void;
   setChunks(chunks: ChunkInstance[]): void;
+  setGzipSize(content: string): void;
 }
 
 export interface ChunkInstance {

--- a/packages/utils/src/common/graph/assets.ts
+++ b/packages/utils/src/common/graph/assets.ts
@@ -116,6 +116,7 @@ export function getAssetsSizeInfo(
       files: assets.map((e) => ({
         path: e.path,
         size: e.size,
+        gzipSize: e.gzipSize,
         initial: isInitialAsset(e, chunks),
         content: withFileContent ? e.content : undefined,
       })),


### PR DESCRIPTION
## Summary
1.add assets gzipSize  attribute
2.expose gzipSize   in  /packages/components/src/components/Card/size.tsx

![image](https://github.com/user-attachments/assets/8bef7a72-80ca-41d1-8121-6cc70f76d596)
## Related Links
#772



<!--- Provide links of related issues or pages -->
