### PR TITLE
fix: the problem when use mini-css-extract-plugin loader

### DIFF
--- a/e2e/cases/doctor-webpack/fixtures2/a.js
+++ b/e2e/cases/doctor-webpack/fixtures2/a.js
@@ -1,0 +1,1 @@
+console.log('a');

--- a/e2e/cases/doctor-webpack/fixtures2/b.js
+++ b/e2e/cases/doctor-webpack/fixtures2/b.js
@@ -1,0 +1,12 @@
+import './index.less';
+
+const ll = 1;
+
+console.log('a');
+
+function kk() {
+  console.log('hhe: ', ll);
+  return '111';
+}
+
+kk();

--- a/e2e/cases/doctor-webpack/fixtures2/index.less
+++ b/e2e/cases/doctor-webpack/fixtures2/index.less
@@ -1,0 +1,3 @@
+.nav {
+  color: antiquewhite;
+}

--- a/e2e/cases/doctor-webpack/fixtures2/loaders/comment.js
+++ b/e2e/cases/doctor-webpack/fixtures2/loaders/comment.js
@@ -1,0 +1,39 @@
+/**
+ * @template {{
+ *   mode: 'async' | 'callback' | 'sync';
+ *   pitchResult?: string;
+ * }} Options
+ */
+
+/**
+ * @type {import("webpack").LoaderDefinitionFunction<Options, {}>}
+ */
+module.exports = function (input) {
+  /**
+   * @type Options
+   */
+  const options = this.getOptions();
+  const res = [input, '// hello world'].join('\n');
+
+  if (options.mode === 'async') {
+    const cb = this.async();
+    setTimeout(() => {
+      cb(null, res);
+    }, 3000);
+  } else if (options.mode === 'callback') {
+    this.callback(null, res);
+  } else {
+    return res;
+  }
+};
+
+module.exports.pitch = function () {
+  /**
+   * @type Options
+   */
+  const options = this.getOptions();
+
+  if (options.pitchResult) {
+    return options.pitchResult;
+  }
+};

--- a/e2e/cases/doctor-webpack/fixtures2/loaders/serialize-query-to-comment.js
+++ b/e2e/cases/doctor-webpack/fixtures2/loaders/serialize-query-to-comment.js
@@ -1,0 +1,16 @@
+const { parseQuery } = require('loader-utils');
+
+/**
+ * @type {import("webpack").LoaderDefinitionFunction<{}, {}>}
+ */
+module.exports = function (input) {
+  const res = [input, `// ${JSON.stringify(this.query)}`];
+
+  // Based on https://github.com/windicss/windicss-webpack-plugin/blob/main/src/loaders/windicss-template.ts#L42
+  // test the loader query
+  if (this.query !== '') {
+    res.push(`// ${JSON.stringify(parseQuery(this.query))}`);
+  }
+
+  return res.join('\n');
+};

--- a/e2e/cases/doctor-webpack/fixtures2/loaders/serialize-resource-query-to-comment.js
+++ b/e2e/cases/doctor-webpack/fixtures2/loaders/serialize-resource-query-to-comment.js
@@ -1,0 +1,16 @@
+const { parseQuery } = require('loader-utils');
+
+/**
+ * @type {import("webpack").LoaderDefinitionFunction<{}, {}>}
+ */
+module.exports = function (input) {
+  const res = [input, `// ${JSON.stringify(this.resourceQuery)}`];
+
+  // Based on https://github.com/windicss/windicss-webpack-plugin/blob/main/src/loaders/windicss-template.ts#L42
+  // test the loader query
+  if (this.resourceQuery !== '') {
+    res.push(`// ${JSON.stringify(parseQuery(this.resourceQuery))}`);
+  }
+
+  return res.join('\n');
+};

--- a/e2e/cases/doctor-webpack/fixtures2/port.js
+++ b/e2e/cases/doctor-webpack/fixtures2/port.js
@@ -1,0 +1,7 @@
+const { RsdoctorWebpackPlugin } = require('../../dist/index');
+
+const plugin = new RsdoctorWebpackPlugin({});
+
+plugin.sdk.bootstrap().then(() => {
+  console.log(plugin.sdk.server.port);
+});

--- a/e2e/cases/doctor-webpack/plugins/loader-mini-css-extract.test.ts
+++ b/e2e/cases/doctor-webpack/plugins/loader-mini-css-extract.test.ts
@@ -1,0 +1,185 @@
+import { Common } from '@rsdoctor/types';
+import { compileByWebpack5 } from '@scripts/test-helper';
+import { cloneDeep } from 'lodash';
+import path from 'path';
+import { test, expect } from '@playwright/test';
+import type { NormalModule, WebpackPluginInstance } from 'webpack';
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+import { createRsdoctorPlugin } from '../test-utils';
+
+const testLoaderPath = path.resolve(
+  __dirname,
+  '../fixtures2/loaders/comment.js',
+);
+
+async function webpack(
+  compile: typeof compileByWebpack5,
+  transformer: (module: NormalModule) => void,
+) {
+  const file = path.resolve(__dirname, '../fixtures2/b.js');
+
+  const beforeTransform = (data: any) => data;
+  let beforeTransformRes;
+  const afterTransform = (data: any) => data;
+  let afterTransformRes;
+
+  /**
+   * Based on https://github.com/arco-design/arco-plugins/blob/main/packages/plugin-webpack-react/src/arco-design-plugin/utils/index.ts#L37
+   */
+  const arcoDesignPluginForked: WebpackPluginInstance = {
+    apply(compiler) {
+      const pluginName = 'arco-design-plugin-forked';
+      const mapper = (module: NormalModule) =>
+        module.loaders.map((e) => ({
+          loader: e.loader,
+          options: cloneDeep(e.options),
+        }));
+      const hookHandler = (
+        context: Common.PlainObject,
+        module: NormalModule,
+      ) => {
+        beforeTransformRes = beforeTransform(mapper(module));
+        transformer(module);
+        afterTransformRes = afterTransform(mapper(module));
+      };
+      // @ts-ignore
+      compiler.hooks.compilation.tap(pluginName, (compilation) => {
+        compiler.webpack.NormalModule.getCompilationHooks(
+          compilation,
+        ).loader.tap(pluginName, hookHandler);
+      });
+    },
+  };
+
+  const RsdoctorPlugin = createRsdoctorPlugin({});
+
+  const result = await compile(file, {
+    optimization: {
+      minimize: true,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          use: {
+            loader: testLoaderPath,
+            options: {
+              mode: 'callback',
+            },
+          },
+        },
+        {
+          test: /\.(css|less)$/,
+          use: [MiniCssExtractPlugin.loader, 'css-loader', 'less-loader'],
+        },
+      ],
+    },
+    plugins: [
+      // @ts-ignore
+      RsdoctorPlugin,
+      // @ts-ignore
+      arcoDesignPluginForked,
+      new MiniCssExtractPlugin({
+        // @ts-ignore
+        filename: `$[name].min.[contenthash:8].css`,
+        chunkFilename: `$[name].chunk.[name].[contenthash:8].css`,
+        experimentalUseImportModule: false,
+      }),
+    ],
+  });
+
+  return {
+    RsdoctorPlugin,
+    loaderData: RsdoctorPlugin.sdk.getStoreData().loader,
+    afterTransformRes,
+    beforeTransformRes,
+  };
+}
+
+function createTests(title: string, compile: typeof compileByWebpack5) {
+  test(`${title} basic usage`, async () => {
+    const { loaderData, beforeTransformRes, afterTransformRes } = await webpack(
+      compile,
+      () => {},
+    );
+
+    expect(beforeTransformRes).toStrictEqual([
+      { loader: testLoaderPath, options: { mode: 'callback' } },
+    ]);
+
+    expect(afterTransformRes).toStrictEqual([
+      { loader: testLoaderPath, options: { mode: 'callback' } },
+    ]);
+
+    // test the data from sdk
+    const { options, loader } = loaderData[0].loaders[0];
+    expect(loader).toEqual(testLoaderPath);
+    expect(options).toStrictEqual({ mode: 'callback' });
+  });
+
+  test(`${title} overwrite loader options`, async () => {
+    const { loaderData, beforeTransformRes, afterTransformRes } = await webpack(
+      compile,
+      (module) => {
+        module.loaders[0].options.mode = 'async';
+      },
+    );
+
+    expect(beforeTransformRes).toStrictEqual([
+      { loader: testLoaderPath, options: { mode: 'callback' } },
+    ]);
+
+    expect(afterTransformRes).toStrictEqual([
+      { loader: testLoaderPath, options: { mode: 'async' } },
+    ]);
+
+    // test the data from sdk
+    const { options, loader } = loaderData[0].loaders[0];
+    expect(loader).toEqual(testLoaderPath);
+    expect(options).toStrictEqual({ mode: 'async' });
+  });
+
+  test(`${title} add loader and overwrite options`, async () => {
+    const { loaderData, beforeTransformRes, afterTransformRes } = await webpack(
+      compile,
+      (module) => {
+        const originLoaders = cloneDeep(module.loaders);
+
+        originLoaders[0].options.mode = 'async';
+
+        module.loaders = [
+          ...originLoaders,
+          {
+            loader: testLoaderPath,
+            options: { pitchResult: '// hello world' },
+            ident: null,
+            type: null,
+          },
+        ];
+      },
+    );
+
+    expect(beforeTransformRes).toStrictEqual([
+      { loader: testLoaderPath, options: { mode: 'callback' } },
+    ]);
+
+    expect(afterTransformRes).toStrictEqual([
+      { loader: testLoaderPath, options: { mode: 'async' } },
+      {
+        loader: testLoaderPath,
+        options: { pitchResult: '// hello world' },
+      },
+    ]);
+
+    // test the data from sdk
+    expect(loaderData[0].loaders).toHaveLength(2);
+    expect(loaderData[0].loaders[0].options).toStrictEqual({
+      pitchResult: '// hello world',
+    });
+    expect(loaderData[0].loaders[1].options).toStrictEqual({
+      mode: 'async',
+    });
+  });
+}
+
+createTests('[webpack5]', compileByWebpack5);

--- a/packages/core/src/inner-plugins/utils/loader.ts
+++ b/packages/core/src/inner-plugins/utils/loader.ts
@@ -121,7 +121,8 @@ export function interceptLoader<T extends Plugin.BuildRuleSetRule>(
     };
     // In the childCompiler of mini-css-extract-plugin, the options[Loader.LoaderInternalPropertyName] of proxy-loader is set to proxy-loader, ultimately causing errors in the compilation of less files.
     opts[Loader.LoaderInternalPropertyName] =
-      /proxy.js/.test(rule.loader!) &&
+      rule.loader &&
+      /proxy.js/.test(rule.loader) &&
       'options' in rule &&
       typeof rule.options === 'object'
         ? rule.options[Loader.LoaderInternalPropertyName]

--- a/packages/core/src/inner-plugins/utils/loader.ts
+++ b/packages/core/src/inner-plugins/utils/loader.ts
@@ -119,12 +119,17 @@ export function interceptLoader<T extends Plugin.BuildRuleSetRule>(
           : rule.options
         : {}),
     };
-
-    opts[Loader.LoaderInternalPropertyName] = {
-      ...options,
-      hasOptions: 'options' in rule && Boolean(rule.options),
-      loader: 'loader' in rule ? resolve(rule.loader!) : '',
-    };
+    // In the childCompiler of mini-css-extract-plugin, the options[Loader.LoaderInternalPropertyName] of proxy-loader is set to proxy-loader, ultimately causing errors in the compilation of less files.
+    opts[Loader.LoaderInternalPropertyName] =
+      /proxy.js/.test(rule.loader!) &&
+      'options' in rule &&
+      typeof rule.options === 'object'
+        ? rule.options[Loader.LoaderInternalPropertyName]
+        : {
+            ...options,
+            hasOptions: 'options' in rule && Boolean(rule.options),
+            loader: 'loader' in rule ? resolve(rule.loader!) : '',
+          };
 
     return {
       ...rule,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,18 +96,9 @@ importers:
       '@types/react':
         specifier: ^18.3.19
         version: 18.3.19
-      css-loader:
-        specifier: ^7.1.2
-        version: 7.1.2(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.97.1)
-      less-loader:
-        specifier: ^12.2.0
-        version: 12.2.0(@rspack/core@1.2.8(@swc/helpers@0.5.15))(less@4.2.1)(webpack@5.97.1)
       loader-utils:
         specifier: ^2.0.4
         version: 2.0.4
-      mini-css-extract-plugin:
-        specifier: ^2.9.2
-        version: 2.9.2(webpack@5.97.1)
       playwright:
         specifier: 1.44.1
         version: 1.44.1
@@ -5111,18 +5102,6 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
 
-  css-loader@7.1.2:
-    resolution: {integrity: sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==}
-    engines: {node: '>= 18.12.0'}
-    peerDependencies:
-      '@rspack/core': 0.x || 1.x
-      webpack: ^5.27.0
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
-      webpack:
-        optional: true
-
   css-minimizer-webpack-plugin@5.0.1:
     resolution: {integrity: sha512-3caImjKFQkS+ws1TGcFn0V1HyDJFq1Euy589JlD6/3rV2kj+w7r5G9WDMgSHvpvXHNZ2calVypZWuEDQd9wfLg==}
     engines: {node: '>= 14.15.0'}
@@ -6826,19 +6805,6 @@ packages:
     peerDependencies:
       less: ^3.5.0 || ^4.0.0
       webpack: ^5.0.0
-
-  less-loader@12.2.0:
-    resolution: {integrity: sha512-MYUxjSQSBUQmowc0l5nPieOYwMzGPUaTzB6inNW/bdPEG9zOL3eAAD1Qw5ZxSPk7we5dMojHwNODYMV1hq4EVg==}
-    engines: {node: '>= 18.12.0'}
-    peerDependencies:
-      '@rspack/core': 0.x || 1.x
-      less: ^3.5.0 || ^4.0.0
-      webpack: ^5.0.0
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
-      webpack:
-        optional: true
 
   less@4.2.1:
     resolution: {integrity: sha512-CasaJidTIhWmjcqv0Uj5vccMI7pJgfD9lMkKtlnTHAdJdYK/7l8pM9tumLyJ0zhbD4KJLo/YvTj+xznQd5NBhg==}
@@ -15403,20 +15369,6 @@ snapshots:
       semver: 7.6.3
       webpack: 5.97.1(webpack-cli@5.1.4)
 
-  css-loader@7.1.2(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.97.1):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.5.3)
-      postcss: 8.5.3
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.3)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.3)
-      postcss-modules-scope: 3.2.1(postcss@8.5.3)
-      postcss-modules-values: 4.0.0(postcss@8.5.3)
-      postcss-value-parser: 4.2.0
-      semver: 7.6.3
-    optionalDependencies:
-      '@rspack/core': 1.2.8(@swc/helpers@0.5.15)
-      webpack: 5.97.1(webpack-cli@5.1.4)
-
   css-minimizer-webpack-plugin@5.0.1(esbuild@0.17.19)(webpack@5.97.1(esbuild@0.17.19)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
@@ -17285,13 +17237,6 @@ snapshots:
       less: 4.2.1
       webpack: 5.97.1(webpack-cli@5.1.4)
 
-  less-loader@12.2.0(@rspack/core@1.2.8(@swc/helpers@0.5.15))(less@4.2.1)(webpack@5.97.1):
-    dependencies:
-      less: 4.2.1
-    optionalDependencies:
-      '@rspack/core': 1.2.8(@swc/helpers@0.5.15)
-      webpack: 5.97.1(webpack-cli@5.1.4)
-
   less@4.2.1:
     dependencies:
       copy-anything: 2.0.6
@@ -18139,12 +18084,6 @@ snapshots:
       schema-utils: 4.3.0
       tapable: 2.2.1
       webpack: 5.97.1(esbuild@0.17.19)
-
-  mini-css-extract-plugin@2.9.2(webpack@5.97.1):
-    dependencies:
-      schema-utils: 4.3.0
-      tapable: 2.2.1
-      webpack: 5.97.1(webpack-cli@5.1.4)
 
   mini-svg-data-uri@1.4.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,9 +96,18 @@ importers:
       '@types/react':
         specifier: ^18.3.19
         version: 18.3.19
+      css-loader:
+        specifier: ^7.1.2
+        version: 7.1.2(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.97.1)
+      less-loader:
+        specifier: ^12.2.0
+        version: 12.2.0(@rspack/core@1.2.8(@swc/helpers@0.5.15))(less@4.2.1)(webpack@5.97.1)
       loader-utils:
         specifier: ^2.0.4
         version: 2.0.4
+      mini-css-extract-plugin:
+        specifier: ^2.9.2
+        version: 2.9.2(webpack@5.97.1)
       playwright:
         specifier: 1.44.1
         version: 1.44.1
@@ -5102,6 +5111,18 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
 
+  css-loader@7.1.2:
+    resolution: {integrity: sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@rspack/core': 0.x || 1.x
+      webpack: ^5.27.0
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
+
   css-minimizer-webpack-plugin@5.0.1:
     resolution: {integrity: sha512-3caImjKFQkS+ws1TGcFn0V1HyDJFq1Euy589JlD6/3rV2kj+w7r5G9WDMgSHvpvXHNZ2calVypZWuEDQd9wfLg==}
     engines: {node: '>= 14.15.0'}
@@ -6805,6 +6826,19 @@ packages:
     peerDependencies:
       less: ^3.5.0 || ^4.0.0
       webpack: ^5.0.0
+
+  less-loader@12.2.0:
+    resolution: {integrity: sha512-MYUxjSQSBUQmowc0l5nPieOYwMzGPUaTzB6inNW/bdPEG9zOL3eAAD1Qw5ZxSPk7we5dMojHwNODYMV1hq4EVg==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@rspack/core': 0.x || 1.x
+      less: ^3.5.0 || ^4.0.0
+      webpack: ^5.0.0
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
 
   less@4.2.1:
     resolution: {integrity: sha512-CasaJidTIhWmjcqv0Uj5vccMI7pJgfD9lMkKtlnTHAdJdYK/7l8pM9tumLyJ0zhbD4KJLo/YvTj+xznQd5NBhg==}
@@ -11671,9 +11705,9 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.1.2
 
-  '@csstools/utilities@1.0.0(postcss@8.5.1)':
+  '@csstools/utilities@1.0.0(postcss@8.5.3)':
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
   '@ctrl/tinycolor@3.6.1': {}
 
@@ -12514,26 +12548,26 @@ snapshots:
       '@rsbuild/plugin-yaml': 1.0.2(@rsbuild/core@1.1.13)
       '@rsbuild/webpack': 1.1.6(@rsbuild/core@1.1.13)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(esbuild@0.17.19)
       '@swc/helpers': 0.5.13
-      autoprefixer: 10.4.20(postcss@8.5.1)
+      autoprefixer: 10.4.20(postcss@8.5.3)
       babel-loader: 9.1.3(@babel/core@7.26.0)(webpack@5.97.1(esbuild@0.17.19))
       babel-plugin-import: 1.13.8
       babel-plugin-styled-components: 1.13.3(styled-components@5.3.11(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       babel-plugin-transform-react-remove-prop-types: 0.4.24
       browserslist: 4.24.3
-      cssnano: 6.0.1(postcss@8.5.1)
+      cssnano: 6.0.1(postcss@8.5.3)
       glob: 9.3.5
       html-minifier-terser: 7.2.0
       html-webpack-plugin: 5.6.3(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.97.1(esbuild@0.17.19))
       lodash: 4.17.21
       picocolors: 1.1.1
-      postcss: 8.5.1
-      postcss-custom-properties: 13.3.12(postcss@8.5.1)
-      postcss-flexbugs-fixes: 5.0.2(postcss@8.5.1)
-      postcss-font-variant: 5.0.0(postcss@8.5.1)
-      postcss-initial: 4.0.1(postcss@8.5.1)
-      postcss-media-minmax: 5.0.0(postcss@8.5.1)
-      postcss-nesting: 12.1.5(postcss@8.5.1)
-      postcss-page-break: 3.0.4(postcss@8.5.1)
+      postcss: 8.5.3
+      postcss-custom-properties: 13.3.12(postcss@8.5.3)
+      postcss-flexbugs-fixes: 5.0.2(postcss@8.5.3)
+      postcss-font-variant: 5.0.0(postcss@8.5.3)
+      postcss-initial: 4.0.1(postcss@8.5.3)
+      postcss-media-minmax: 5.0.0(postcss@8.5.3)
+      postcss-nesting: 12.1.5(postcss@8.5.3)
+      postcss-page-break: 3.0.4(postcss@8.5.3)
       react-refresh: 0.14.2
       rspack-manifest-plugin: 5.0.3(@rspack/core@1.2.8(@swc/helpers@0.5.15))
       terser-webpack-plugin: 5.3.11(esbuild@0.17.19)(webpack@5.97.1(esbuild@0.17.19))
@@ -14603,14 +14637,14 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoprefixer@10.4.20(postcss@8.5.1):
+  autoprefixer@10.4.20(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
       caniuse-lite: 1.0.30001701
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -15325,10 +15359,6 @@ snapshots:
 
   css-color-keywords@1.0.0: {}
 
-  css-declaration-sorter@7.2.0(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-
   css-declaration-sorter@7.2.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
@@ -15371,6 +15401,20 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.1)
       postcss-value-parser: 4.2.0
       semver: 7.6.3
+      webpack: 5.97.1(webpack-cli@5.1.4)
+
+  css-loader@7.1.2(@rspack/core@1.2.8(@swc/helpers@0.5.15))(webpack@5.97.1):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.3)
+      postcss: 8.5.3
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.3)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.3)
+      postcss-modules-scope: 3.2.1(postcss@8.5.3)
+      postcss-modules-values: 4.0.0(postcss@8.5.3)
+      postcss-value-parser: 4.2.0
+      semver: 7.6.3
+    optionalDependencies:
+      '@rspack/core': 1.2.8(@swc/helpers@0.5.15)
       webpack: 5.97.1(webpack-cli@5.1.4)
 
   css-minimizer-webpack-plugin@5.0.1(esbuild@0.17.19)(webpack@5.97.1(esbuild@0.17.19)):
@@ -15421,40 +15465,6 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-default@6.1.2(postcss@8.5.1):
-    dependencies:
-      browserslist: 4.24.4
-      css-declaration-sorter: 7.2.0(postcss@8.5.1)
-      cssnano-utils: 4.0.2(postcss@8.5.1)
-      postcss: 8.5.1
-      postcss-calc: 9.0.1(postcss@8.5.1)
-      postcss-colormin: 6.1.0(postcss@8.5.1)
-      postcss-convert-values: 6.1.0(postcss@8.5.1)
-      postcss-discard-comments: 6.0.2(postcss@8.5.1)
-      postcss-discard-duplicates: 6.0.3(postcss@8.5.1)
-      postcss-discard-empty: 6.0.3(postcss@8.5.1)
-      postcss-discard-overridden: 6.0.2(postcss@8.5.1)
-      postcss-merge-longhand: 6.0.5(postcss@8.5.1)
-      postcss-merge-rules: 6.1.1(postcss@8.5.1)
-      postcss-minify-font-values: 6.1.0(postcss@8.5.1)
-      postcss-minify-gradients: 6.0.3(postcss@8.5.1)
-      postcss-minify-params: 6.1.0(postcss@8.5.1)
-      postcss-minify-selectors: 6.0.4(postcss@8.5.1)
-      postcss-normalize-charset: 6.0.2(postcss@8.5.1)
-      postcss-normalize-display-values: 6.0.2(postcss@8.5.1)
-      postcss-normalize-positions: 6.0.2(postcss@8.5.1)
-      postcss-normalize-repeat-style: 6.0.2(postcss@8.5.1)
-      postcss-normalize-string: 6.0.2(postcss@8.5.1)
-      postcss-normalize-timing-functions: 6.0.2(postcss@8.5.1)
-      postcss-normalize-unicode: 6.1.0(postcss@8.5.1)
-      postcss-normalize-url: 6.0.2(postcss@8.5.1)
-      postcss-normalize-whitespace: 6.0.2(postcss@8.5.1)
-      postcss-ordered-values: 6.0.2(postcss@8.5.1)
-      postcss-reduce-initial: 6.1.0(postcss@8.5.1)
-      postcss-reduce-transforms: 6.0.2(postcss@8.5.1)
-      postcss-svgo: 6.0.3(postcss@8.5.1)
-      postcss-unique-selectors: 6.0.4(postcss@8.5.1)
-
   cssnano-preset-default@6.1.2(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
@@ -15489,19 +15499,9 @@ snapshots:
       postcss-svgo: 6.0.3(postcss@8.5.3)
       postcss-unique-selectors: 6.0.4(postcss@8.5.3)
 
-  cssnano-utils@4.0.2(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-
   cssnano-utils@4.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
-
-  cssnano@6.0.1(postcss@8.5.1):
-    dependencies:
-      cssnano-preset-default: 6.1.2(postcss@8.5.1)
-      lilconfig: 2.1.0
-      postcss: 8.5.1
 
   cssnano@6.0.1(postcss@8.5.3):
     dependencies:
@@ -17285,6 +17285,13 @@ snapshots:
       less: 4.2.1
       webpack: 5.97.1(webpack-cli@5.1.4)
 
+  less-loader@12.2.0(@rspack/core@1.2.8(@swc/helpers@0.5.15))(less@4.2.1)(webpack@5.97.1):
+    dependencies:
+      less: 4.2.1
+    optionalDependencies:
+      '@rspack/core': 1.2.8(@swc/helpers@0.5.15)
+      webpack: 5.97.1(webpack-cli@5.1.4)
+
   less@4.2.1:
     dependencies:
       copy-anything: 2.0.6
@@ -18133,6 +18140,12 @@ snapshots:
       tapable: 2.2.1
       webpack: 5.97.1(esbuild@0.17.19)
 
+  mini-css-extract-plugin@2.9.2(webpack@5.97.1):
+    dependencies:
+      schema-utils: 4.3.0
+      tapable: 2.2.1
+      webpack: 5.97.1(webpack-cli@5.1.4)
+
   mini-svg-data-uri@1.4.4: {}
 
   minimalistic-assert@1.0.1: {}
@@ -18664,24 +18677,10 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-calc@9.0.1(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-      postcss-selector-parser: 6.1.2
-      postcss-value-parser: 4.2.0
-
   postcss-calc@9.0.1(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-selector-parser: 6.1.2
-      postcss-value-parser: 4.2.0
-
-  postcss-colormin@6.1.0(postcss@8.5.1):
-    dependencies:
-      browserslist: 4.24.4
-      caniuse-api: 3.0.0
-      colord: 2.9.3
-      postcss: 8.5.1
       postcss-value-parser: 4.2.0
 
   postcss-colormin@6.1.0(postcss@8.5.3):
@@ -18692,94 +18691,58 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@6.1.0(postcss@8.5.1):
-    dependencies:
-      browserslist: 4.24.4
-      postcss: 8.5.1
-      postcss-value-parser: 4.2.0
-
   postcss-convert-values@6.1.0(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-custom-properties@13.3.12(postcss@8.5.1):
+  postcss-custom-properties@13.3.12(postcss@8.5.3):
     dependencies:
       '@csstools/cascade-layer-name-parser': 1.0.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
-      '@csstools/utilities': 1.0.0(postcss@8.5.1)
-      postcss: 8.5.1
+      '@csstools/utilities': 1.0.0(postcss@8.5.3)
+      postcss: 8.5.3
       postcss-value-parser: 4.2.0
-
-  postcss-discard-comments@6.0.2(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
 
   postcss-discard-comments@6.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
 
-  postcss-discard-duplicates@6.0.3(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-
   postcss-discard-duplicates@6.0.3(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
-
-  postcss-discard-empty@6.0.3(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
 
   postcss-discard-empty@6.0.3(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
 
-  postcss-discard-overridden@6.0.2(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-
   postcss-discard-overridden@6.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
 
-  postcss-flexbugs-fixes@5.0.2(postcss@8.5.1):
+  postcss-flexbugs-fixes@5.0.2(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-font-variant@5.0.0(postcss@8.5.1):
+  postcss-font-variant@5.0.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-initial@4.0.1(postcss@8.5.1):
+  postcss-initial@4.0.1(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
+      postcss: 8.5.3
 
-  postcss-media-minmax@5.0.0(postcss@8.5.1):
+  postcss-media-minmax@5.0.0(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
-
-  postcss-merge-longhand@6.0.5(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-      postcss-value-parser: 4.2.0
-      stylehacks: 6.1.1(postcss@8.5.1)
+      postcss: 8.5.3
 
   postcss-merge-longhand@6.0.5(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
       stylehacks: 6.1.1(postcss@8.5.3)
-
-  postcss-merge-rules@6.1.1(postcss@8.5.1):
-    dependencies:
-      browserslist: 4.24.4
-      caniuse-api: 3.0.0
-      cssnano-utils: 4.0.2(postcss@8.5.1)
-      postcss: 8.5.1
-      postcss-selector-parser: 6.1.2
 
   postcss-merge-rules@6.1.1(postcss@8.5.3):
     dependencies:
@@ -18789,21 +18752,9 @@ snapshots:
       postcss: 8.5.3
       postcss-selector-parser: 6.1.2
 
-  postcss-minify-font-values@6.1.0(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-      postcss-value-parser: 4.2.0
-
   postcss-minify-font-values@6.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
-      postcss-value-parser: 4.2.0
-
-  postcss-minify-gradients@6.0.3(postcss@8.5.1):
-    dependencies:
-      colord: 2.9.3
-      cssnano-utils: 4.0.2(postcss@8.5.1)
-      postcss: 8.5.1
       postcss-value-parser: 4.2.0
 
   postcss-minify-gradients@6.0.3(postcss@8.5.3):
@@ -18813,24 +18764,12 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@6.1.0(postcss@8.5.1):
-    dependencies:
-      browserslist: 4.24.4
-      cssnano-utils: 4.0.2(postcss@8.5.1)
-      postcss: 8.5.1
-      postcss-value-parser: 4.2.0
-
   postcss-minify-params@6.1.0(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
       cssnano-utils: 4.0.2(postcss@8.5.3)
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
-
-  postcss-minify-selectors@6.0.4(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-      postcss-selector-parser: 6.1.2
 
   postcss-minify-selectors@6.0.4(postcss@8.5.3):
     dependencies:
@@ -18891,34 +18830,20 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.3)
       string-hash: 1.1.3
 
-  postcss-nesting@12.1.5(postcss@8.5.1):
+  postcss-nesting@12.1.5(postcss@8.5.3):
     dependencies:
       '@csstools/selector-resolve-nested': 1.1.0(postcss-selector-parser@6.1.2)
       '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.2)
-      postcss: 8.5.1
+      postcss: 8.5.3
       postcss-selector-parser: 6.1.2
-
-  postcss-normalize-charset@6.0.2(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
 
   postcss-normalize-charset@6.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
 
-  postcss-normalize-display-values@6.0.2(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-      postcss-value-parser: 4.2.0
-
   postcss-normalize-display-values@6.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
-      postcss-value-parser: 4.2.0
-
-  postcss-normalize-positions@6.0.2(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
       postcss-value-parser: 4.2.0
 
   postcss-normalize-positions@6.0.2(postcss@8.5.3):
@@ -18926,19 +18851,9 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@6.0.2(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-      postcss-value-parser: 4.2.0
-
   postcss-normalize-repeat-style@6.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
-      postcss-value-parser: 4.2.0
-
-  postcss-normalize-string@6.0.2(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
       postcss-value-parser: 4.2.0
 
   postcss-normalize-string@6.0.2(postcss@8.5.3):
@@ -18946,20 +18861,9 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@6.0.2(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-      postcss-value-parser: 4.2.0
-
   postcss-normalize-timing-functions@6.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
-      postcss-value-parser: 4.2.0
-
-  postcss-normalize-unicode@6.1.0(postcss@8.5.1):
-    dependencies:
-      browserslist: 4.24.4
-      postcss: 8.5.1
       postcss-value-parser: 4.2.0
 
   postcss-normalize-unicode@6.1.0(postcss@8.5.3):
@@ -18968,30 +18872,14 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@6.0.2(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-      postcss-value-parser: 4.2.0
-
   postcss-normalize-url@6.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@6.0.2(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-      postcss-value-parser: 4.2.0
-
   postcss-normalize-whitespace@6.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
-      postcss-value-parser: 4.2.0
-
-  postcss-ordered-values@6.0.2(postcss@8.5.1):
-    dependencies:
-      cssnano-utils: 4.0.2(postcss@8.5.1)
-      postcss: 8.5.1
       postcss-value-parser: 4.2.0
 
   postcss-ordered-values@6.0.2(postcss@8.5.3):
@@ -19000,26 +18888,15 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-page-break@3.0.4(postcss@8.5.1):
+  postcss-page-break@3.0.4(postcss@8.5.3):
     dependencies:
-      postcss: 8.5.1
-
-  postcss-reduce-initial@6.1.0(postcss@8.5.1):
-    dependencies:
-      browserslist: 4.24.4
-      caniuse-api: 3.0.0
-      postcss: 8.5.1
+      postcss: 8.5.3
 
   postcss-reduce-initial@6.1.0(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
       caniuse-api: 3.0.0
       postcss: 8.5.3
-
-  postcss-reduce-transforms@6.0.2(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-      postcss-value-parser: 4.2.0
 
   postcss-reduce-transforms@6.0.2(postcss@8.5.3):
     dependencies:
@@ -19036,22 +18913,11 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-svgo@6.0.3(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-      postcss-value-parser: 4.2.0
-      svgo: 3.3.2
-
   postcss-svgo@6.0.3(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
       svgo: 3.3.2
-
-  postcss-unique-selectors@6.0.4(postcss@8.5.1):
-    dependencies:
-      postcss: 8.5.1
-      postcss-selector-parser: 6.1.2
 
   postcss-unique-selectors@6.0.4(postcss@8.5.3):
     dependencies:
@@ -20973,12 +20839,6 @@ snapshots:
       supports-color: 5.5.0
     transitivePeerDependencies:
       - '@babel/core'
-
-  stylehacks@6.1.1(postcss@8.5.1):
-    dependencies:
-      browserslist: 4.24.4
-      postcss: 8.5.1
-      postcss-selector-parser: 6.1.2
 
   stylehacks@6.1.1(postcss@8.5.3):
     dependencies:


### PR DESCRIPTION
## Summary
fix: the problem when use mini-css-extract-plugin loader

The mini-css-extract-plugin will initiate a childCompiler, within which the loader proxy logic will be executed again. This will result in the options[Loader.LoaderInternalPropertyName] of the loader proxy still being the proxy loader, causing errors in CSS and LESS compilation.

This pull request addresses an issue with the `interceptLoader` function in the `loader.ts` file, specifically related to how the `LoaderInternalPropertyName` is set for proxy-loader in the childCompiler of the mini-css-extract-plugin. The most important change involves conditionally setting the `LoaderInternalPropertyName` to prevent errors during the compilation of less files.

Improvements to error handling:

* [`packages/core/src/inner-plugins/utils/loader.ts`](diffhunk://#diff-5888d2100710a75297716d3c2f0291a87e0cc2f7f34400cc1192ed2f80d35661L122-R128): Added a conditional check to set `Loader.LoaderInternalPropertyName` based on whether the loader is a proxy-loader and if the rule contains options, preventing compilation errors for less files.

## Related Links

<!--- Provide links of related issues or pages -->
#476 
#838 