### PR TITLE
optimize: delete some unuse option

### DIFF
--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -31,7 +31,6 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     loaderInterceptorOptions = {},
     disableClientServer = false,
     sdkInstance,
-    disableTOSUpload = false,
     innerClientPath = '',
     output = {
       reportCodeType: {
@@ -126,7 +125,6 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
       compressData:
         output.compressData !== undefined ? output.compressData : true,
     },
-    disableTOSUpload,
     innerClientPath,
     supports,
     port,

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -57,7 +57,7 @@ export interface RsdoctorWebpackPluginOptions<
   disableClientServer?: boolean;
 
   /**
-   * sdk instance of outside. TODO: delete this options
+   * sdk instance of outside.
    */
   sdkInstance?: RsdoctorSDK;
 
@@ -82,13 +82,7 @@ export interface RsdoctorWebpackPluginOptions<
   brief?: SDK.BriefConfig;
 
   /**
-   * control the Rsdoctor upload data to TOS, used by inner-rsdoctor. TODO: delete this options
-   * @default false
-   */
-  disableTOSUpload?: boolean;
-
-  /**
-   * The name of inner rsdoctor's client package, used by inner-rsdoctor. TODO: delete this options
+   * The name of inner rsdoctor's client package, used by inner-rsdoctor.
    * @default false
    */
   innerClientPath?: string;

--- a/packages/rspack-plugin/src/multiple.ts
+++ b/packages/rspack-plugin/src/multiple.ts
@@ -30,7 +30,6 @@ export class RsdoctorRspackMultiplePlugin<
       name: options.name || 'Builder',
       stage: options.stage,
       extraConfig: {
-        disableTOSUpload: normallizedOptions.disableTOSUpload || false,
         innerClientPath: normallizedOptions.innerClientPath,
         printLog: normallizedOptions.printLog,
         mode: normallizedOptions.mode ? normallizedOptions.mode : undefined,

--- a/packages/rspack-plugin/src/plugin.ts
+++ b/packages/rspack-plugin/src/plugin.ts
@@ -74,7 +74,6 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
         root: process.cwd(),
         type: this.options.output.reportCodeType,
         config: {
-          disableTOSUpload: this.options.disableTOSUpload,
           innerClientPath: this.options.innerClientPath,
           printLog: this.options.printLog,
           mode: this.options.mode ? this.options.mode : undefined,

--- a/packages/types/src/sdk/instance.ts
+++ b/packages/types/src/sdk/instance.ts
@@ -121,7 +121,6 @@ export interface BriefConfig {
 }
 
 export type SDKOptionsType = {
-  disableTOSUpload: boolean;
   innerClientPath?: string;
   disableClientServer?: boolean;
   noServer?: boolean;

--- a/packages/webpack-plugin/src/multiple.ts
+++ b/packages/webpack-plugin/src/multiple.ts
@@ -30,7 +30,6 @@ export class RsdoctorWebpackMultiplePlugin<
       name: options.name || 'Builder',
       stage: options.stage,
       extraConfig: {
-        disableTOSUpload: normallizedOptions.disableTOSUpload || false,
         innerClientPath: normallizedOptions.innerClientPath,
         printLog: normallizedOptions.printLog,
         mode: normallizedOptions.mode ? normallizedOptions.mode : undefined,

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -60,7 +60,6 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
         root: process.cwd(),
         type: this.options.output.reportCodeType,
         config: {
-          disableTOSUpload: this.options.disableTOSUpload,
           innerClientPath: this.options.innerClientPath,
           printLog: this.options.printLog,
           mode: this.options.mode,


### PR DESCRIPTION
## Summary
optimize: delete some unuse option
This pull request focuses on removing the `disableTOSUpload` option from various configurations and classes across multiple files. This change simplifies the codebase and removes redundant configuration options.

## Related Links

<!--- Provide links of related issues or pages -->
