### PR TITLE
feat: UI execution diff view add side-by-side check

### DIFF
--- a/packages/components/src/components/Loader/executions.tsx
+++ b/packages/components/src/components/Loader/executions.tsx
@@ -2,24 +2,25 @@ import { ClockCircleTwoTone } from '@ant-design/icons';
 import Editor from '@monaco-editor/react';
 import { SDK } from '@rsdoctor/types';
 import {
+  Checkbox,
   Col,
   Divider,
   Empty,
+  List,
   Row,
   Space,
+  Tabs,
   Tag,
   Timeline,
   Tooltip,
   Typography,
-  Tabs,
-  List,
 } from 'antd';
 import dayjs from 'dayjs';
 import { PropsWithChildren, useCallback, useState } from 'react';
 
-import StepIcon from 'src/common/svg/loader/step.svg';
 import InputIcon from 'src/common/svg/loader/input.svg';
 import OutputIcon from 'src/common/svg/loader/output.svg';
+import StepIcon from 'src/common/svg/loader/step.svg';
 import { Size } from '../../constants';
 import {
   beautifyPath,
@@ -129,7 +130,7 @@ export const LoaderExecutions = ({
   const leftSpan = 5;
   const hasError = loader.errors && loader.errors.length;
   const [activeKey, setActiveKey] = useState('loaderDetails');
-
+  const [isSideBySide, setIsSideBySide] = useState(true);
   const onChange = useCallback((key: string) => {
     setActiveKey(key);
   }, []);
@@ -258,6 +259,8 @@ export const LoaderExecutions = ({
                     <Col span={24} style={{ height: '53%', minHeight: 400 }}>
                       <div
                         style={{
+                          display: 'flex',
+                          alignItems: 'center',
                           padding: Size.BasePadding,
                           borderTop: `1px solid ${isLight ? '#f0f0f0' : 'rgba(253, 253, 253, 0.12)'}`,
                           borderBottom: `1px solid ${isLight ? '#f0f0f0' : 'rgba(253, 253, 253, 0.12)'}`,
@@ -266,6 +269,16 @@ export const LoaderExecutions = ({
                         <Title
                           text={`the result of [${loader.loader}] ${loader.isPitch ? 'pitch' : ''}`}
                         />
+                        <div style={{ flex: 1 }} />
+                        <Checkbox
+                          title="side-by-side"
+                          checked={isSideBySide}
+                          onChange={(evt) => {
+                            setIsSideBySide(evt.target.checked);
+                          }}
+                        >
+                          side-by-side
+                        </Checkbox>
                       </div>
                       {loader.isPitch ? (
                         loader.result ? (
@@ -292,30 +305,36 @@ export const LoaderExecutions = ({
                         )
                       ) : (
                         <div style={{ minHeight: '700px' }}>
-                          <Row>
-                            <Col
-                              span={12}
-                              style={{
-                                padding: `${Size.BasePadding / 2}px ${Size.BasePadding}px`,
-                              }}
-                            >
-                              <Space align="center" className={styles.space}>
-                                <InputIcon />
-                                <Typography.Text strong>Input</Typography.Text>
-                              </Space>
-                            </Col>
-                            <Col
-                              span={12}
-                              style={{
-                                padding: `${Size.BasePadding / 2}px ${Size.BasePadding}px`,
-                              }}
-                            >
-                              <Space align="center" className={styles.space}>
-                                <OutputIcon />
-                                <Typography.Text strong>Output</Typography.Text>
-                              </Space>
-                            </Col>
-                          </Row>
+                          {isSideBySide && (
+                            <Row>
+                              <Col
+                                span={12}
+                                style={{
+                                  padding: `${Size.BasePadding / 2}px ${Size.BasePadding}px`,
+                                }}
+                              >
+                                <Space align="center" className={styles.space}>
+                                  <InputIcon />
+                                  <Typography.Text strong>
+                                    Input
+                                  </Typography.Text>
+                                </Space>
+                              </Col>
+                              <Col
+                                span={12}
+                                style={{
+                                  padding: `${Size.BasePadding / 2}px ${Size.BasePadding}px`,
+                                }}
+                              >
+                                <Space align="center" className={styles.space}>
+                                  <OutputIcon />
+                                  <Typography.Text strong>
+                                    Output
+                                  </Typography.Text>
+                                </Space>
+                              </Col>
+                            </Row>
+                          )}
                           <div style={{ height: '40rem' }}>
                             {!loader.result && !before ? (
                               <Empty
@@ -328,6 +347,12 @@ export const LoaderExecutions = ({
                                 filepath={resource.path}
                                 before={before}
                                 after={loader.result || ''}
+                                editorProps={{
+                                  options: {
+                                    renderSideBySideInlineBreakpoint: 1,
+                                    renderSideBySide: isSideBySide,
+                                  },
+                                }}
                               />
                             )}
                           </div>


### PR DESCRIPTION
## Summary

Add side-by-side Checkbox in diffview.

![CleanShot 2025-04-02 at 21 39 42](https://github.com/user-attachments/assets/ac91b58d-0a6e-4438-a8d7-d3682b418acb)

**reason：**

The monaco DiffEditor has a default behavior that is auto SideBySide at break point width (default 900px). 

see: https://microsoft.github.io/monaco-editor/docs.html#interfaces/editor.IDiffEditorBaseOptions.html#renderSideBySideInlineBreakpoint

## Related Links
close: https://github.com/web-infra-dev/rsdoctor/issues/864
<!--- Provide links of related issues or pages -->
