### PR TITLE
chore: clean ts cache

### DIFF
--- a/scripts/modern.base.config.ts
+++ b/scripts/modern.base.config.ts
@@ -3,7 +3,7 @@ import {
   moduleTools,
   type PartialBaseBuildConfig,
 } from '@modern-js/module-tools';
-
+import fs from 'node:fs';
 import path from 'path';
 
 const define = {
@@ -11,9 +11,24 @@ const define = {
 };
 
 const BUILD_TARGET = 'es2020' as const;
+// Clean tsc cache to ensure the dts files can be generated correctly
+export const pluginCleanTscCache = {
+  name: 'plugin-clean-tsc-cache',
+  setup(api) {
+    api.onBeforeBuild(() => {
+      const tsbuildinfo = path.join(
+        api.context.rootPath,
+        'tsconfig.tsbuildinfo',
+      );
+      if (fs.existsSync(tsbuildinfo)) {
+        fs.rmSync(tsbuildinfo);
+      }
+    });
+  },
+};
 
 export const baseBuildConfig = {
-  plugins: [moduleTools()],
+  plugins: [moduleTools(), pluginCleanTscCache],
   buildConfig: {
     buildType: 'bundleless' as const,
     format: 'cjs' as const,
@@ -58,12 +73,12 @@ export const buildConfigWithMjs: PartialBaseBuildConfig[] = [
 ];
 
 export const configWithMjs = defineConfig({
-  plugins: [moduleTools()],
+  plugins: [moduleTools(), pluginCleanTscCache],
   buildConfig: buildConfigWithMjs,
 });
 
 export const configWithEsm = defineConfig({
-  plugins: [moduleTools()],
+  plugins: [moduleTools(), pluginCleanTscCache],
   buildConfig: [
     {
       buildType: 'bundleless',


### PR DESCRIPTION
## Summary
chore: clean ts cache

This pull request includes changes to the `scripts/modern.base.config.ts` file to improve the build process by adding a new plugin and cleaning up the TypeScript cache. The most important changes include importing the `fs` module, defining the `pluginCleanTscCache`, and updating the build configurations to use the new plugin.

Build process improvements:

* [`scripts/modern.base.config.ts`](diffhunk://#diff-50440b540ef26f2764d8ae3f2ff6da429c86e3f90d83af8e82dc389ed843df67L6-R31): Imported the `fs` module to handle file system operations.
* [`scripts/modern.base.config.ts`](diffhunk://#diff-50440b540ef26f2764d8ae3f2ff6da429c86e3f90d83af8e82dc389ed843df67L6-R31): Defined a new plugin `pluginCleanTscCache` to clean the TypeScript cache before building to ensure the DTS files are generated correctly.
* [`scripts/modern.base.config.ts`](diffhunk://#diff-50440b540ef26f2764d8ae3f2ff6da429c86e3f90d83af8e82dc389ed843df67L6-R31): Updated the `baseBuildConfig`, `configWithMjs`, and `configWithEsm` to include the new `pluginCleanTscCache` plugin. [[1]](diffhunk://#diff-50440b540ef26f2764d8ae3f2ff6da429c86e3f90d83af8e82dc389ed843df67L6-R31) [[2]](diffhunk://#diff-50440b540ef26f2764d8ae3f2ff6da429c86e3f90d83af8e82dc389ed843df67L61-R81)
## Related Links

<!--- Provide links of related issues or pages -->
