### PR TITLE
tweaks: adjust the issuerPath to only include module ids

### DIFF
--- a/packages/core/src/build-utils/common/module-graph/transform.ts
+++ b/packages/core/src/build-utils/common/module-graph/transform.ts
@@ -259,7 +259,6 @@ export function getModuleGraphByStats(
         }
         if (moduleInstance) {
           issuer.moduleId = moduleInstance.id;
-          issuer.identifier = ''; // To prevent data explosion, remove the identifier for modules with moduleInstance.id.
         }
       });
     }

--- a/packages/core/tests/common/module-graph/__snapshots__/transform.test.ts.snap
+++ b/packages/core/tests/common/module-graph/__snapshots__/transform.test.ts.snap
@@ -964,3 +964,196 @@ exports[`module graph transform from stats > module type === from origin 1`] = `
   "variables": [],
 }
 `;
+
+exports[`module graph transform from stats > normal module in multi concatenation module 1`] = `
+{
+  "dependencies": [
+    {
+      "dependency": 3,
+      "id": 1,
+      "kind": 1,
+      "module": 2,
+      "originDependency": 3,
+      "request": "common",
+      "resolvedRequest": "common.js",
+      "statements": [
+        {
+          "module": 2,
+          "position": {
+            "transformed": {
+              "end": {
+                "column": 38,
+                "line": 1,
+              },
+              "start": {
+                "column": 0,
+                "line": 1,
+              },
+            },
+          },
+        },
+      ],
+    },
+    {
+      "dependency": 3,
+      "id": 2,
+      "kind": 1,
+      "module": 5,
+      "originDependency": 3,
+      "request": "common",
+      "resolvedRequest": "common.js",
+      "statements": [
+        {
+          "module": 5,
+          "position": {
+            "transformed": {
+              "end": {
+                "column": 38,
+                "line": 1,
+              },
+              "start": {
+                "column": 0,
+                "line": 1,
+              },
+            },
+          },
+        },
+      ],
+    },
+  ],
+  "exports": [],
+  "layers": [],
+  "moduleGraphModules": [],
+  "modules": [
+    {
+      "chunks": [
+        "0",
+      ],
+      "dependencies": [],
+      "id": 1,
+      "imported": [],
+      "isEntry": true,
+      "isPreferSource": false,
+      "issuerPath": [],
+      "kind": 1,
+      "modules": [
+        2,
+        3,
+      ],
+      "path": "entry1.js",
+      "renderId": undefined,
+      "rootModule": 2,
+      "size": {
+        "parsedSize": -1,
+        "sourceSize": -1,
+        "transformedSize": -1,
+      },
+      "webpackId": "",
+    },
+    {
+      "chunks": [
+        "0",
+      ],
+      "concatenationModules": [
+        1,
+      ],
+      "dependencies": [
+        1,
+      ],
+      "id": 2,
+      "imported": [],
+      "isEntry": true,
+      "isPreferSource": false,
+      "issuerPath": [],
+      "kind": 0,
+      "path": "entry1.js",
+      "renderId": undefined,
+      "size": {
+        "parsedSize": -1,
+        "sourceSize": -1,
+        "transformedSize": -1,
+      },
+      "webpackId": "",
+    },
+    {
+      "chunks": [
+        "0",
+        "1",
+      ],
+      "concatenationModules": [
+        1,
+        4,
+      ],
+      "dependencies": [],
+      "id": 3,
+      "imported": [
+        2,
+        5,
+      ],
+      "isPreferSource": false,
+      "issuerPath": [],
+      "kind": 0,
+      "path": "common.js",
+      "renderId": undefined,
+      "size": {
+        "parsedSize": -1,
+        "sourceSize": -1,
+        "transformedSize": -1,
+      },
+      "webpackId": "",
+    },
+    {
+      "chunks": [
+        "1",
+      ],
+      "dependencies": [],
+      "id": 4,
+      "imported": [],
+      "isEntry": true,
+      "isPreferSource": false,
+      "issuerPath": [],
+      "kind": 1,
+      "modules": [
+        5,
+        3,
+      ],
+      "path": "entry2.js",
+      "renderId": "1",
+      "rootModule": 5,
+      "size": {
+        "parsedSize": -1,
+        "sourceSize": -1,
+        "transformedSize": -1,
+      },
+      "webpackId": "",
+    },
+    {
+      "chunks": [
+        "1",
+      ],
+      "concatenationModules": [
+        4,
+      ],
+      "dependencies": [
+        2,
+      ],
+      "id": 5,
+      "imported": [],
+      "isEntry": true,
+      "isPreferSource": false,
+      "issuerPath": [],
+      "kind": 0,
+      "path": "entry2.js",
+      "renderId": undefined,
+      "size": {
+        "parsedSize": -1,
+        "sourceSize": -1,
+        "transformedSize": -1,
+      },
+      "webpackId": "",
+    },
+  ],
+  "sideEffects": [],
+  "variables": [],
+}
+`;

--- a/packages/core/tests/common/module-graph/__snapshots__/transform.test.ts.snap
+++ b/packages/core/tests/common/module-graph/__snapshots__/transform.test.ts.snap
@@ -928,7 +928,7 @@ exports[`module graph transform from stats > module type === from origin 1`] = `
         },
         {
           "id": null,
-          "identifier": "",
+          "identifier": "javascript/esm|/Users/demo/examples/angular/node_modules/@angular-devkit/build-angular/src/babel/webpack-loader.js??ruleSet[1].rules[3].use[0]!/Users/demo/node_modules/@angular/platform-browser/fesm2022/platform-browser.mjs",
           "moduleId": 3,
           "name": "../../node_modules/@angular/platform-browser/fesm2022/platform-browser.mjs",
         },
@@ -1139,14 +1139,7 @@ exports[`module graph transform from stats > normal module in multi concatenatio
         5,
       ],
       "isPreferSource": false,
-      "issuerPath": [
-        {
-          "id": null,
-          "identifier": "",
-          "moduleId": 2,
-          "name": "packages/core/tests/fixtures/normal-module-in-multi-concatenation/entry1.js",
-        },
-      ],
+      "issuerPath": [],
       "kind": 0,
       "path": "common.js",
       "renderId": undefined,

--- a/packages/core/tests/common/module-graph/__snapshots__/transform.test.ts.snap
+++ b/packages/core/tests/common/module-graph/__snapshots__/transform.test.ts.snap
@@ -883,23 +883,7 @@ exports[`module graph transform from stats > module type === from origin 1`] = `
         2,
       ],
       "isPreferSource": false,
-      "issuerPath": [
-        {
-          "id": null,
-          "identifier": "/Users/demo/examples/angular/node_modules/@angular-devkit/build-angular/src/babel/webpack-loader.js??ruleSet[1].rules[3].use[0]!/Users/demo/examples/angular/node_modules/@ngtools/webpack/src/ivy/index.js!/Users/demo/examples/angular/src/main.ts",
-          "name": "src/main.ts",
-        },
-        {
-          "id": null,
-          "identifier": "/Users/demo/examples/angular/node_modules/@angular-devkit/build-angular/src/babel/webpack-loader.js??ruleSet[1].rules[3].use[0]!/Users/demo/examples/angular/node_modules/@ngtools/webpack/src/ivy/index.js!/Users/demo/examples/angular/src/app/app.module.ts",
-          "name": "src/app/app.module.ts",
-        },
-        {
-          "id": null,
-          "identifier": "/Users/demo/examples/angular/node_modules/@angular-devkit/build-angular/src/babel/webpack-loader.js??ruleSet[1].rules[3].use[0]!/Users/demo/examples/angular/node_modules/@ngtools/webpack/src/ivy/index.js!/Users/demo/examples/angular/src/app/app.component.ts",
-          "name": "src/app/app.component.ts",
-        },
-      ],
+      "issuerPath": [],
       "kind": 0,
       "path": "/Users/demo/node_modules/@angular/common/fesm2022/common.mjs",
       "renderId": undefined,
@@ -921,17 +905,7 @@ exports[`module graph transform from stats > module type === from origin 1`] = `
       ],
       "isPreferSource": false,
       "issuerPath": [
-        {
-          "id": null,
-          "identifier": "/Users/demo/examples/angular/node_modules/@angular-devkit/build-angular/src/babel/webpack-loader.js??ruleSet[1].rules[3].use[0]!/Users/demo/examples/angular/node_modules/@ngtools/webpack/src/ivy/index.js!/Users/demo/examples/angular/src/main.ts",
-          "name": "src/main.ts",
-        },
-        {
-          "id": null,
-          "identifier": "javascript/esm|/Users/demo/examples/angular/node_modules/@angular-devkit/build-angular/src/babel/webpack-loader.js??ruleSet[1].rules[3].use[0]!/Users/demo/node_modules/@angular/platform-browser/fesm2022/platform-browser.mjs",
-          "moduleId": 3,
-          "name": "../../node_modules/@angular/platform-browser/fesm2022/platform-browser.mjs",
-        },
+        3,
       ],
       "kind": 0,
       "path": "/Users/demo/node_modules/@angular/common/fesm2022/http.mjs",
@@ -954,13 +928,7 @@ exports[`module graph transform from stats > module type === from origin 1`] = `
         4,
       ],
       "isPreferSource": false,
-      "issuerPath": [
-        {
-          "id": null,
-          "identifier": "/Users/demo/examples/angular/node_modules/@angular-devkit/build-angular/src/babel/webpack-loader.js??ruleSet[1].rules[3].use[0]!/Users/demo/examples/angular/node_modules/@ngtools/webpack/src/ivy/index.js!/Users/demo/examples/angular/src/main.ts",
-          "name": "src/main.ts",
-        },
-      ],
+      "issuerPath": [],
       "kind": 0,
       "path": "/Users/demo/node_modules/@angular/platform-browser/fesm2022/platform-browser.mjs",
       "renderId": undefined,
@@ -980,23 +948,7 @@ exports[`module graph transform from stats > module type === from origin 1`] = `
       "id": 4,
       "imported": [],
       "isPreferSource": false,
-      "issuerPath": [
-        {
-          "id": null,
-          "identifier": "/Users/demo/examples/angular/node_modules/@angular-devkit/build-angular/src/babel/webpack-loader.js??ruleSet[1].rules[3].use[0]!/Users/demo/examples/angular/node_modules/@ngtools/webpack/src/ivy/index.js!/Users/demo/examples/angular/src/main.ts",
-          "name": "src/main.ts",
-        },
-        {
-          "id": null,
-          "identifier": "/Users/demo/examples/angular/node_modules/@angular-devkit/build-angular/src/babel/webpack-loader.js??ruleSet[1].rules[3].use[0]!/Users/demo/examples/angular/node_modules/@ngtools/webpack/src/ivy/index.js!/Users/demo/examples/angular/src/app/app.module.ts",
-          "name": "src/app/app.module.ts",
-        },
-        {
-          "id": null,
-          "identifier": "/Users/demo/examples/angular/node_modules/@angular-devkit/build-angular/src/babel/webpack-loader.js??ruleSet[1].rules[3].use[0]!/Users/demo/examples/angular/node_modules/@ngtools/webpack/src/ivy/index.js!/Users/demo/examples/angular/src/app/app-routing.module.ts",
-          "name": "src/app/app-routing.module.ts",
-        },
-      ],
+      "issuerPath": [],
       "kind": 0,
       "path": "/Users/demo/node_modules/@angular/router/fesm2022/router.mjs",
       "renderId": undefined,
@@ -1006,199 +958,6 @@ exports[`module graph transform from stats > module type === from origin 1`] = `
         "transformedSize": 268651,
       },
       "webpackId": "javascript/esm|/Users/demo/examples/angular/node_modules/@angular-devkit/build-angular/src/babel/webpack-loader.js??ruleSet[1].rules[3].use[0]!/Users/demo/node_modules/@angular/router/fesm2022/router.mjs",
-    },
-  ],
-  "sideEffects": [],
-  "variables": [],
-}
-`;
-
-exports[`module graph transform from stats > normal module in multi concatenation module 1`] = `
-{
-  "dependencies": [
-    {
-      "dependency": 3,
-      "id": 1,
-      "kind": 1,
-      "module": 2,
-      "originDependency": 3,
-      "request": "common",
-      "resolvedRequest": "common.js",
-      "statements": [
-        {
-          "module": 2,
-          "position": {
-            "transformed": {
-              "end": {
-                "column": 38,
-                "line": 1,
-              },
-              "start": {
-                "column": 0,
-                "line": 1,
-              },
-            },
-          },
-        },
-      ],
-    },
-    {
-      "dependency": 3,
-      "id": 2,
-      "kind": 1,
-      "module": 5,
-      "originDependency": 3,
-      "request": "common",
-      "resolvedRequest": "common.js",
-      "statements": [
-        {
-          "module": 5,
-          "position": {
-            "transformed": {
-              "end": {
-                "column": 38,
-                "line": 1,
-              },
-              "start": {
-                "column": 0,
-                "line": 1,
-              },
-            },
-          },
-        },
-      ],
-    },
-  ],
-  "exports": [],
-  "layers": [],
-  "moduleGraphModules": [],
-  "modules": [
-    {
-      "chunks": [
-        "0",
-      ],
-      "dependencies": [],
-      "id": 1,
-      "imported": [],
-      "isEntry": true,
-      "isPreferSource": false,
-      "issuerPath": [],
-      "kind": 1,
-      "modules": [
-        2,
-        3,
-      ],
-      "path": "entry1.js",
-      "renderId": undefined,
-      "rootModule": 2,
-      "size": {
-        "parsedSize": -1,
-        "sourceSize": -1,
-        "transformedSize": -1,
-      },
-      "webpackId": "",
-    },
-    {
-      "chunks": [
-        "0",
-      ],
-      "concatenationModules": [
-        1,
-      ],
-      "dependencies": [
-        1,
-      ],
-      "id": 2,
-      "imported": [],
-      "isEntry": true,
-      "isPreferSource": false,
-      "issuerPath": [],
-      "kind": 0,
-      "path": "entry1.js",
-      "renderId": undefined,
-      "size": {
-        "parsedSize": -1,
-        "sourceSize": -1,
-        "transformedSize": -1,
-      },
-      "webpackId": "",
-    },
-    {
-      "chunks": [
-        "0",
-        "1",
-      ],
-      "concatenationModules": [
-        1,
-        4,
-      ],
-      "dependencies": [],
-      "id": 3,
-      "imported": [
-        2,
-        5,
-      ],
-      "isPreferSource": false,
-      "issuerPath": [],
-      "kind": 0,
-      "path": "common.js",
-      "renderId": undefined,
-      "size": {
-        "parsedSize": -1,
-        "sourceSize": -1,
-        "transformedSize": -1,
-      },
-      "webpackId": "",
-    },
-    {
-      "chunks": [
-        "1",
-      ],
-      "dependencies": [],
-      "id": 4,
-      "imported": [],
-      "isEntry": true,
-      "isPreferSource": false,
-      "issuerPath": [],
-      "kind": 1,
-      "modules": [
-        5,
-        3,
-      ],
-      "path": "entry2.js",
-      "renderId": "1",
-      "rootModule": 5,
-      "size": {
-        "parsedSize": -1,
-        "sourceSize": -1,
-        "transformedSize": -1,
-      },
-      "webpackId": "",
-    },
-    {
-      "chunks": [
-        "1",
-      ],
-      "concatenationModules": [
-        4,
-      ],
-      "dependencies": [
-        2,
-      ],
-      "id": 5,
-      "imported": [],
-      "isEntry": true,
-      "isPreferSource": false,
-      "issuerPath": [],
-      "kind": 0,
-      "path": "entry2.js",
-      "renderId": undefined,
-      "size": {
-        "parsedSize": -1,
-        "sourceSize": -1,
-        "transformedSize": -1,
-      },
-      "webpackId": "",
     },
   ],
   "sideEffects": [],

--- a/packages/core/tests/common/module-graph/transform.test.ts
+++ b/packages/core/tests/common/module-graph/transform.test.ts
@@ -42,8 +42,11 @@ describe('module graph transform from stats', () => {
     expect(graph.getDependencies().length).toEqual(2);
     const graphData = graph.toData();
     expect(graphData.modules[0].webpackId.length).toBeTruthy();
-    expect(graphData.modules[2].issuerPath[0].identifier).toBeTruthy();
-    expect(graphData.modules[2].issuerPath[0].moduleId).toBeTruthy();
+    console.log(
+      'graphData.modules[2]?.issuerPath:::',
+      graphData.modules[2]?.issuerPath,
+    );
+    expect(graphData.modules[2]?.issuerPath?.[0]).toBeTruthy();
 
     graphData.modules.forEach((mod) => {
       // prevent ci failed on win32

--- a/packages/core/tests/common/module-graph/transform.test.ts
+++ b/packages/core/tests/common/module-graph/transform.test.ts
@@ -42,10 +42,6 @@ describe('module graph transform from stats', () => {
     expect(graph.getDependencies().length).toEqual(2);
     const graphData = graph.toData();
     expect(graphData.modules[0].webpackId.length).toBeTruthy();
-    console.log(
-      'graphData.modules[2]?.issuerPath:::',
-      graphData.modules[2]?.issuerPath,
-    );
     expect(graphData.modules[2]?.issuerPath?.[0]).toBeTruthy();
 
     graphData.modules.forEach((mod) => {

--- a/packages/core/tests/common/module-graph/transform.test.ts
+++ b/packages/core/tests/common/module-graph/transform.test.ts
@@ -42,6 +42,8 @@ describe('module graph transform from stats', () => {
     expect(graph.getDependencies().length).toEqual(2);
     const graphData = graph.toData();
     expect(graphData.modules[0].webpackId.length).toBeTruthy();
+    expect(graphData.modules[2].issuerPath[0].identifier).toBeTruthy();
+    expect(graphData.modules[2].issuerPath[0].moduleId).toBeTruthy();
 
     graphData.modules.forEach((mod) => {
       // prevent ci failed on win32
@@ -49,6 +51,7 @@ describe('module graph transform from stats', () => {
       mod.size.sourceSize = -1;
       mod.size.transformedSize = -1;
       mod.size.parsedSize = -1;
+      mod.issuerPath = [];
     });
     expect(graphData).toMatchSnapshot();
   });

--- a/packages/graph/src/graph/module-graph/module.ts
+++ b/packages/graph/src/graph/module-graph/module.ts
@@ -345,7 +345,10 @@ export class Module implements SDK.ModuleInstance {
       size: this.getSize(),
       kind: this.kind,
       ...(this.layer ? { layer: this.layer } : {}),
-      issuerPath: this.issuerPath,
+      issuerPath:
+        this.issuerPath
+          ?.filter((issuer) => issuer.moduleId)
+          .map((issuer) => issuer.moduleId) || [],
     };
 
     if (this.meta.hasSetEsModuleStatement || this.meta.strictHarmonyModule) {

--- a/packages/types/src/plugin/baseStats.ts
+++ b/packages/types/src/plugin/baseStats.ts
@@ -48,6 +48,7 @@ type KnownStatsModuleIssuer = {
   identifier?: string;
   name?: string;
   id?: string | number | null;
+  moduleId?: string | number | null;
 };
 
 export interface StatsModule {

--- a/packages/types/src/sdk/module.ts
+++ b/packages/types/src/sdk/module.ts
@@ -336,7 +336,7 @@ export interface ModuleGraphInstance {
 export interface ModuleData
   extends Omit<
     NonFunctionProperties<ModuleInstance>,
-    'rootModule' | 'isEntry' | 'concatenationModules' | 'meta'
+    'rootModule' | 'isEntry' | 'concatenationModules' | 'meta' | 'issuerPath'
   > {
   /** chunk identifier */
   chunks: string[];
@@ -371,6 +371,9 @@ export interface ModuleData
 
   /** Build original attributes */
   meta?: Partial<Omit<ModuleBuildMeta, 'packageData'>>;
+
+  /** Issuer path */
+  issuerPath?: string[] | number[];
 }
 
 export type ModuleCodeData = Record<number, ModuleSource>;


### PR DESCRIPTION
## Summary
Adjust the issuerPath to only include module ids.

The same issuerPath type with rspack native plugin: https://github.com/web-infra-dev/rspack/pull/10007
## Related Links

<!--- Provide links of related issues or pages -->
