### PR TITLE
fix: improve `OverlayAlerts` spacing and add pluralization

### DIFF
--- a/packages/components/src/components/Alerts/overlay.tsx
+++ b/packages/components/src/components/Alerts/overlay.tsx
@@ -53,13 +53,15 @@ function getOverlayAlertsMessage(
           Compiled with
         </Typography.Text>
         <Typography.Text strong style={{ color: Color.Red, fontSize }}>
-          {errors} errors
+          {' '}
+          {errors} {errors === 1 ? 'error' : 'errors'}{' '}
         </Typography.Text>
         <Typography.Text style={{ color: 'inherit', fontSize }}>
           and
         </Typography.Text>
         <Typography.Text strong style={{ color: Color.Yellow, fontSize }}>
-          {warns} warnings
+          {' '}
+          {warns} {warns === 1 ? 'warning' : 'warnings'}
         </Typography.Text>
       </Typography.Text>
     ),


### PR DESCRIPTION
## Summary

### Before

<img width="978" alt="Screenshot 2025-04-22 at 4 52 59 PM" src="https://github.com/user-attachments/assets/3f4ab1c6-0b9f-446c-8b6d-274918b56928" />

### After

<img width="987" alt="Screenshot 2025-04-22 at 4 52 51 PM" src="https://github.com/user-attachments/assets/32d3425c-35eb-48b8-a845-e143fddd504f" />

## Related Links

<!--- Provide links of related issues or pages -->
