### PR TITLE
fix: add spacing to bundled and source sizes

### DIFF
--- a/packages/components/src/pages/BundleSize/components/asset.tsx
+++ b/packages/components/src/pages/BundleSize/components/asset.tsx
@@ -530,15 +530,15 @@ export const AssetDetail: React.FC<{
                 {parsedSize > 0 ? (
                   <>
                     <Tag style={tagStyle} color={'orange'}>
-                      {'Bundled:' + formatSize(parsedSize)}
+                      {`Bundled: ${formatSize(parsedSize)}`}
                     </Tag>
                     <Tag style={tagStyle} color={'lime'}>
-                      {'Source:' + formatSize(sourceSize)}
+                      {`Source: ${formatSize(sourceSize)}`}
                     </Tag>
                   </>
                 ) : (
                   <Tag style={tagStyle} color={'lime'}>
-                    {'Source:' + formatSize(sourceSize)}
+                    {`Source: ${formatSize(sourceSize)}`}
                   </Tag>
                 )}
               </Space>


### PR DESCRIPTION
## Summary

### Before

<img width="1242" alt="Screenshot 2025-04-22 at 4 57 39 PM" src="https://github.com/user-attachments/assets/58ba7159-6efe-48dd-b6e2-381ff6b1a66a" />

### After

<img width="1242" alt="Screenshot 2025-04-22 at 5 00 20 PM" src="https://github.com/user-attachments/assets/e9a21ea3-c8e4-4120-b22c-4caac0461e12" />

## Related Links

<!--- Provide links of related issues or pages -->
