### PR TITLE
feat: rsdoctor mcp get auto port

### DIFF
--- a/examples/rsbuild-minimal/rsbuild.config.ts
+++ b/examples/rsbuild-minimal/rsbuild.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
       chain.plugin('Rsdoctor').use(RsdoctorRspackPlugin, [
         {
           disableClientServer: !process.env.ENABLE_CLIENT_SERVER,
-          features: ['bundle', 'plugins', 'loader', 'resolver'],
           output: {
             reportCodeType: {
               noAssetsAndModuleSource: true,

--- a/packages/ai/src/server/server.ts
+++ b/packages/ai/src/server/server.ts
@@ -16,6 +16,7 @@ import {
   getSimilarPackages,
   getLoaderTimeForAllFiles,
   getLoaderTimes,
+  getPort,
 } from './tools.js';
 import { registerStaticResources } from './resource.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -273,6 +274,20 @@ server.tool(
     };
   },
 );
+
+server.tool(Tools.getPort, 'Get the port of the MCP server', {}, async () => {
+  const res = await getPort();
+  return {
+    content: [
+      {
+        name: Tools.getPort,
+        description: 'Get the port of the MCP server',
+        type: 'text',
+        text: res,
+      },
+    ],
+  };
+});
 
 registerStaticResources(server);
 

--- a/packages/ai/src/server/socket.ts
+++ b/packages/ai/src/server/socket.ts
@@ -1,7 +1,7 @@
 import { Socket, io } from 'socket.io-client';
 import { logger } from '@rsdoctor/utils/logger';
 import { GlobalConfig } from '@rsdoctor/utils/common';
-import fs from 'fs';
+import fs from 'node:fs';
 
 const map: Record<string, Socket> = {};
 

--- a/packages/ai/src/server/tools.ts
+++ b/packages/ai/src/server/tools.ts
@@ -1,5 +1,5 @@
 import { SDK } from '@rsdoctor/types';
-import { sendRequest } from './socket.js';
+import { getWsUrl, sendRequest } from './socket.js';
 import { toolDescriptions } from '@/prompt/bundle.js';
 
 export enum Tools {
@@ -19,6 +19,7 @@ export enum Tools {
   GetMediaAssetPrompt = 'get_media_asset_prompt',
   getLoaderTimeForAllFiles = 'get_loader_time_all_files',
   getLoaderTimes = 'get_loader_times',
+  getPort = 'get_port',
 }
 
 // Define the type for the response of getAllChunks
@@ -193,8 +194,7 @@ export const getRuleInfo = async () => {
 };
 
 export const getDuplicatePackages = async () => {
-  const ruleInfo =
-    (await getRuleInfo()) as SDK.ServerAPI.InferResponseType<SDK.ServerAPI.API.GetOverlayAlerts>;
+  const ruleInfo = await sendRequest(SDK.ServerAPI.API.GetOverlayAlerts, {});
 
   if (!ruleInfo) {
     return {
@@ -329,4 +329,8 @@ export const getLoaderTimeForAllFiles = async (): Promise<
 
 export const getLoaderTimes = async () => {
   return await sendRequest(SDK.ServerAPI.API.GetDirectoriesLoaders, {});
+};
+
+export const getPort = async () => {
+  return getWsUrl();
 };

--- a/packages/ai/src/server/tools.ts
+++ b/packages/ai/src/server/tools.ts
@@ -186,7 +186,14 @@ export const getPackageInfo = async (): Promise<
 };
 
 export const getPackageDependency = async () => {
-  return await sendRequest(SDK.ServerAPI.API.GetPackageDependency, {});
+  const res = (await sendRequest(
+    SDK.ServerAPI.API.GetPackageDependency,
+    {},
+  )) as SDK.ServerAPI.InferResponseType<SDK.ServerAPI.API.GetPackageDependency>;
+  if (res.length > 300) {
+    return res.slice(0, 300);
+  }
+  return res;
 };
 
 export const getRuleInfo = async () => {

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -1,7 +1,7 @@
 import { Common, SDK, Thirdparty, Client } from '@rsdoctor/types';
 import { Server } from '@rsdoctor/utils/build';
 import serve from 'sirv';
-import { Bundle } from '@rsdoctor/utils/common';
+import { Bundle, GlobalConfig } from '@rsdoctor/utils/common';
 import assert from 'assert';
 import bodyParser from 'body-parser';
 import cors from 'cors';
@@ -87,6 +87,11 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
       port: this.port,
     });
     await this._socket.bootstrap();
+
+    GlobalConfig.writeMcpPort(this.port, this.sdk.name);
+    logger.info(
+      `Successfully wrote mcp.json for ${chalk.cyan(this.sdk.name)} builder`,
+    );
 
     this.disposed = false;
 
@@ -223,9 +228,11 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     const localhostUrl = `http://localhost:${this.port}${relativeUrl}`;
     await openBrowser(localhostUrl, !needEncodeURI);
     if (this._printServerUrl) {
-      logger.info(`Rsdoctor analyze server running on: ${chalk.cyan(url)}`);
       logger.info(
-        `Rsdoctor analyze server running on: ${chalk.cyan(localhostUrl)}`,
+        `Rsdoctor analyze server for ${chalk.bgGreen(`${this.sdk.name} builder`)} running on:  ${chalk.cyan(url)}`,
+      );
+      logger.info(
+        `Rsdoctor analyze server for ${chalk.bgGreen(`${this.sdk.name} builder`)} running on: ${chalk.cyan(localhostUrl)}`,
       );
     }
   }

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -9,7 +9,7 @@ import { PassThrough } from 'stream';
 import { Socket } from './socket';
 import { Router } from './router';
 import * as APIs from './apis';
-import { chalk, logger } from '@rsdoctor/utils/logger';
+import { chalk, debug, logger } from '@rsdoctor/utils/logger';
 import { openBrowser } from '@/sdk/utils/openBrowser';
 import path from 'path';
 import { getLocalIpAddress } from './utils';
@@ -89,8 +89,10 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     await this._socket.bootstrap();
 
     GlobalConfig.writeMcpPort(this.port, this.sdk.name);
-    logger.info(
-      `Successfully wrote mcp.json for ${chalk.cyan(this.sdk.name)} builder`,
+
+    debug(
+      () =>
+        `Successfully wrote mcp.json for ${chalk.cyan(this.sdk.name)} builder`,
     );
 
     this.disposed = false;
@@ -229,10 +231,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     await openBrowser(localhostUrl, !needEncodeURI);
     if (this._printServerUrl) {
       logger.info(
-        `Rsdoctor analyze server for ${chalk.bgGreen(`${this.sdk.name} builder`)} running on:  ${chalk.cyan(url)}`,
-      );
-      logger.info(
-        `Rsdoctor analyze server for ${chalk.bgGreen(`${this.sdk.name} builder`)} running on: ${chalk.cyan(localhostUrl)}`,
+        `${chalk.green(`${this.sdk.name} compiler's`)} analyzer running on: ${chalk.cyan(url)}`,
       );
     }
   }

--- a/packages/utils/src/common/data/index.ts
+++ b/packages/utils/src/common/data/index.ts
@@ -455,8 +455,20 @@ export class APIDataLoader {
         return this.loader.loadData('moduleGraph').then((moduleGraph) => {
           const { moduleId } =
             body as SDK.ServerAPI.InferRequestBodyType<SDK.ServerAPI.API.GetModuleIssuerPath>;
-          return (moduleGraph?.modules.find((m) => String(m.id) === moduleId)
-            ?.issuerPath || []) as R;
+          const modules = moduleGraph?.modules || [];
+          const issuerPath =
+            modules.find((m) => String(m.id) === moduleId)?.issuerPath || [];
+          if (
+            Array.isArray(issuerPath) &&
+            issuerPath.length > 0 &&
+            typeof issuerPath[0] === 'number'
+          ) {
+            return issuerPath
+              .map((id) => modules.find((m) => m.id === id)?.path)
+              .filter(Boolean) as R;
+          }
+
+          return issuerPath as R;
         });
 
       case SDK.ServerAPI.API.GetPackageInfo:

--- a/packages/utils/src/common/data/index.ts
+++ b/packages/utils/src/common/data/index.ts
@@ -488,6 +488,9 @@ export class APIDataLoader {
           const chunkInfo = chunks.find(
             (c) => c.id === chunkId,
           ) as SDK.ServerAPI.ExtendedChunkData;
+          if (!chunkInfo) {
+            return null as R;
+          }
           const chunkModules = modules
             .filter((m) => chunkInfo.modules.includes(m.id))
             .map((module) => {

--- a/packages/utils/src/common/global-config.ts
+++ b/packages/utils/src/common/global-config.ts
@@ -1,0 +1,87 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+/**
+ * Get the root directory of a monorepo or single repository
+ * @param {string} startPath - The starting path (usually a subpackage or any folder)
+ * @returns {string|null} The root directory path, or null if not found
+ */
+export function findRepoRoot(startPath?: string) {
+  let dir = path.resolve(startPath ?? process.cwd());
+
+  while (dir !== path.dirname(dir)) {
+    // 1. Lerna
+    if (fs.existsSync(path.join(dir, 'lerna.json'))) return dir;
+    // 2. pnpm
+    if (fs.existsSync(path.join(dir, 'pnpm-workspace.yaml'))) return dir;
+    // 3. Yarn/NPM workspaces
+    const pkgPath = path.join(dir, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+      if (pkg.workspaces) return dir;
+    }
+    // 4. lock file (single repository may also have)
+    if (
+      fs.existsSync(path.join(dir, 'yarn.lock')) ||
+      fs.existsSync(path.join(dir, 'pnpm-lock.yaml')) ||
+      fs.existsSync(path.join(dir, 'package-lock.json'))
+    ) {
+      return dir;
+    }
+    dir = path.dirname(dir);
+  }
+  return null;
+}
+
+/**
+ * @description Writes the builder port information to mcp.json.
+ *
+ * The mcp.json file uses the following format:
+ * {
+ *   portList: {
+ *     builder1: portNumber,
+ *     builder2: portNumber,
+ *   },
+ *   port: portNumber // The port of the last builder is used by default
+ * }
+ *
+ * @param {number} port - The port number to write.
+ * @param {string} [builderName] - The name of the builder.
+ */
+export function writeMcpPort(port: number, builderName?: string) {
+  const homeDir = os.homedir();
+  const rsdoctorDir = path.join(homeDir, '.cache/rsdoctor');
+  const mcpPortFilePath = path.join(rsdoctorDir, 'mcp.json');
+
+  if (!fs.existsSync(rsdoctorDir)) {
+    fs.mkdirSync(rsdoctorDir, { recursive: true });
+  }
+
+  let mcpJson: { portList: Record<string, number>; port: number } = {
+    portList: {},
+    port: 0,
+  };
+  if (fs.existsSync(mcpPortFilePath)) {
+    mcpJson = JSON.parse(fs.readFileSync(mcpPortFilePath, 'utf8'));
+  }
+
+  if (!mcpJson.portList) mcpJson.portList = {};
+  mcpJson.portList[builderName || 'builder'] = port;
+
+  // Use the latest generated port.
+  mcpJson.port = port;
+
+  fs.writeFileSync(mcpPortFilePath, JSON.stringify(mcpJson, null, 2), 'utf8');
+}
+
+/**
+ * @description Gets the path to the mcp.json file.
+ * @returns {string} The path to the mcp.json file.
+ */
+export function getMcpConfigPath() {
+  const homeDir = os.homedir();
+  const rsdoctorDir = path.join(homeDir, '.cache/rsdoctor');
+  const mcpPortFilePath = path.join(rsdoctorDir, 'mcp.json');
+  return mcpPortFilePath;
+}

--- a/packages/utils/src/common/global-config.ts
+++ b/packages/utils/src/common/global-config.ts
@@ -3,38 +3,6 @@ import path from 'path';
 import os from 'os';
 
 /**
- * Get the root directory of a monorepo or single repository
- * @param {string} startPath - The starting path (usually a subpackage or any folder)
- * @returns {string|null} The root directory path, or null if not found
- */
-export function findRepoRoot(startPath?: string) {
-  let dir = path.resolve(startPath ?? process.cwd());
-
-  while (dir !== path.dirname(dir)) {
-    // 1. Lerna
-    if (fs.existsSync(path.join(dir, 'lerna.json'))) return dir;
-    // 2. pnpm
-    if (fs.existsSync(path.join(dir, 'pnpm-workspace.yaml'))) return dir;
-    // 3. Yarn/NPM workspaces
-    const pkgPath = path.join(dir, 'package.json');
-    if (fs.existsSync(pkgPath)) {
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-      if (pkg.workspaces) return dir;
-    }
-    // 4. lock file (single repository may also have)
-    if (
-      fs.existsSync(path.join(dir, 'yarn.lock')) ||
-      fs.existsSync(path.join(dir, 'pnpm-lock.yaml')) ||
-      fs.existsSync(path.join(dir, 'package-lock.json'))
-    ) {
-      return dir;
-    }
-    dir = path.dirname(dir);
-  }
-  return null;
-}
-
-/**
  * @description Writes the builder port information to mcp.json.
  *
  * The mcp.json file uses the following format:

--- a/packages/utils/src/common/index.ts
+++ b/packages/utils/src/common/index.ts
@@ -14,3 +14,4 @@ export * as Alerts from './alerts';
 export * as Rspack from './rspack';
 export * as Package from './package';
 export * as Lodash from './lodash';
+export * as GlobalConfig from './global-config';


### PR DESCRIPTION
## Summary
feat: rsdoctor mcp get auto port

This pull request introduces functionality to manage and retrieve MCP server port information, along with several related enhancements and fixes. The changes include adding utilities for handling MCP configuration (`mcp.json`), updating server and socket logic to use these utilities, and improving error handling and data processing in other parts of the codebase.

### MCP Port Management Enhancements:
* Added `writeMcpPort` and `getMcpConfigPath` utilities in `packages/utils/src/common/global-config.ts` to manage MCP port configuration in a `mcp.json` file. These utilities allow storing and retrieving port information for different builders.
* Updated `RsdoctorServer` in `packages/sdk/src/sdk/server/index.ts` to write the MCP port to `mcp.json` upon server initialization and log the builder-specific server information. [[1]](diffhunk://#diff-a63f672ceb1546c9152b900267dfea885d31cdb941e992c8088255667d66eff0R91-R95) [[2]](diffhunk://#diff-a63f672ceb1546c9152b900267dfea885d31cdb941e992c8088255667d66eff0L226-R235)
* Implemented `getMcpPort` in `packages/ai/src/server/socket.ts` to read the MCP port from `mcp.json`, supporting builder-specific ports. This function is used in the `getPortFromArgs` method to determine the server port dynamically. [[1]](diffhunk://#diff-ce9c8e1083acf01954164cd0a0a195be294c5902380ff8b2589263b168211ed8R58-R76) [[2]](diffhunk://#diff-ce9c8e1083acf01954164cd0a0a195be294c5902380ff8b2589263b168211ed8R24-R38)

### Server and Tooling Updates:
* Added a new `getPort` tool in `packages/ai/src/server/tools.ts` to retrieve the MCP server port dynamically. This tool is registered in the server and integrated with the `getWsUrl` function. [[1]](diffhunk://#diff-477862e067ec18e1f9585e30dbe52d64a70e7384da1c7e81ea19a5774522ed53R19) [[2]](diffhunk://#diff-477862e067ec18e1f9585e30dbe52d64a70e7384da1c7e81ea19a5774522ed53R278-R291) [[3]](diffhunk://#diff-611c96efd910e6666b3694e487d95acc7687fe16adcd5f094228f1fd39a50e5dR340-R343)
* Extended the `Tools` enum in `packages/ai/src/server/tools.ts` to include `getPort`.

### Data Processing and Error Handling Improvements:
* Enhanced `APIDataLoader` in `packages/utils/src/common/data/index.ts` to handle cases where module or chunk information is missing, improving robustness. [[1]](diffhunk://#diff-47a87880c655366ae4c8e71e5c4c86c29f71e9bc5e160668773d23afc1e44bbdL458-R471) [[2]](diffhunk://#diff-47a87880c655366ae4c8e71e5c4c86c29f71e9bc5e160668773d23afc1e44bbdR503-R505)
* Limited the response size of `getPackageDependency` in `packages/ai/src/server/tools.ts` to 300 items to avoid processing overly large datasets.

### Miscellaneous Changes:
* Added `GlobalConfig` export in `packages/utils/src/common/index.ts` to make the new MCP utilities accessible to other modules.
* Updated imports across files to integrate the new utilities and methods. [[1]](diffhunk://#diff-ce9c8e1083acf01954164cd0a0a195be294c5902380ff8b2589263b168211ed8R3-R4) [[2]](diffhunk://#diff-611c96efd910e6666b3694e487d95acc7687fe16adcd5f094228f1fd39a50e5dL2-R2) [[3]](diffhunk://#diff-a63f672ceb1546c9152b900267dfea885d31cdb941e992c8088255667d66eff0L4-R4)
## Related Links

<!--- Provide links of related issues or pages -->
