### PR TITLE
fix(rspack-plugin): mark @rspack/core as optional peer

### DIFF
--- a/packages/rspack-plugin/package.json
+++ b/packages/rspack-plugin/package.json
@@ -37,6 +37,11 @@
   "peerDependencies": {
     "@rspack/core": "*"
   },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/rspack-plugin/src/multiple.ts
+++ b/packages/rspack-plugin/src/multiple.ts
@@ -4,7 +4,7 @@ import type { RsdoctorMultiplePluginOptions } from '@rsdoctor/core';
 
 import { RsdoctorRspackPlugin } from './plugin';
 import { normalizeUserConfig } from '@rsdoctor/core/plugins';
-import { Compiler } from '@rspack/core';
+import type { Compiler } from '@rspack/core';
 
 let globalController: RsdoctorSDKController | undefined;
 


### PR DESCRIPTION
## Summary

Mark `@rspack/core` as optional peer dependency to fix the "unmet peer dependency" warning with Rsbuild.

## Related Links

- see https://github.com/web-infra-dev/rsbuild/discussions/5192
