### PR TITLE
fix: the rsdoctor mcp-server change the builder property to compiler

### DIFF
--- a/packages/ai/src/server/socket.ts
+++ b/packages/ai/src/server/socket.ts
@@ -21,13 +21,13 @@ export const createSocket = (url: string): Socket => {
 export function getPortFromArgs(): number {
   const args = process.argv.slice(2); // Skip the first two elements
   const portIndex = args.indexOf('--port');
-  const builderIndex = args.indexOf('--builder');
+  const compilerIndex = args.indexOf('--compiler');
   if (portIndex !== -1 && args[portIndex + 1]) {
     return parseInt(args[portIndex + 1], 10);
   }
   if (portIndex === -1) {
     const port = getMcpPort(
-      builderIndex !== -1 ? args[builderIndex + 1] : undefined,
+      compilerIndex !== -1 ? args[compilerIndex + 1] : undefined,
     );
     if (port) {
       return port;
@@ -56,7 +56,7 @@ export const sendRequest = async (api: string, params = {}) => {
   return res;
 };
 
-export const getMcpPort = (builder?: string) => {
+export const getMcpPort = (compiler?: string) => {
   const mcpPortFilePath = GlobalConfig.getMcpConfigPath();
 
   if (!fs.existsSync(mcpPortFilePath)) {
@@ -65,10 +65,10 @@ export const getMcpPort = (builder?: string) => {
 
   const mcpJson = JSON.parse(fs.readFileSync(mcpPortFilePath, 'utf8'));
 
-  if (builder) {
-    const builderPort = mcpJson.portList[builder];
-    if (builderPort) {
-      return builderPort;
+  if (compiler) {
+    const compilerPort = mcpJson.portList[compiler];
+    if (compilerPort) {
+      return compilerPort;
     }
   }
 


### PR DESCRIPTION
## Summary
fix: the rsdoctor mcp-server change the builder property to compiler


## Related Links
#1082 
<!--- Provide links of related issues or pages -->
