### PR TITLE
docs: add Rstest to homepage

### DIFF
--- a/packages/document/i18n.json
+++ b/packages/document/i18n.json
@@ -11,14 +11,6 @@
     "en": "Visualize the building process",
     "zh": "让构建过程可视化"
   },
-  "toolStackTitle": {
-    "en": "Rstack",
-    "zh": "Rstack"
-  },
-  "toolStackDesc": {
-    "en": "High-performance toolchain built around Rspack to boost modern web development",
-    "zh": "围绕 Rspack 打造的高性能工具链，助力现代 Web 开发"
-  },
   "frameworkAgnostic": {
     "en": "Unlimited Framework",
     "zh": "框架无关"

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -39,7 +39,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@rstack-dev/doc-ui": "1.7.4",
+    "@rstack-dev/doc-ui": "1.10.0",
     "react-markdown": "^9.1.0",
     "rspress": "2.0.0-beta.3"
   }

--- a/packages/document/theme/components/ToolStack.tsx
+++ b/packages/document/theme/components/ToolStack.tsx
@@ -1,26 +1,12 @@
-import {
-  containerStyle,
-  descStyle,
-  innerContainerStyle,
-  titleAndDescStyle,
-  titleStyle,
-} from '@rstack-dev/doc-ui/section-style';
+import { containerStyle } from '@rstack-dev/doc-ui/section-style';
 import { ToolStack as BaseToolStack } from '@rstack-dev/doc-ui/tool-stack';
 import { useLang } from 'rspress/runtime';
-import { useI18n } from 'rspress/runtime';
 
 export function ToolStack() {
-  const t = useI18n<typeof import('i18n')>();
   const lang = useLang();
   return (
     <section className={containerStyle}>
-      <div className={innerContainerStyle}>
-        <div className={titleAndDescStyle}>
-          <h1 className={titleStyle}>{t('toolStackTitle')}</h1>
-          <p className={descStyle}>{t('toolStackDesc')}</p>
-        </div>
-        <BaseToolStack lang={lang} />
-      </div>
+      <BaseToolStack lang={lang} />
     </section>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -803,8 +803,8 @@ importers:
   packages/document:
     dependencies:
       '@rstack-dev/doc-ui':
-        specifier: 1.7.4
-        version: 1.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.10.0
+        version: 1.10.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-markdown:
         specifier: ^9.1.0
         version: 9.1.0(@types/react@18.3.21)(react@18.3.1)
@@ -4031,8 +4031,8 @@ packages:
     resolution: {integrity: sha512-0hSlQkY02ybmly/hZJddPBGt4KbjR4HXft3uIarjjNtY2s4sbZo7tE2GjyDPdaClBrSCgwzgRIC8PJuizdHQPw==}
     engines: {node: '>=18.0.0'}
 
-  '@rstack-dev/doc-ui@1.7.4':
-    resolution: {integrity: sha512-hv2yN06dOwftQqRGIuXk7ij1phkdEFCg9qYEOCz0s2dTAtjmI4OaYlLLyAM1m2ip6/ivx8i726fKgUD+Noen2Q==}
+  '@rstack-dev/doc-ui@1.10.0':
+    resolution: {integrity: sha512-PRACISyGl8vnqQ1occngpVIfDT0ShKtpi+Tb/HIG7KK+WBV4DaZeNsN1JC5+LHWObEgYsyemCTwxHA9+i3PKIw==}
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
@@ -6255,8 +6255,8 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
-  framer-motion@12.7.3:
-    resolution: {integrity: sha512-dNT4l5gEnUo2ytXLUBUf6AI21dZ77TMclDKE3ElaIHZ8m90nJ/NCcExW51zdSIaS0RhAS5iXcF7bEIxZe8XG2g==}
+  framer-motion@12.11.4:
+    resolution: {integrity: sha512-kyE5oWZCUxhDb7LtpEyyadNThJJvoE8a6bfUTBqz++zw3XxDOosPAvw1lqNhYbjOgy57YuAlJ5qG/Cx5BigiEQ==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -7816,11 +7816,11 @@ packages:
   monaco-editor@0.49.0:
     resolution: {integrity: sha512-2I8/T3X/hLxB2oPHgqcNYUVdA/ZEFShT7IAujifIPMfKkNbLOqY8XCoyHCXrsdjb36dW9MwoTwBCFpXKMwNwaQ==}
 
-  motion-dom@12.7.3:
-    resolution: {integrity: sha512-IjMt1YJHrvyvruFvmpmd6bGXXGCvmygrnvSb3aZ8KhOzF4H3PulU+cMBzH+U8TBJHjC/mnmJFRIA1Cu4vBfcBA==}
+  motion-dom@12.11.4:
+    resolution: {integrity: sha512-1z/qYsrDjSx5QjOH8GfJ2RfFBvEzI2gdAEt2zNW+f7QkLlqjM3sQieESJr5+QtVmvD81qPANM7t97ROixKIt9Q==}
 
-  motion-utils@12.7.2:
-    resolution: {integrity: sha512-XhZwqctxyJs89oX00zn3OGCuIIpVevbTa+u82usWBC6pSHUd2AoNWiYa7Du8tJxJy9TFbZ82pcn5t7NOm1PHAw==}
+  motion-utils@12.9.4:
+    resolution: {integrity: sha512-BW3I65zeM76CMsfh3kHid9ansEJk9Qvl+K5cu4DVHKGsI52n76OJ4z2CUJUV+Mn3uEP9k1JJA3tClG0ggSrRcg==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -14406,9 +14406,9 @@ snapshots:
       react-dom: 18.3.1(react@19.1.0)
       react-syntax-highlighter: 15.6.1(react@19.1.0)
 
-  '@rstack-dev/doc-ui@1.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@rstack-dev/doc-ui@1.10.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      framer-motion: 12.7.3(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      framer-motion: 12.11.4(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react
@@ -17159,10 +17159,10 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
-  framer-motion@12.7.3(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  framer-motion@12.11.4(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      motion-dom: 12.7.3
-      motion-utils: 12.7.2
+      motion-dom: 12.11.4
+      motion-utils: 12.9.4
       tslib: 2.8.1
     optionalDependencies:
       '@emotion/is-prop-valid': 1.3.1
@@ -19301,11 +19301,11 @@ snapshots:
 
   monaco-editor@0.49.0: {}
 
-  motion-dom@12.7.3:
+  motion-dom@12.11.4:
     dependencies:
-      motion-utils: 12.7.2
+      motion-utils: 12.9.4
 
-  motion-utils@12.7.2: {}
+  motion-utils@12.9.4: {}
 
   mri@1.2.0: {}
 


### PR DESCRIPTION
## Summary

- Update @rstack-dev/doc-ui to 1.10.0 to add Rstest to homepage.
- This update also includes some UI and text improvements.

Related: https://github.com/rspack-contrib/rstack-doc-ui/releases

## Rstack List

### Before

<img width="1472" alt="Screenshot 2025-05-15 at 22 09 54" src="https://github.com/user-attachments/assets/984c7df8-05f3-41ea-a743-8384400cfe72" />

### After

![image](https://github.com/user-attachments/assets/965ec88d-8087-48ed-b8ee-a897ed76fa1d)


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
