### PR TITLE
feat: add tooltips for bundle size tags

### DIFF
--- a/packages/components/src/pages/BundleSize/components/asset.tsx
+++ b/packages/components/src/pages/BundleSize/components/asset.tsx
@@ -53,6 +53,7 @@ const tagStyle = {
   margin: 'none',
   marginInlineEnd: 0,
 };
+
 const EmptyCodeItem = () => (
   <Empty
     description={`Do not have the module code.
@@ -326,6 +327,98 @@ export const ModulesStatistics: React.FC<{
   );
 };
 
+const ConcatenatedTag = ({ moduleCount }: { moduleCount: number }) => {
+  return (
+    <Tooltip
+      title={
+        <Space>
+          <Typography.Text style={{ color: 'inherit' }}>
+            This is a concatenated container module that includes {moduleCount}{' '}
+            modules
+          </Typography.Text>
+        </Space>
+      }
+    >
+      <Tag color="blue" style={tagStyle}>
+        concatenated container
+      </Tag>
+    </Tooltip>
+  );
+};
+
+const TotalBundledSizeTag = ({ size }: { size: number }) => {
+  return (
+    <Tooltip
+      title={
+        <Space>
+          <Typography.Text style={{ color: 'inherit' }}>
+            The total output size of all the files in this folder. If you
+            enabled minification, this value shows the minified size.
+          </Typography.Text>
+        </Space>
+      }
+    >
+      <Tag style={tagStyle} color={'geekblue'}>
+        {`bundled size: ${formatSize(size)}`}
+      </Tag>
+    </Tooltip>
+  );
+};
+
+const BundledSizeTag = ({ size }: { size: number }) => {
+  return (
+    <Tooltip
+      title={
+        <Space>
+          <Typography.Text style={{ color: 'inherit' }}>
+            The final output size of this file. If you enabled minification,
+            this value shows the minified size.
+          </Typography.Text>
+        </Space>
+      }
+    >
+      <Tag color={'geekblue'}>{`bundled size: ${formatSize(size)}`}</Tag>
+    </Tooltip>
+  );
+};
+
+const TotalSourceSizeTag = ({ size }: { size: number }) => {
+  return (
+    <Tooltip
+      title={
+        <Space>
+          <Typography.Text style={{ color: 'inherit' }}>
+            The total original size of all the files in this folder, before any
+            transformations and minification.
+          </Typography.Text>
+        </Space>
+      }
+    >
+      <Tag
+        style={tagStyle}
+        color={'cyan'}
+      >{`source size: ${formatSize(size)}`}</Tag>
+    </Tooltip>
+  );
+};
+
+const SourceSizeTag = ({ size }: { size: number }) => {
+  return (
+    <Tooltip
+      title={
+        <Space>
+          <Typography.Text style={{ color: 'inherit' }}>
+            The original size of this file, before any transformations and
+            minification.
+          </Typography.Text>
+        </Space>
+      }
+    >
+      <Tag color={'cyan'}>{`source size: ${formatSize(size)}`}</Tag>
+    </Tooltip>
+  );
+};
+
 export const AssetDetail: React.FC<{
   asset: SDK.AssetData;
   chunks: SDK.ChunkData[];
@@ -406,49 +499,28 @@ export const AssetDetail: React.FC<{
                 <Tooltip
                   title={
                     <Space direction="vertical">
-                      <Tag color={'orange'}>
-                        {`Bundled Size: ${formatSize(parsedSize)}`}
-                      </Tag>
-                      <Tag color={'volcano'}>
-                        {`Source Size: ${formatSize(sourceSize)}`}
-                      </Tag>
+                      <BundledSizeTag size={parsedSize} />
+                      <SourceSizeTag size={sourceSize} />
                     </Space>
                   }
                   color={'white'}
                 >
-                  <Tag color={'purple'} style={tagStyle}>
-                    {`Bundled Size: ${formatSize(parsedSize)}`}
-                  </Tag>
+                  <BundledSizeTag size={parsedSize} />
                 </Tooltip>
               ) : sourceSize !== 0 ? (
                 // fallback to display tag for source size
-                <Tag color={'geekblue'}>
-                  {`Source Size: ${formatSize(sourceSize)}`}
-                </Tag>
+                <SourceSizeTag size={sourceSize} />
               ) : null}
               {isConcatenation ? (
-                <Tooltip
-                  title={
-                    <Space>
-                      <Typography.Text style={{ color: 'inherit' }}>
-                        this is a concatenated module, it contains{' '}
-                        {mod.modules?.length} modules
-                      </Typography.Text>
-                    </Space>
-                  }
-                >
-                  <Tag color="green" style={tagStyle}>
-                    concatenated
-                  </Tag>
-                </Tooltip>
+                <ConcatenatedTag moduleCount={mod.modules?.length || 0} />
               ) : null}
               {containedOtherModules && containedOtherModules.length ? (
                 <Tooltip
                   title={
                     <Space direction="vertical">
                       <Typography.Text style={{ color: 'inherit' }}>
-                        this is a concatenated module, it is be contained in
-                        these modules below:
+                        This module is concatenated into another container
+                        module:
                       </Typography.Text>
                       {containedOtherModules.map(({ id, path }) => {
                         if (isJsDataUrl(path)) {
@@ -522,17 +594,11 @@ export const AssetDetail: React.FC<{
               <Space>
                 {parsedSize > 0 ? (
                   <>
-                    <Tag style={tagStyle} color={'orange'}>
-                      {`Bundled: ${formatSize(parsedSize)}`}
-                    </Tag>
-                    <Tag style={tagStyle} color={'lime'}>
-                      {`Source: ${formatSize(sourceSize)}`}
-                    </Tag>
+                    <TotalBundledSizeTag size={parsedSize} />
+                    <TotalSourceSizeTag size={sourceSize} />
                   </>
                 ) : (
-                  <Tag style={tagStyle} color={'lime'}>
-                    {`Source: ${formatSize(sourceSize)}`}
-                  </Tag>
+                  <TotalSourceSizeTag size={sourceSize} />
                 )}
               </Space>
             </div>

--- a/packages/document/docs/en/guide/usage/bundle-size.mdx
+++ b/packages/document/docs/en/guide/usage/bundle-size.mdx
@@ -19,8 +19,8 @@ Click on the **"Bundle Size"** option in the navigation bar to view the Bundle a
 
 - **`Assets`**: Resources refer to images, fonts, media, and other file types. They are the files that ultimately exist in the output folder. Each Chunk has corresponding [Assets resources](https://webpack.js.org/concepts/under-the-hood/#chunks).
 - **`Module`**: One or more Modules combine to form a Chunk. For more information about Module types, please refer to [Rspack Modules](https://www.rspack.rs/api/modules.html) and [Webpack Modules](https://webpack.js.org/concepts/modules/#what-is-a-webpack-module).
-- **`Bundle Size`**: The final packaged size of the resource artifact, which is the final size after being processed by the bundler.
-- **`Module Bundled Source & Size`**: **Module Parsed Source** refers to the final code fragment of the **Module** in the packaged artifact, and **Module Parsed Size** refers to the size of the final code fragment of the **Module** in the packaged artifact.
+- **`Source Size`**: The original size of the file, before any transformations and minification.
+- **`Bundle Size`**: The final output size of the files. If you enabled minification, this value shows the minified size.
 - **`Package Count`**: The number of third-party packages.
 - **`Initial Chunk`**: The **initial** chunk is the main chunk of the entry point. This chunk contains all the modules specified by the entry point and their dependencies, unlike the **chunks** for "on-demand loading".
   - For more information about Initial Chunk, please refer to [Initial Chunk Introduction](https://webpack.js.org/concepts/under-the-hood/#chunks).

--- a/packages/document/docs/zh/guide/usage/bundle-size.mdx
+++ b/packages/document/docs/zh/guide/usage/bundle-size.mdx
@@ -19,8 +19,8 @@
 
 - **`Assets`**：资源是对图像、字体、媒体和其他文件类型的统称，是最终存在于输出文件夹内的文件，同时，每个 Chunk 都有对应的 [Assets 资源](https://webpack.js.org/concepts/under-the-hood/#chunks)。
 - **`Module`**：一个或多个 Module 组合成了 Chunk。有关 Module 类型的详细信息，请参阅 [Rspack Modules](https://www.rspack.rs/api/modules.html) 和 [Webpack Modules](https://webpack.js.org/concepts/modules/#what-is-a-webpack-module)。
-- **`Bundle Size`**：资源产物的最终打包大小，这是打包工具处理后的最终大小。
-- **`Module Bundled Source & Size`**：**Module Parsed Source** 是指 **Module** 在打包产物中的最终代码片段，**Module Parsed Size** 是指 **Module** 在打包产物中的最终代码片段的大小。
+- **`Source Size`**：文件的原始大小，未经过任何转换和压缩。
+- **`Bundle Size`**：文件最终输出的大小。如果开启了压缩，这个值代表压缩后的大小。
 - **`Package Count`**：第三方包的数量。
 - **`Initial Chunk`**: **initial(初始化)** 是入口起点的主 Chunk，该 chunk 包含入口起点指定的所有模块及其依赖项，与「**按需加载**」的 **Chunk** 资源不同。
   - 有关 Initial Chunk 的详细信息，请参阅 [Initial Chunk 介绍](https://webpack.js.org/concepts/under-the-hood/#chunks)。


### PR DESCRIPTION
## Summary

This PR introduces improvements to the bundle size page by refactoring tag components for better modularity and readability. 

Added reusable components like `ConcatenatedTag`, `BundledSizeTag`, `TotalBundledSizeTag`, `SourceSizeTag`, and `TotalSourceSizeTag` to encapsulate tooltip.

## Preview

<img width="1064" alt="Screenshot 2025-06-12 at 17 01 50" src="https://github.com/user-attachments/assets/a309241e-3878-4185-a868-4b5a8b906919" />

<img width="1089" alt="Screenshot 2025-06-12 at 17 01 56" src="https://github.com/user-attachments/assets/c3b41f83-59fd-493a-8408-c0805801e93e" />

<img width="1048" alt="Screenshot 2025-06-12 at 17 02 02" src="https://github.com/user-attachments/assets/d20caa88-b07b-47e5-a4a4-d15fa410cd6a" />

<img width="1055" alt="Screenshot 2025-06-12 at 17 02 06" src="https://github.com/user-attachments/assets/f1e5f0ff-2600-467c-86d3-b07d8012ecdd" />
