### PR TITLE
tweaks(core): optimize the normalizeUserConfig and supply tests

### DIFF
--- a/packages/core/tests/build/utils.ts
+++ b/packages/core/tests/build/utils.ts
@@ -4,7 +4,7 @@ import { removeAbsModulePath } from '../common/utils';
 import {
   Chunks,
   ModuleGraph as ModuleGraphBuildUtils,
-} from '../../src/build-utils/build';
+} from '@/build-utils/build';
 import { SDK, Plugin } from '@rsdoctor/types';
 
 export class ModuleGraphTestPlugin {

--- a/packages/core/tests/build/utils/config.test.ts
+++ b/packages/core/tests/build/utils/config.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest';
+import { normalizeUserConfig } from '../../../src/inner-plugins/utils/config';
+import { SDK } from '@rsdoctor/types';
+
+describe('normalizeUserConfig', () => {
+  it('should use all default values when config is empty', () => {
+    const result = normalizeUserConfig();
+    expect(result.linter).toBeDefined();
+    expect(result.features).toEqual({
+      bundle: true,
+      lite: false,
+      loader: true,
+      plugins: true,
+      resolver: false,
+      treeShaking: false,
+    });
+    expect(result.output.reportCodeType).toBeDefined();
+    expect(result.output.compressData).toBe(true);
+    expect(result.mode).toBe('normal');
+  });
+
+  it('should respect custom features array', () => {
+    const result = normalizeUserConfig({
+      features: ['loader', 'plugins', 'lite'],
+    });
+    expect(result.features.loader).toBe(true);
+    expect(result.features.plugins).toBe(true);
+    expect(result.features.lite).toBe(true);
+    expect(result.features.resolver).toBe(false);
+    expect(result.output.reportCodeType).toBe(SDK.ToDataType.NoSource);
+  });
+
+  it('should respect custom features object', () => {
+    const result = normalizeUserConfig({
+      features: { loader: false, plugins: true, lite: true },
+    });
+    expect(result.features.loader).toBe(false);
+    expect(result.features.plugins).toBe(true);
+    expect(result.features.lite).toBe(true);
+  });
+
+  it('should normalize output.reportCodeType according to mode', () => {
+    const result = normalizeUserConfig({
+      output: { reportCodeType: { noCode: true } },
+      mode: 'brief',
+    });
+    expect(result.output.reportCodeType).toBe(SDK.ToDataType.NoCode);
+  });
+
+  it('should use default supports when not provided', () => {
+    const result = normalizeUserConfig();
+    expect(result.supports).toEqual({
+      parseBundle: true,
+      banner: undefined,
+      generateTileGraph: true,
+      gzip: false,
+    });
+  });
+
+  it('should respect custom supports', () => {
+    const customSupports = {
+      parseBundle: false,
+      banner: true,
+      generateTileGraph: false,
+      gzip: true,
+    };
+    const result = normalizeUserConfig({ supports: customSupports });
+    expect(result.supports).toEqual(customSupports);
+  });
+
+  describe('output.reportCodeType', () => {
+    it('should return NoCode when mode is brief regardless of reportCodeType', () => {
+      const result = normalizeUserConfig({
+        mode: 'brief',
+        output: {
+          reportCodeType: {
+            noModuleSource: true,
+            noAssetsAndModuleSource: false,
+            noCode: false,
+          },
+        },
+      });
+      expect(result.output.reportCodeType).toBe(SDK.ToDataType.NoCode);
+    });
+
+    it('should return NoSource when mode is lite and no special flags', () => {
+      const result = normalizeUserConfig({
+        mode: 'lite',
+        output: {
+          reportCodeType: {
+            noModuleSource: false,
+            noAssetsAndModuleSource: false,
+            noCode: false,
+          },
+        },
+      });
+      expect(result.output.reportCodeType).toBe(SDK.ToDataType.NoSource);
+    });
+
+    it('should return NoSourceAndAssets when mode is lite and noAssetsAndModuleSource is true', () => {
+      const result = normalizeUserConfig({
+        mode: 'lite',
+        output: {
+          reportCodeType: {
+            noModuleSource: false,
+            noAssetsAndModuleSource: true,
+            noCode: false,
+          },
+        },
+      });
+      expect(result.output.reportCodeType).toBe(
+        SDK.ToDataType.NoSourceAndAssets,
+      );
+    });
+
+    it('should respect noCode flag in normal mode', () => {
+      const result = normalizeUserConfig({
+        mode: 'normal',
+        output: {
+          reportCodeType: {
+            noModuleSource: false,
+            noAssetsAndModuleSource: false,
+            noCode: true,
+          },
+        },
+      });
+      expect(result.output.reportCodeType).toBe(SDK.ToDataType.NoCode);
+    });
+
+    it('should respect noAssetsAndModuleSource flag in normal mode', () => {
+      const result = normalizeUserConfig({
+        mode: 'normal',
+        output: {
+          reportCodeType: {
+            noModuleSource: false,
+            noAssetsAndModuleSource: true,
+            noCode: false,
+          },
+        },
+      });
+      expect(result.output.reportCodeType).toBe(
+        SDK.ToDataType.NoSourceAndAssets,
+      );
+    });
+
+    it('should respect noModuleSource flag in normal mode', () => {
+      const result = normalizeUserConfig({
+        mode: 'normal',
+        output: {
+          reportCodeType: {
+            noModuleSource: true,
+            noAssetsAndModuleSource: false,
+            noCode: false,
+          },
+        },
+      });
+      expect(result.output.reportCodeType).toBe(SDK.ToDataType.NoSource);
+    });
+
+    it('should return Normal when no flags are set in normal mode', () => {
+      const result = normalizeUserConfig({
+        mode: 'normal',
+        output: {
+          reportCodeType: {
+            noModuleSource: false,
+            noAssetsAndModuleSource: false,
+            noCode: false,
+          },
+        },
+      });
+      expect(result.output.reportCodeType).toBe(SDK.ToDataType.Normal);
+    });
+  });
+});

--- a/packages/core/tests/build/utils/parseBundle.test.ts
+++ b/packages/core/tests/build/utils/parseBundle.test.ts
@@ -3,7 +3,6 @@ import fs from 'fs';
 import os from 'os';
 import { describe, it, expect } from 'vitest';
 import { parseBundle } from '@/build-utils/build/utils/parseBundle';
-import { SDK } from '@rsdoctor/types';
 
 const BUNDLES_DIR = `${__dirname}/bundles`;
 

--- a/packages/core/tests/tsconfig.json
+++ b/packages/core/tests/tsconfig.json
@@ -2,10 +2,11 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./",
+    "rootDir": "../",
     "paths": {
-      "@/*": ["../src/*"],
+      "@/*": ["../src/*"]
     }
   },
-  "include": ["./**/*.ts"],
+  "include": ["./**/*.ts", "../src/**/*.ts"],
   "exclude": ["../**/node_modules"]
 }


### PR DESCRIPTION
## Summary
tweaks(core): optimize the normalizeUserConfig and supply some tests. **No impact on users.**

This pull request refactors the `normalizeUserConfig` function and related utilities, introduces helper functions for default values, and adds comprehensive test coverage. It also includes minor updates to imports and configuration files.

### Refactoring and Code Simplification:
* Refactored `normalizeUserConfig` in `packages/core/src/inner-plugins/utils/config.ts` by extracting default value logic into new helper functions: `getDefaultOutput`, `getDefaultSupports`, `normalizeFeatures`, and `normalizeLinter`. This improves readability and modularity. [[1]](diffhunk://#diff-0bc1a98d5cf2810e43077f2e07c17dced9b44cbbb6f1f19e517f4bdcfd222015L25-R57) [[2]](diffhunk://#diff-0bc1a98d5cf2810e43077f2e07c17dced9b44cbbb6f1f19e517f4bdcfd222015R67-R117)
* Simplified the `normalizeReportType` function by replacing the `switch` statement with concise conditional logic.

### Test Coverage:
* Added a new test suite for `normalizeUserConfig` in `packages/core/tests/build/utils/config.test.ts`, covering various scenarios such as default values, custom configurations, and `output.reportCodeType` behavior across modes.


## Related Links

<!--- Provide links of related issues or pages -->
