### PR TITLE
feat: rsdoctor mcp supports bailout reason analysis

### DIFF
--- a/packages/ai/src/prompt/bundle.ts
+++ b/packages/ai/src/prompt/bundle.ts
@@ -2,42 +2,36 @@ export const toolDescriptions = {
   getAllChunks: 'get all chunks',
   getChunkById:
     'get chunk by id, if chunk not found, return `Chunk not found`, and stop the execution',
-  getModuleById: `get module detail by id：
-    - id: the id of the module
-    - issuerPath: the referrer of the module, the issuerPath is a array of module id, the module id is the id of the module that depends on the module.
-    - dependencies: the complete dependencies of the module, when user ask the dependencies of the module, 
-      please return the dependencies of the module first, not return the allDependencies of the module. 
-      But if user ask the detail dependencies of the module, please return the allDependencies of the module.
-    - allDependencies: the complete dependencies of the module. 
-      when user ask the dependencies of the module, please return the dependencies of the module first, not return the allDependencies of the module. 
-    - chunks: an array of chunk identifiers associated with the module.
-    - imported: an array of module identifiers on which the module depends.
-    - isEntry: indicates if the module is an entry module.
-    - size: the size of the module.
-    - layer: the layer of the module.
-    - modules: connected base subpackage module numbers.
-    - rootModule: the root module.
-    - webpackId: the module's unique identifier in webpack.
+  getModuleById: `
+    get module detail by id (Rspack or Webpack module id)：
+    - id: the id of the module (corresponds to Rspack or Webpack's internal module id)
+    - issuerPath: the referrer chain (array of module ids, from entry to this module)
+    - dependencies: direct dependencies (array of module ids this module imports/requires)
+    - allDependencies: all transitive dependencies (if user asks for detail)
+    - chunks: array of chunk ids this module belongs to
+    - imported: array of module ids that import this module
+    - isEntry: whether this module is an entry point
+    - size: { sourceSize, transformedSize, parsedSize }
+    - layer, modules, rootModule, webpackId: advanced info
+    - bailoutReason: if present, the reason why this module is not tree-shaken or optimized away (e.g. "side effects", "dynamic import", "unknown exports", etc.)
+    - Please use Rspack or Webpack's terminology for all fields.
+    - If user asks for "why not tree-shaken", always return bailoutReason and explain in plain language.
+    - If user asks for "who imported this module", return issuerPath as a dependency chain.
+    - If user asks for "all dependencies", return allDependencies.
   `,
-  getModuleByPath: `get module detail by module name or path, if find multiple modules match the name or path, return all matched modules path, stop execution, and let user select the module path。
-    - id: the id of the module
-    - issuerPath: the referrer of the module, the issuerPath is a array of module id, the module id is the id of the module that depends on the module.
-    - dependencies: the complete dependencies of the module, when user ask the dependencies of the module, 
-      please return the dependencies of the module first, not return the allDependencies of the module. 
-      But if user ask the detail dependencies of the module, please return the allDependencies of the module.
-    - allDependencies: the complete dependencies of the module. 
-      when user ask the dependencies of the module, please return the dependencies of the module first, not return the allDependencies of the module. 
-    - chunks: an array of chunk identifiers associated with the module.
-    - imported: an array of module identifiers on which the module depends.
-    - isEntry: indicates if the module is an entry module.
-    - size: the size of the module.
-    - layer: the layer of the module.
-    - modules: connected base subpackage module numbers.
-    - rootModule: the root module.
-    - webpackId: the module's unique identifier in webpack.
+  getModuleByPath: `
+    get module detail by module name or path (absolute or relative, as in Rspack or Webpack stats)
+    - If multiple modules match, return all matched module paths and stop, let user select.
+    - Otherwise, return the same fields as getModuleById.
+    - Always include bailoutReason if present.
+    - If user asks for "why is this module in the bundle", show the full issuerPath chain.
+    - If user asks for "why not tree-shaken", show bailoutReason and explain.
   `,
-  getModuleIssuerPath: `get module issuer path, issuer path is the path of the module that depends on the module.Please draw the returned issuer path as a dependency diagram.
-  - The values in the array are module ids, please get the detailed module information based on the module id
+  getModuleIssuerPath: `
+    get module issuer path (who imported this module, recursively)
+    - Return as a dependency chain (array of module ids from entry to this module)
+    - If possible, render as a tree or graph for clarity.
+    - For each module in the chain, show its path and (if present) bailoutReason.
   `,
   getPackageInfo: 'get package info',
   getPackageDependency: 'get package dependency',
@@ -181,5 +175,33 @@ export const toolDescriptions = {
       - GetSimilarPackages to check if there are similar packages that need optimization
       - getMediaAssetPrompt to check if media assets need optimization
       - GetAllChunks to check if there are oversized resources and provide splitChunk suggestions
+  `,
+
+  analysisExamples: `
+    # Rspack or Webpack Analysis Examples
+
+    1. "Why is node_modules/rc-tree/lib/util.js not tree-shaken?"
+      - Return the module's bailoutReason, explain it in plain language.
+      - Show the issuerPath (import chain) to this module.
+
+    2. "Who imported lodash-es/constant.js?"
+      - Show the issuerPath as a dependency chain.
+
+    3. "List all modules in chunk 123"
+      - Use getChunkById, then list all module paths.
+
+    4. "Show all modules with side effects"
+      - List all modules with non-empty bailoutReason containing 'side_effects'.
+
+    5. "Why is package X duplicated?"
+      - Use getRuleInfo to explain E1001/E1002, show which chunks and modules contain the duplicates.
+
+    6. "Which modules are not tree-shaken due to side effects?"
+      - List modules with bailoutReason containing 'side_effects', and show their paths and issuerPath.
+
+    # Output format
+    - For dependency chains, use a tree or arrow notation.
+    - For module details, use a table or key-value list.
+    - For explanations, use concise, plain language.
   `,
 };

--- a/packages/ai/src/server/prompt.ts
+++ b/packages/ai/src/server/prompt.ts
@@ -1,5 +1,4 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { logger } from '@rsdoctor/utils/logger';
 import { z } from 'zod';
 
@@ -55,29 +54,25 @@ function registerPredefinedPrompts(
     });
 
     // Register the prompt with the server
-    server.prompt(
-      prompt.name,
-      schemaObj,
-      (args: Record<string, any>, extra: RequestHandlerExtra) => ({
-        messages: prompt.messages.map((message: Message) => {
-          let text = message.text;
-          prompt.arguments.forEach((arg: Argument) => {
-            const regex = new RegExp(`\\$\\{${arg.name}\\}`, 'g');
-            text = text.replace(regex, args[arg.name]);
-          });
+    server.prompt(prompt.name, schemaObj, (args: Record<string, any>) => ({
+      messages: prompt.messages.map((message: Message) => {
+        let text = message.text;
+        prompt.arguments.forEach((arg: Argument) => {
+          const regex = new RegExp(`\\$\\{${arg.name}\\}`, 'g');
+          text = text.replace(regex, args[arg.name]);
+        });
 
-          return {
-            role: message.role as 'user' | 'assistant',
-            content: {
-              type: 'text',
-              text: text,
-            },
-          };
-        }),
-        _meta: {},
-        description: prompt.description,
+        return {
+          role: message.role as 'user' | 'assistant',
+          content: {
+            type: 'text',
+            text: text,
+          },
+        };
       }),
-    );
+      _meta: {},
+      description: prompt.description,
+    }));
 
     logger.info(`✅ Registered prompt: ${prompt.name}`);
   });

--- a/packages/ai/src/server/resource.ts
+++ b/packages/ai/src/server/resource.ts
@@ -5,7 +5,6 @@ import {
 import path, { dirname } from 'path';
 import fs from 'fs';
 import { promisify } from 'util';
-import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { fileURLToPath } from 'url';
 
 const readFileAsync = promisify(fs.readFile);
@@ -13,10 +12,7 @@ const readFileAsync = promisify(fs.readFile);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const readMarkdownResource: ReadResourceCallback = async (
-  uri: URL,
-  extra: RequestHandlerExtra,
-) => {
+const readMarkdownResource: ReadResourceCallback = async (uri: URL) => {
   // Read the contents of the Markdown file
   const contents = await readFileAsync(
     path.join(__dirname, './resources', uri.pathname),

--- a/packages/document/docs/en/guide/start/mcp.mdx
+++ b/packages/document/docs/en/guide/start/mcp.mdx
@@ -9,7 +9,7 @@
 **@rsdoctor/mcp-server** provides four core analysis capabilities:
 
 - **Bundle Analysis**: Analyzes bundle size, composition and other information
-- **Dependency Analysis**: Analyzes project dependencies and duplicate dependency issues
+- **Dependency Analysis**: Analyzes project dependency relationships, duplicate dependencies, and Tree Shaking issues.
 - **Bundle Optimization Suggestions**: Provides suggestions for bundle size optimization and code splitting
 - **Compilation Optimization Suggestions**: Analyzes compilation time and provides compilation performance optimization suggestions
 
@@ -79,6 +79,17 @@ Example video:
   controls={true}
   loop={true}
   playsInline
+/>
+
+### 4. Tree Shaking Issues
+
+By asking "Please help me to check why react-dom/client.js can not be tree-shaken?", the tool will help analyze why this module cannot be tree-shaken.
+
+> Note: Please use Rsdoctor plugin version 1.1.5 or above.
+
+<img
+  src="https://assets.rspack.rs/others/assets/rsdoctor/tree-shake-mcp.png"
+  alt="tree-shaking"
 />
 
 ## Quick start

--- a/packages/document/docs/en/guide/usage/bundle-size.mdx
+++ b/packages/document/docs/en/guide/usage/bundle-size.mdx
@@ -128,12 +128,24 @@ The **Modules** tag is shown in the right image, from left to right representing
 - **Module Explorer** tag: Click to open the dependency analysis page between `Modules`.
 - **Code View** tag: Click to expand code segments, including `Source` (source code), `Transformed` (compiled code), and `Bundled` (bundled code).
 
+### Module details
+
+Click the module tag to view module details, as shown below:
+
+<img src="https://assets.rspack.rs/others/assets/rsdoctor/bailout-reason.gif" />
+
+- **Reasons**: This refers to the reason why a Module exists, i.e., which Modules import this Module. The entire Reasons Tree shows the upstream reference chain of this Module, including both direct and indirect parents. This corresponds to Rspack's `stats.reasons`.
+- **Dependencies**: The Modules that this Module depends on.
+- **Bailout Reason**: The reason why this Module failed Tree Shaking during the build process.
+
+> For more details, see: [Module details](/guide/usage/module-analysis)
+
 ## Bundle tile graph
 
 Click the **"Tile Graph"** label on the **"Bundle Size"** page to view the tile graph. The tile graph clearly shows the proportion and relationship between resources and modules, as shown in the following image:
 
 <img
-  src="https://lf3-static.bytednsdoc.com/obj/eden-cn/lognuvj/rsdoctor/docs/usage/bundle/treemap.png"
+  src="https://assets.rspack.rs/others/assets/rsdoctor/treemap.png"
   width="500px"
   style={{ margin: 'auto' }}
 />
@@ -141,7 +153,7 @@ Click the **"Tile Graph"** label on the **"Bundle Size"** page to view the tile 
 You can also click the 🔍 button on the card title to search for Module resources, click the Module resource, and zoom in to the Module area, as shown in the following image:
 
 <img
-  src="https://lf3-static.bytednsdoc.com/obj/eden-cn/lognuvj/rsdoctor/docs/usage/bundle/treemap.gif"
+  src="https://assets.rspack.rs/others/assets/rsdoctor/treemap.gif"
   width="500px"
   style={{ margin: 'auto' }}
 />

--- a/packages/document/docs/en/guide/usage/module-analysis.mdx
+++ b/packages/document/docs/en/guide/usage/module-analysis.mdx
@@ -27,6 +27,7 @@ Clicking on an **Assets** in the **[Bundle Size](./bundle-size)** page will disp
 
 - **`Reasons`**: As the name suggests, it means the reasons why a `Module` exists. Reasons indicate which other `Module`s import this `Module`, and the entire `Reasons Tree` represents the upstream reference chain of this `Module`, including both direct and indirect parent `Module`s. [Similar to Webpack's stats.reasons.](https://webpack.js.org/configuration/stats/#statsreasons)
 - **`Dependencies`**: The `Module`s that this `Module` depends on.
+- **`Bailout Reason`** : The reason why this `Module` failed Tree Shaking.
 
 ## Reasons dependency tree
 
@@ -56,3 +57,24 @@ The `Reasons Tree` displays the dependency chain of this `Module`, showing which
   width="600px"
   style={{ margin: 'auto' }}
 />
+
+## Bailout Reason
+
+### Usage
+
+`Bailout Reason` shows the reason why this `Module` failed Tree Shaking.
+
+<img
+  src="https://assets.rspack.rs/others/assets/rsdoctor/bailout-reason.gif"
+  width="600px"
+  style={{ margin: 'auto' }}
+/>
+
+You can also use MCP for analysis. By asking "Please help me to check why react-dom/client.js can not be tree-shaken?", the tool will help analyze why this module cannot be tree-shaken.
+
+<img
+  src="https://assets.rspack.rs/others/assets/rsdoctor/tree-shake-mcp.png"
+  alt="tree-shaking"
+/>
+
+> For MCP analysis, see [MCP Analysis](/guide/start/mcp)

--- a/packages/document/docs/zh/guide/start/mcp.mdx
+++ b/packages/document/docs/zh/guide/start/mcp.mdx
@@ -9,7 +9,7 @@
 **@rsdoctor/mcp-server** 提供四大类核心分析能力：
 
 - **产物信息分析**: 分析构建产物的体积、组成等信息
-- **依赖问题分析**: 分析项目依赖关系、重复依赖等问题
+- **依赖问题分析**: 分析项目依赖关系、重复依赖、Tree Shaking 等问题
 - **产物优化建议**: 提供产物体积优化、代码分割等建议
 - **编译优化建议**: 分析编译耗时，提供编译性能优化建议
 
@@ -79,6 +79,17 @@
   controls={true}
   loop={true}
   playsInline
+/>
+
+### 4. Tree shaking 问题
+
+通过提问 "Please help me to check why react-dom/client.js can not be tree-shaken?"，工具会帮忙分析该模块没有被 Tree shaking 的原因。
+
+> 注意：请使用 1.1.5 及以上版本的 Rsdoctor 插件。
+
+<img
+  src="https://assets.rspack.rs/others/assets/rsdoctor/tree-shake-mcp.png"
+  alt="tree-shaking"
 />
 
 ## 快速开始

--- a/packages/document/docs/zh/guide/usage/bundle-size.mdx
+++ b/packages/document/docs/zh/guide/usage/bundle-size.mdx
@@ -119,12 +119,24 @@
 - **Module Explorer** 标签：点击可打开 `Module` 之间的依赖关系分析页面。
 - **代码查看** 标签，点击可展开代码段，包括 `Source`（源码）、`Transformed`（编译后代码）和 `Bundled`（打包后代码）。
 
+### Module 详情
+
+点击模块标签，可以查看模块详情，如下图所示：
+
+<img src="https://assets.rspack.rs/others/assets/rsdoctor/bailout-reason.gif" />
+
+- Reasons : 顾名思义是 [原因] 的意思，即某个 Module 存在的原因。Reasons 就是该 Module 被哪些 Module 们引入，而整个 Reasons Tree 就是这个 Module 的整个上游引用链，包括了直接父级和间接父级们。即 Rspack 的 stats.reasons。
+- Dependencies : 是该 Module 依赖了哪些 Module。
+- Bailout Reason : Tree shaking 时，该 Module Tree shaking 失败的原因。
+
+> 更多可查看详情：[Module 详情](/guide/usage/module-analysis)
+
 ## 产物总览瓦片图
 
 点击 **「Bundle Size」** 页面的 **「Tile Graph」** 标签，可以查看瓦片图。通过瓦片图可以清晰的看到各个资源和模块之间的占比和关系，如下图所示：
 
 <img
-  src="https://lf3-static.bytednsdoc.com/obj/eden-cn/lognuvj/rsdoctor/docs/usage/bundle/treemap.png"
+  src="https://assets.rspack.rs/others/assets/rsdoctor/treemap.png"
   width="500px"
   style={{ margin: 'auto' }}
 />
@@ -132,7 +144,7 @@
 同时可以点击卡片标题侧的 🔍 按钮，搜索 Module 资源，点击 Module 资源，可以放大到该 Module 区域，如下图所示：
 
 <img
-  src="https://lf3-static.bytednsdoc.com/obj/eden-cn/lognuvj/rsdoctor/docs/usage/bundle/treemap.gif"
+  src="https://assets.rspack.rs/others/assets/rsdoctor/treemap.gif"
   width="500px"
   style={{ margin: 'auto' }}
 />

--- a/packages/document/docs/zh/guide/usage/module-analysis.mdx
+++ b/packages/document/docs/zh/guide/usage/module-analysis.mdx
@@ -29,6 +29,7 @@
 
 - **`Reasons`** : 顾名思义是 `[原因]` 的意思，即某个 `Module` 存在的原因。Reasons 就是该 `Module` 被哪些 `Module` 们引入，而整个 `Reasons Tree` 就是这个 `Module` 的整个上游引用链，包括了直接父级和间接父级们。[即 Rspack 的 stats.reasons。](https://webpack.js.org/configuration/stats/#statsreasons)
 - **`Dependencies`** : 是该 `Module` 依赖了哪些 `Module`。
+- **`Bailout Reason`** : Tree shaking 时，该 `Module` Tree shaking 失败的原因。
 
 ## Reasons 依赖树
 
@@ -58,3 +59,24 @@
   width="600px"
   style={{ margin: 'auto' }}
 />
+
+## Bailout Reason
+
+### 使用介绍
+
+`Bailout Reason` 展示了该 `Module` 在 Tree shaking 时失败的原因。
+
+<img
+  src="https://assets.rspack.rs/others/assets/rsdoctor/bailout-reason.gif"
+  width="600px"
+  style={{ margin: 'auto' }}
+/>
+
+还可以使用 MCP 进行分析，通过提问 "Please help me to check why react-dom/client.js can not be tree-shaken?"，工具会帮忙分析该模块没有被 Tree shaking 的原因。
+
+<img
+  src="https://assets.rspack.rs/others/assets/rsdoctor/tree-shake-mcp.png"
+  alt="tree-shaking"
+/>
+
+> MCP 分析请查看 [MCP 分析](/guide/start/mcp)


### PR DESCRIPTION
## Summary
feat: rsdoctor mcp supports bailout reason analysis

- mcp: add bailout reason mcp resources.
- docs:
   - bailout reason documentation.
- fix: rm some mcp useless args.

## Related Links

<!--- Provide links of related issues or pages -->
