### PR TITLE
fix: rspack bundle analysis failed when open treeshaking

### DIFF
--- a/e2e/cases/doctor-rspack/plugin.test.ts
+++ b/e2e/cases/doctor-rspack/plugin.test.ts
@@ -66,6 +66,9 @@ async function rspackCompile(tapName: string, compile: typeof compileByRspack) {
     plugins: [
       // @ts-ignore
       createRsdoctorPlugin({
+        features: {
+          treeShaking: true,
+        },
         linter: {
           rules: {
             'ecma-version-check': [

--- a/packages/core/src/inner-plugins/plugins/ensureModulesChunkGraph.ts
+++ b/packages/core/src/inner-plugins/plugins/ensureModulesChunkGraph.ts
@@ -90,18 +90,16 @@ export const ensureModulesChunksGraphFn = (
               'Rspack currently does not support treeShaking capabilities.',
             ),
           );
-          return;
+        } else {
+          _this.modulesGraph =
+            ModuleGraphBuildUtils.appendTreeShaking(
+              _this.modulesGraph,
+              stats.compilation,
+            ) || _this.modulesGraph;
+          _this.sdk.addClientRoutes([
+            Manifest.RsdoctorManifestClientRoutes.TreeShaking,
+          ]);
         }
-
-        _this.modulesGraph =
-          ModuleGraphBuildUtils.appendTreeShaking(
-            _this.modulesGraph,
-            stats.compilation,
-          ) || _this.modulesGraph;
-        _this.sdk.addClientRoutes([
-          Manifest.RsdoctorManifestClientRoutes.TreeShaking,
-        ]);
-
         debug(
           Process.getMemoryUsageMessage,
           '[After AppendTreeShaking to ModuleGraph]',


### PR DESCRIPTION
## Summary
fix: rspack bundle analysis failed when open treeshaking

## Related Links
closes: #1153

<!--- Provide links of related issues or pages -->
