### PR TITLE
chore: correct check-dependency-version script

### DIFF
--- a/examples/rspack-banner-minimal/package.json
+++ b/examples/rspack-banner-minimal/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.1",
   "private": true,
   "scripts": {
-    "dev": "ENABLE_CLIENT_SERVER=true NODE_ENV=development rspack serve",
-    "build": "ENABLE_CLIENT_SERVER=false NODE_ENV=production rspack build -c ./rspack.config.js",
-    "build:analysis": "ENABLE_CLIENT_SERVER=true NODE_ENV=production rspack build"
+    "dev": "cross-env ENABLE_CLIENT_SERVER=true NODE_ENV=development rspack serve",
+    "build": "cross-env ENABLE_CLIENT_SERVER=false NODE_ENV=production rspack build -c ./rspack.config.js",
+    "build:analysis": "cross-env ENABLE_CLIENT_SERVER=true NODE_ENV=production rspack build"
   },
   "dependencies": {
     "@arco-design/web-react": "^2.58.3",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     ]
   },
   "scripts": {
-    "build": "cross-env NX_DAEMON=false nx run-many -t build --exclude @examples/* @scripts/* @e2e/* --parallel=10",
+    "build": "cross-env NX_DAEMON=false nx run-many -t build --projects=@rsdoctor/*,@examples/rsdoctor-rspack-banner --parallel=10",
     "change": "changeset",
     "changeset": "changeset",
     "bump": "changeset version",
     "check-spell": "pnpx cspell && heading-case",
     "check-changeset": "pnpx disallow-major-changeset",
-    "check-dependency-version": "pnpx check-dependency-version-consistency .",
+    "check-dependency-version": "pnpx check-dependency-version-consistency . && echo",
     "dev:doc": "cd packages/document && pnpm run dev",
     "e2e": "pnpm run e2e:base && pnpm run e2e:native",
     "e2e:base": "cd ./e2e && cross-env NODE_OPTIONS=--max-old-space-size=8192 pnpm test",


### PR DESCRIPTION
## Summary
check-dependency-version 5.0.1 update command from v12 to v13 which will throw an error with excessArguments

<img width="1390" height="178" alt="image" src="https://github.com/user-attachments/assets/4074edc1-e19b-4656-b981-fa6002ad72c3" />


## Related Links

<!--- Provide links of related issues or pages -->
