### PR TITLE
fix(components-overall): Fix typo in 'View Bundle Size' button on the…

### DIFF
--- a/packages/components/src/components/Overall/bundle.tsx
+++ b/packages/components/src/components/Overall/bundle.tsx
@@ -310,7 +310,7 @@ export const BundleOverall: React.FC<{
                 >
                   <div style={{ display: 'flex', alignItems: 'center' }}>
                     <span style={{ marginRight: '8px', fontSize: '13px' }}>
-                      View Bundler Size
+                      {t('ViewBundleSize')}
                     </span>
                     <RightOutlined style={{ fontSize: '10px' }} />
                   </div>

--- a/packages/components/src/utils/i18n/cn.ts
+++ b/packages/components/src/utils/i18n/cn.ts
@@ -15,6 +15,7 @@ const cn: typeof en = {
   ModuleResolve: 'Module Resolve 分析',
   'Bundle Analysis': '产物分析',
   BundleSize: '产物体积分析',
+  ViewBundleSize: '查看包大小',
   'Module Graph': 'Module Graph',
   TreeShaking: 'Tree Shaking',
   'Rule Index': '错误索引信息',

--- a/packages/components/src/utils/i18n/en.ts
+++ b/packages/components/src/utils/i18n/en.ts
@@ -14,6 +14,7 @@ const en = {
   ModuleResolve: 'Module Resolve',
   'Bundle Analysis': 'Bundle Analysis',
   BundleSize: 'Bundle Size',
+  ViewBundleSize: 'View Bundle Size',
   'Module Graph': 'Module Graph',
   TreeShaking: 'Tree Shaking',
   'Rule Index': 'Rule Index',


### PR DESCRIPTION
## Summary
On the dashboard page there is a typo in "View Bundler Size" button in both en and cn languages:

<img width="473" height="409" alt="Screenshot 2025-07-20 at 15 24 41" src="https://github.com/user-attachments/assets/8e3b13c5-bdfc-4db8-9fbd-f4e772576fa0" />
<img width="450" height="405" alt="Screenshot 2025-07-20 at 15 50 04" src="https://github.com/user-attachments/assets/e60f739a-dadf-445c-a6b7-3c87fd6d2b74" />

The typo was fixed and also the 'View Bundle Size' string was added to the translations. 
I don't speak Chinese, so please let me know if the translation can be improved. 