### PR TITLE
hotfix: normalization function problem

### DIFF
--- a/packages/core/src/build-utils/build/utils/loader.ts
+++ b/packages/core/src/build-utils/build/utils/loader.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import fse from 'fs-extra';
 import { omit } from 'lodash';
 import { Loader } from '@rsdoctor/utils/common';
@@ -171,7 +171,7 @@ export function isESMLoader(r: Plugin.BuildRuleSetRule) {
         : '';
   if (!_loaderName) return false;
   const isPath =
-    _loaderName.startsWith('/') ||
+    path.isAbsolute(_loaderName) ||
     _loaderName.startsWith('./') ||
     _loaderName.startsWith('../');
   if (isPath) {

--- a/packages/core/tests/plugins/loader-path.test.ts
+++ b/packages/core/tests/plugins/loader-path.test.ts
@@ -1,0 +1,124 @@
+import path from 'path';
+import { isESMLoader } from '../../src/build-utils/build/utils/loader';
+import type { Plugin } from '@rsdoctor/types';
+import { describe, test, expect } from 'vitest';
+
+describe('loader path detection', () => {
+  describe('absolute paths', () => {
+    test('Unix-like absolute paths', () => {
+      expect(
+        isESMLoader({
+          loader: '/usr/local/my-loader.js',
+        } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+      expect(
+        isESMLoader({
+          loader: '/home/user/loaders/custom-loader.js',
+        } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+    });
+
+    test('Windows absolute paths', () => {
+      expect(
+        isESMLoader({
+          loader: 'C:\\Users\\loader.js',
+        } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+      expect(
+        isESMLoader({
+          loader: 'D:\\Project\\loaders\\my-loader.js',
+        } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+      expect(
+        isESMLoader({
+          loader: '\\\\server\\shared\\loader.js',
+        } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+    });
+  });
+
+  describe('relative paths', () => {
+    test('current directory relative paths', () => {
+      expect(
+        isESMLoader({ loader: './loader.js' } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+      expect(
+        isESMLoader({
+          loader: './loaders/my-loader.js',
+        } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+    });
+
+    test('parent directory relative paths', () => {
+      expect(
+        isESMLoader({ loader: '../loader.js' } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+      expect(
+        isESMLoader({
+          loader: '../loaders/custom-loader.js',
+        } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+    });
+  });
+
+  describe('package names', () => {
+    test('common loader package names', () => {
+      expect(
+        isESMLoader({ loader: 'babel-loader' } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+      expect(
+        isESMLoader({ loader: 'ts-loader' } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+      expect(
+        isESMLoader({ loader: 'style-loader' } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+    });
+  });
+
+  describe('mixed path separators', () => {
+    test('handles mixed path separators correctly', () => {
+      const mixedPath = path.join('some', 'mixed', 'path', 'loader.js');
+      expect(
+        isESMLoader({ loader: mixedPath } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('handles empty and invalid inputs', () => {
+      expect(isESMLoader({ loader: '' } as Plugin.BuildRuleSetRule)).toBe(
+        false,
+      );
+      expect(isESMLoader({ loader: '.' } as Plugin.BuildRuleSetRule)).toBe(
+        false,
+      );
+      expect(isESMLoader({ loader: '..' } as Plugin.BuildRuleSetRule)).toBe(
+        false,
+      );
+      expect(isESMLoader({ loader: '/' } as Plugin.BuildRuleSetRule)).toBe(
+        false,
+      );
+      expect(isESMLoader({ loader: '\\' } as Plugin.BuildRuleSetRule)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('loader objects', () => {
+    test('handles loader objects', () => {
+      expect(
+        isESMLoader({
+          loader: '/absolute/path/loader.js',
+        } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+      expect(
+        isESMLoader({
+          loader: './relative/path/loader.js',
+        } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+      expect(
+        isESMLoader({ loader: 'babel-loader' } as Plugin.BuildRuleSetRule),
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

### Loader Path Detection Tests:
- Added extensive tests for `isESMLoader` in `packages/core/tests/plugins/loader-path.test.ts` to validate handling of absolute paths, relative paths, package names, mixed path separators, edge cases, and loader objects.
- Changed `path` import to use `node:path` for better compatibility in `packages/core/src/build-utils/build/utils/loader.ts`.
- Replaced `_loaderName.startsWith('/')` with `path.isAbsolute(_loaderName)` for improved absolute path detection in `isESMLoader`.
## Related Links

<!--- Provide links of related issues or pages -->
