### PR TITLE
hotfix: normallize config

### DIFF
--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -4,10 +4,10 @@ name: Test (Ubuntu)
 on:
   # Triggers the workflow on pull request events but only for the main branch
   pull_request:
-    branches: [main]
+    branches: [main, hotfix/*]
 
   push:
-    branches: [main]
+    branches: [main, hotfix/*]
     paths-ignore:
       - 'document/**'
       - '*.md'

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -4,10 +4,10 @@ name: Test (Windows)
 on:
   # Triggers the workflow on pull request events but only for the main branch
   pull_request:
-    branches: [main]
+    branches: [main, hotfix/*]
 
   push:
-    branches: [main]
+    branches: [main, hotfix/*]
     paths-ignore:
       - "document/**"
       - "*.md"

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -215,25 +215,26 @@ export const normalizeReportType = (
   reportCodeType: IReportCodeType,
   mode: keyof typeof SDK.IMode,
 ): SDK.ToDataType => {
+  if (reportCodeType.noCode) {
+    return SDK.ToDataType.NoCode;
+  }
+
   if (mode === SDK.IMode[SDK.IMode.brief]) {
     return SDK.ToDataType.NoCode;
   }
 
   if (mode === SDK.IMode[SDK.IMode.lite]) {
-    return reportCodeType.noAssetsAndModuleSource
-      ? SDK.ToDataType.NoSourceAndAssets
-      : SDK.ToDataType.NoSource;
+    return SDK.ToDataType.NoSourceAndAssets;
   }
 
-  if (reportCodeType.noCode) {
-    return SDK.ToDataType.NoCode;
-  }
   if (reportCodeType.noAssetsAndModuleSource) {
     return SDK.ToDataType.NoSourceAndAssets;
   }
+
   if (reportCodeType.noModuleSource) {
     return SDK.ToDataType.NoSource;
   }
+
   return SDK.ToDataType.Normal;
 };
 

--- a/packages/core/tests/build/utils/config.test.ts
+++ b/packages/core/tests/build/utils/config.test.ts
@@ -27,7 +27,7 @@ describe('normalizeUserConfig', () => {
     expect(result.features.plugins).toBe(true);
     expect(result.features.lite).toBe(true);
     expect(result.features.resolver).toBe(false);
-    expect(result.output.reportCodeType).toBe(SDK.ToDataType.NoSource);
+    expect(result.output.reportCodeType).toBe(SDK.ToDataType.NoSourceAndAssets);
   });
 
   it('should respect custom features object', () => {
@@ -43,6 +43,14 @@ describe('normalizeUserConfig', () => {
     const result = normalizeUserConfig({
       output: { reportCodeType: { noCode: true } },
       mode: 'brief',
+    });
+    expect(result.output.reportCodeType).toBe(SDK.ToDataType.NoCode);
+  });
+
+  it('should normalize output.reportCodeType and mode:lite', () => {
+    const result = normalizeUserConfig({
+      output: { reportCodeType: { noCode: true } },
+      mode: 'lite',
     });
     expect(result.output.reportCodeType).toBe(SDK.ToDataType.NoCode);
   });
@@ -92,7 +100,9 @@ describe('normalizeUserConfig', () => {
           },
         },
       });
-      expect(result.output.reportCodeType).toBe(SDK.ToDataType.NoSource);
+      expect(result.output.reportCodeType).toBe(
+        SDK.ToDataType.NoSourceAndAssets,
+      );
     });
 
     it('should return NoSourceAndAssets when mode is lite and noAssetsAndModuleSource is true', () => {


### PR DESCRIPTION
## Summary
hotfix: normallize config

This pull request introduces changes to workflow configurations and updates to the `normalizeReportType` function and its associated tests in the codebase. The most notable changes include extending workflow triggers to support `hotfix` branches and refining the logic for handling `reportCodeType` and `mode` in the `normalizeReportType` function, along with corresponding updates to test cases.

### Updates to `normalizeReportType` function:
* [`packages/core/src/inner-plugins/utils/config.ts`](diffhunk://#diff-0bc1a98d5cf2810e43077f2e07c17dced9b44cbbb6f1f19e517f4bdcfd222015R218-R237): Refined logic to prioritize `reportCodeType.noCode` and adjusted handling of `mode:lite` to consistently return `SDK.ToDataType.NoSourceAndAssets`.

### Test case enhancements:
* `packages/core/tests/build/utils/config.test.ts`: 
  - Updated existing test cases to reflect changes in `normalizeReportType` logic, ensuring correct handling of `reportCodeType` and `mode`. [[1]](diffhunk://#diff-28e4c2f2fe57d82641c66c1cdd55bb2509646b7fb6cd348c75859f2950ae82f5L30-R30) [[2]](diffhunk://#diff-28e4c2f2fe57d82641c66c1cdd55bb2509646b7fb6cd348c75859f2950ae82f5L95-R105)
  - Added a new test case to validate normalization behavior for `output.reportCodeType` when `mode:lite` and `reportCodeType.noCode` are true.


<!--- Provide links of related issues or pages -->
