### PR TITLE
fix: the style of the file tree

### DIFF
--- a/packages/components/src/pages/BundleSize/components/index.module.scss
+++ b/packages/components/src/pages/BundleSize/components/index.module.scss
@@ -102,7 +102,10 @@
       margin-right: 2px;
     }
 
-    .ant-tree-node-content-wrapper-open,
+    .ant-tree-node-content-wrapper-open {
+      display: flex;
+    }
+
     .ant-tree-node-content-wrapper-close {
       display: flex;
     }


### PR DESCRIPTION
## Summary

fix: the style of the file tree

- before:
<img width="2648" height="848" alt="76c37f2e7245ee9bf7ebfdbb54ebfc05" src="https://github.com/user-attachments/assets/6eeddebb-ad52-4679-8898-854808213f58" />


- after:
<img width="2638" height="666" alt="c3d311522ff99d76b0f0fab717170718" src="https://github.com/user-attachments/assets/f2aaabd8-bc4c-4b37-b1ba-abe37a470c76" />


## Related Links

<!--- Provide links of related issues or pages -->
