### PR TITLE
feat: fix typo and improve alert collapse sorting

### DIFF
--- a/packages/components/src/components/Alerts/bundle-alert.tsx
+++ b/packages/components/src/components/Alerts/bundle-alert.tsx
@@ -30,7 +30,7 @@ export const BundleAlert: React.FC<BundleAlertProps> = ({
   dataSource,
   extraData,
 }) => {
-  const [activekey, setActiveKey] = useState('E1001');
+  const [activeKey, setActiveKey] = useState('E1001');
   const tabData: Array<{
     key: string;
     label: string;
@@ -70,7 +70,7 @@ export const BundleAlert: React.FC<BundleAlertProps> = ({
 
   const tabItems = tabData.map((td) => {
     const tagStyle =
-      activekey === td.key
+      activeKey === td.key
         ? ({
             border: '1px solid #91D5FF',
             backgroundColor: '#E6F7FF',
@@ -78,7 +78,7 @@ export const BundleAlert: React.FC<BundleAlertProps> = ({
         : {};
 
     const tagTextStyle =
-      activekey === td.key
+      activeKey === td.key
         ? {
             color: '#1890FF',
           }

--- a/packages/components/src/components/Alerts/collapse.tsx
+++ b/packages/components/src/components/Alerts/collapse.tsx
@@ -45,171 +45,184 @@ export const AlertCollapse = (props: {
 }) => {
   const { data, extraData } = props;
 
-  const items = data.map((d) => {
-    const { packages } = d as Rule.PackageRelationDiffRuleStoreData;
-    const totalSize = sumBy(packages, (e) => e.targetSize.sourceSize);
-    const totalSizeStr = formatSize(totalSize);
-    const { name } = packages.find((e) => !!e.target.name)!.target;
-    const versions = packages.map((item) => item.target.version);
+  const items = data
+    .map((d) => {
+      const data = d as Rule.PackageRelationDiffRuleStoreData;
+      const { packages } = data;
+      const totalSize = sumBy(packages, (e) => e.targetSize.sourceSize);
 
-    const ChildComponent = () => {
-      return packages.map((pkg, idx) => {
-        const version = pkg.target.version;
-        const root = pkg.target.root;
-        const sizeStr = formatSize(pkg.targetSize.sourceSize);
-        const parsedSizeStr = pkg.targetSize.parsedSize
-          ? formatSize(pkg.targetSize.parsedSize)
-          : null;
+      return {
+        totalSize,
+        data,
+      };
+    })
+    .sort((a, b) => {
+      return b.totalSize - a.totalSize;
+    })
+    .map(({ data, totalSize }) => {
+      const { packages } = data;
+      const totalSizeStr = formatSize(totalSize);
+      const { name } = packages.find((e) => !!e.target.name)!.target;
+      const versions = packages.map((item) => item.target.version);
 
-        return (
-          <div className={styles.collapseContainer}>
-            <Overview
-              style={{ backgroundColor: '#fff' }}
-              title={
-                <Text
-                  style={{ width: innerWidth > 1500 ? 900 : 700 }}
-                  ellipsis={{
-                    tooltip: root,
-                  }}
-                >
-                  {root}
-                </Text>
-              }
-              description={
-                <div className={styles.collapseChild}>
-                  <div>
-                    <div className={styles.attribute}>Version</div>
-                    <div className={styles.iconContainer}>
-                      <Icon
-                        style={{ fontSize: '18px' }}
-                        component={VersionSvg}
-                      />
-                      <span className={styles.data}>v{version}</span>
-                    </div>
-                  </div>
-                  <div>
-                    <div className={styles.attribute}>Source size</div>
-                    <div className={styles.iconContainer}>
-                      <Icon
-                        style={{ fontSize: '18px' }}
-                        component={SourceSizeSvg}
-                      />
-                      <span className={styles.data}>{sizeStr}</span>
-                    </div>
-                  </div>
-                  <div>
-                    <div className={styles.attribute}>Bundle size</div>
-                    <div className={styles.iconContainer}>
-                      <Icon
-                        style={{ fontSize: '18px' }}
-                        component={BundleSizeSvg}
-                      />
-                      <Tooltip
-                        title={`The bundle size of "${name}" is ${sizeStr}, this is after bundled, concatenated module cannot get bundled size. `}
-                      >
-                        <span className={styles.data}>
-                          {parsedSizeStr || 'CONCATENATED'}
-                        </span>
-                      </Tooltip>
-                    </div>
-                  </div>
-                </div>
-              }
-              icon={
-                <Paragraph
-                  style={{ position: 'relative', top: '-10px' }}
-                  copyable={{ text: root }}
-                />
-              }
-            />
-            {idx !== packages.length - 1 ? (
-              <Divider style={{ margin: '10px 0' }} />
-            ) : null}
-          </div>
-        );
-      });
-    };
+      const ChildComponent = () => {
+        return packages.map((pkg, idx) => {
+          const version = pkg.target.version;
+          const root = pkg.target.root;
+          const sizeStr = formatSize(pkg.targetSize.sourceSize);
+          const parsedSizeStr = pkg.targetSize.parsedSize
+            ? formatSize(pkg.targetSize.parsedSize)
+            : null;
 
-    return {
-      key: d.code,
-      label: (
-        <LabelComponent
-          title={
-            <Tag style={{ backgroundColor: '#EAEDF1', borderRadius: '2px' }}>
-              <span className={styles.pkgName}>{name}</span>
-            </Tag>
-          }
-          description={`${packages.length} versions was found`}
-          extra={
-            <div className={styles.extraContainer}>
-              <div className={styles.iconContainer}>
-                <Icon style={{ fontSize: '18px' }} component={TotalSizeSvg} />
-                <span className={styles.data}>{totalSizeStr}</span>
-              </div>
-              {packages && packages.length > 0 ? (
-                <TextDrawer
-                  text="Show Relations"
-                  buttonProps={{ size: 'small' }}
-                  drawerProps={{ title: d.title, width: '60%' }}
-                >
-                  <Space
-                    direction="vertical"
-                    className="alert-space"
-                    style={{ width: '100%' }}
+          return (
+            <div className={styles.collapseContainer}>
+              <Overview
+                style={{ backgroundColor: '#fff' }}
+                title={
+                  <Text
+                    style={{ width: innerWidth > 1500 ? 900 : 700 }}
+                    ellipsis={{
+                      tooltip: root,
+                    }}
                   >
-                    <Space
-                      style={{
-                        marginBottom: Size.BasePadding / 2,
-                        width: '100%',
-                      }}
-                    >
-                      <Title
-                        text={
-                          <Tag style={{ backgroundColor: '#EAEDF1' }}>
-                            {name}
-                          </Tag>
-                        }
-                        upperFirst={false}
-                      />
-                      <Typography.Text strong>
-                        {versions.length}
-                      </Typography.Text>
-                      <Typography.Text> versions found</Typography.Text>
-                    </Space>
-                    <Tabs
-                      size="middle"
-                      items={
-                        packages.map((pkg) => {
-                          const { target, targetSize } = pkg;
-                          return {
-                            label: (
-                              <Space className={styles.drawerLabelTitle}>
-                                <div>v{target.version}</div>
-                                <Tag className={styles.drawerLabelSize}>
-                                  {formatSize(targetSize.sourceSize)}
-                                </Tag>
-                              </Space>
-                            ),
-                            key: `${target.root}${target.name}${target.version}`,
-                            children:
-                              extraData.getPackageRelationContentComponent({
-                                data: d as Rule.PackageRelationDiffRuleStoreData,
-                                package: pkg,
-                              }),
-                          };
-                        })!
-                      }
-                    />
-                  </Space>
-                </TextDrawer>
+                    {root}
+                  </Text>
+                }
+                description={
+                  <div className={styles.collapseChild}>
+                    <div>
+                      <div className={styles.attribute}>Version</div>
+                      <div className={styles.iconContainer}>
+                        <Icon
+                          style={{ fontSize: '18px' }}
+                          component={VersionSvg}
+                        />
+                        <span className={styles.data}>v{version}</span>
+                      </div>
+                    </div>
+                    <div>
+                      <div className={styles.attribute}>Source size</div>
+                      <div className={styles.iconContainer}>
+                        <Icon
+                          style={{ fontSize: '18px' }}
+                          component={SourceSizeSvg}
+                        />
+                        <span className={styles.data}>{sizeStr}</span>
+                      </div>
+                    </div>
+                    <div>
+                      <div className={styles.attribute}>Bundle size</div>
+                      <div className={styles.iconContainer}>
+                        <Icon
+                          style={{ fontSize: '18px' }}
+                          component={BundleSizeSvg}
+                        />
+                        <Tooltip
+                          title={`The bundle size of "${name}" is ${sizeStr}, this is after bundled, concatenated module cannot get bundled size. `}
+                        >
+                          <span className={styles.data}>
+                            {parsedSizeStr || 'CONCATENATED'}
+                          </span>
+                        </Tooltip>
+                      </div>
+                    </div>
+                  </div>
+                }
+                icon={
+                  <Paragraph
+                    style={{ position: 'relative', top: '-10px' }}
+                    copyable={{ text: root }}
+                  />
+                }
+              />
+              {idx !== packages.length - 1 ? (
+                <Divider style={{ margin: '10px 0' }} />
               ) : null}
             </div>
-          }
-        />
-      ),
-      children: <ChildComponent />,
-    };
-  });
+          );
+        });
+      };
+
+      return {
+        key: data.code,
+        label: (
+          <LabelComponent
+            title={
+              <Tag style={{ backgroundColor: '#EAEDF1', borderRadius: '2px' }}>
+                <span className={styles.pkgName}>{name}</span>
+              </Tag>
+            }
+            description={`${packages.length} versions was found`}
+            extra={
+              <div className={styles.extraContainer}>
+                <div className={styles.iconContainer}>
+                  <Icon style={{ fontSize: '18px' }} component={TotalSizeSvg} />
+                  <span className={styles.data}>{totalSizeStr}</span>
+                </div>
+                {packages && packages.length > 0 ? (
+                  <TextDrawer
+                    text="Show Relations"
+                    buttonProps={{ size: 'small' }}
+                    drawerProps={{ title: data.title, width: '60%' }}
+                  >
+                    <Space
+                      direction="vertical"
+                      className="alert-space"
+                      style={{ width: '100%' }}
+                    >
+                      <Space
+                        style={{
+                          marginBottom: Size.BasePadding / 2,
+                          width: '100%',
+                        }}
+                      >
+                        <Title
+                          text={
+                            <Tag style={{ backgroundColor: '#EAEDF1' }}>
+                              {name}
+                            </Tag>
+                          }
+                          upperFirst={false}
+                        />
+                        <Typography.Text strong>
+                          {versions.length}
+                        </Typography.Text>
+                        <Typography.Text> versions found</Typography.Text>
+                      </Space>
+                      <Tabs
+                        size="middle"
+                        items={
+                          packages.map((pkg) => {
+                            const { target, targetSize } = pkg;
+                            return {
+                              label: (
+                                <Space className={styles.drawerLabelTitle}>
+                                  <div>v{target.version}</div>
+                                  <Tag className={styles.drawerLabelSize}>
+                                    {formatSize(targetSize.sourceSize)}
+                                  </Tag>
+                                </Space>
+                              ),
+                              key: `${target.root}${target.name}${target.version}`,
+                              children:
+                                extraData.getPackageRelationContentComponent({
+                                  data,
+                                  package: pkg,
+                                }),
+                            };
+                          })!
+                        }
+                      />
+                    </Space>
+                  </TextDrawer>
+                ) : null}
+              </div>
+            }
+          />
+        ),
+        children: <ChildComponent />,
+      };
+    });
 
   return (
     <Collapse


### PR DESCRIPTION
## Summary

- Fix typo
- Add data sort by total size in Bundle Alerts -> Duplicate Packages

Why choose to directly increase the sorting of data, instead of adding a sort button. The reason is that under the current code organization structure, adding a sort button would have a significant impact on the code structure. Moreover, for the purpose of data presentation, it is only necessary to have sorted data packages to improve processing efficiency, and there is no need to switch to an unsorted state. Adding a sorting toggle function is not helpful.

## Related Links

close https://github.com/web-infra-dev/rsdoctor/issues/1145
<!--- Provide links of related issues or pages -->
