### PR TITLE
docs: add quick install buttons for mcp

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -117,6 +117,8 @@ Once connected, you can interact directly with Rsdoctor's build analysis data in
 
 ### Cursor
 
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=rsdoctor&config=eyJjb21tYW5kIjoibnB4IC15IEByc2RvY3Rvci9tY3Atc2VydmVyQGxhdGVzdCJ9)
+
 To integrate @rsdoctor/mcp-server in the Cursor editor, usually you only need to add the server configuration in the `.cursor/mcp.json` file.
 
 ```json
@@ -131,6 +133,25 @@ To integrate @rsdoctor/mcp-server in the Cursor editor, usually you only need to
 ```
 
 Once connected, you can interact directly with Rsdoctor's build analysis data in the MCP panel of Cursor, asking questions about artifacts, dependencies, optimizations, and more.
+
+#### VS Code / GitHub Copilot
+
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Rsdoctor_MCP-0098FF?style=flat-square&logo=visualstudiocode&logoColor=ffffff)](vscode:mcp/install?%7B%22name%22%3A%22rsdoctor%22%2C%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40rsdoctor%2Fmcp-server%40latest%22%5D%7D)
+
+1. Create `.vscode/mcp.json` in your project root directory. GitHub Copilot will automatically load the MCP Server configuration.
+
+```json
+{
+  "mcpServers": {
+    "rsdoctor": {
+      "command": "npx",
+      "args": ["-y", "@rsdoctor/mcp-server@latest"]
+    }
+  }
+}
+```
+
+2. In the Copilot Chat view, select [Agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_use-agent-mode), then start interacting.
 
 ### Cline
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -134,7 +134,7 @@ To integrate @rsdoctor/mcp-server in the Cursor editor, usually you only need to
 
 Once connected, you can interact directly with Rsdoctor's build analysis data in the MCP panel of Cursor, asking questions about artifacts, dependencies, optimizations, and more.
 
-#### VS Code / GitHub Copilot
+### VS Code / GitHub Copilot
 
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Rsdoctor_MCP-0098FF?style=flat-square&logo=visualstudiocode&logoColor=ffffff)](vscode:mcp/install?%7B%22name%22%3A%22rsdoctor%22%2C%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40rsdoctor%2Fmcp-server%40latest%22%5D%7D)
 

--- a/packages/ai/README.zh-CN.md
+++ b/packages/ai/README.zh-CN.md
@@ -113,6 +113,8 @@ npm run build
 
 #### Cursor
 
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=rsdoctor&config=eyJjb21tYW5kIjoibnB4IC15IEByc2RvY3Rvci9tY3Atc2VydmVyQGxhdGVzdCJ9)
+
 在 Cursor 编辑器中集成 @rsdoctor/mcp-server，通常只需在 .cursor/mcp.json 文件中添加服务器配置。
 
 ```json
@@ -127,6 +129,25 @@ npm run build
 ```
 
 连接成功后，此时你可以在 Cursor 的 MCP 面板中直接与 Rsdoctor 构建分析数据进行交互，提问产物、依赖、优化等相关问题。
+
+#### VS Code / GitHub Copilot
+
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Rsdoctor_MCP-0098FF?style=flat-square&logo=visualstudiocode&logoColor=ffffff)](vscode:mcp/install?%7B%22name%22%3A%22rsdoctor%22%2C%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40rsdoctor%2Fmcp-server%40latest%22%5D%7D)
+
+1. 在项目根目录创建 `.vscode/mcp.json`，GitHub Copilot 默认会自动加载 MCP Server 配置
+
+```json
+{
+  "mcpServers": {
+    "rsdoctor": {
+      "command": "npx",
+      "args": ["-y", "@rsdoctor/mcp-server@latest"]
+    }
+  }
+}
+```
+
+2. 在 Copilot Chat 面板中选择 [Agent 模式](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_use-agent-mode)，然后开始交互。
 
 #### Cline
 

--- a/packages/ai/README.zh-CN.md
+++ b/packages/ai/README.zh-CN.md
@@ -130,7 +130,7 @@ npm run build
 
 连接成功后，此时你可以在 Cursor 的 MCP 面板中直接与 Rsdoctor 构建分析数据进行交互，提问产物、依赖、优化等相关问题。
 
-#### VS Code / GitHub Copilot
+### VS Code / GitHub Copilot
 
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Rsdoctor_MCP-0098FF?style=flat-square&logo=visualstudiocode&logoColor=ffffff)](vscode:mcp/install?%7B%22name%22%3A%22rsdoctor%22%2C%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40rsdoctor%2Fmcp-server%40latest%22%5D%7D)
 

--- a/packages/document/docs/en/guide/start/mcp.mdx
+++ b/packages/document/docs/en/guide/start/mcp.mdx
@@ -125,6 +125,16 @@ RSDOCTOR=true npm run build
 
 #### Cursor
 
+<div style={{ display: 'inline-block', marginTop: 16 }}>
+  <a href="cursor://anysphere.cursor-deeplink/mcp/install?name=rsdoctor&config=eyJjb21tYW5kIjoibnB4IC15IEByc2RvY3Rvci9tY3Atc2VydmVyQGxhdGVzdCJ9">
+    <img
+      src="https://cursor.com/deeplink/mcp-install-dark.svg"
+      alt="Add Rsdoctor MCP server to Cursor"
+      height="32"
+    />
+  </a>
+</div>
+
 1. Create a `.cursor/mcp.json` file in the project root directory:
 
 ```json
@@ -141,7 +151,16 @@ RSDOCTOR=true npm run build
 2. Restart the Cursor editor
 3. Start interaction in the MCP panel
 
-#### GitHub Copilot
+#### VS Code / GitHub Copilot
+
+<div style={{ display: 'inline-block', marginTop: 16 }}>
+  <a href="vscode:mcp/install?%7B%22name%22%3A%22rsdoctor%22%2C%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40rsdoctor%2Fmcp-server%40latest%22%5D%7D">
+    <img
+      src="https://img.shields.io/badge/VS_Code-Install_Rsdoctor_MCP-0098FF?style=flat-square&logo=visualstudiocode&logoColor=ffffff"
+      alt="Install in VS Code"
+    />
+  </a>
+</div>
 
 1. Create `.vscode/mcp.json` in your project root directory. GitHub Copilot will automatically load the MCP Server configuration.
 

--- a/packages/document/docs/zh/guide/start/mcp.mdx
+++ b/packages/document/docs/zh/guide/start/mcp.mdx
@@ -125,6 +125,16 @@ RSDOCTOR=true npm run build
 
 #### Cursor
 
+<div style={{ display: 'inline-block', marginTop: 16 }}>
+  <a href="cursor://anysphere.cursor-deeplink/mcp/install?name=rsdoctor&config=eyJjb21tYW5kIjoibnB4IC15IEByc2RvY3Rvci9tY3Atc2VydmVyQGxhdGVzdCJ9">
+    <img
+      src="https://cursor.com/deeplink/mcp-install-dark.svg"
+      alt="将 Rsdoctor MCP 服务器添加到 Cursor"
+      height="32"
+    />
+  </a>
+</div>
+
 1. 在项目根目录创建 `.cursor/mcp.json`：
 
 ```json
@@ -141,7 +151,16 @@ RSDOCTOR=true npm run build
 2. 重启 Cursor 编辑器
 3. 在 MCP 面板中开始交互
 
-#### GitHub Copilot
+#### VS Code / GitHub Copilot
+
+<div style={{ display: 'inline-block', marginTop: 16 }}>
+  <a href="vscode:mcp/install?%7B%22name%22%3A%22rsdoctor%22%2C%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40rsdoctor%2Fmcp-server%40latest%22%5D%7D">
+    <img
+      src="https://img.shields.io/badge/VS_Code-Install_Rsdoctor_MCP-0098FF?style=flat-square&logo=visualstudiocode&logoColor=ffffff"
+      alt="在 VS Code 中安装"
+    />
+  </a>
+</div>
 
 1. 在项目根目录创建 `.vscode/mcp.json`，GitHub Copilot 默认会自动加载 MCP Server 配置
 

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -169,4 +169,8 @@ export default defineConfig({
       },
     },
   },
+  mediumZoom: {
+    // Select all images that are NOT descendants of an anchor
+    selector: '.rspress-doc img:not(a img)',
+  },
 });


### PR DESCRIPTION
## Summary

A few things happened here:

- Added a `Add to Cursor` button to quickly add Rsdoctor MCP to Cursor without having to deal with the configuration file manually
- Noticed we had a section on the website for GitHub Copilot (VS Code), but not in the README. I synced it.
- Added an install button for VS Code too

## Screenshot

<img width="893" height="942" alt="Screenshot 2025-08-07 at 3 42 14 PM" src="https://github.com/user-attachments/assets/df62f60e-15cf-4785-86a8-7f51deb403ed" />

## Related Links

<!--- Provide links of related issues or pages -->
