### PR TITLE
fix: filter the treemap's assets type

### DIFF
--- a/packages/components/src/pages/BundleSize/components/index.tsx
+++ b/packages/components/src/pages/BundleSize/components/index.tsx
@@ -334,7 +334,7 @@ export const WebpackModulesOverallBase: React.FC<
                   {(data) => {
                     // Filter assets to only show JS (js, cjs, mjs), CSS, and HTML files
                     const isTargetFileType = (filePath: string): boolean => {
-                      const ext = filePath.toLowerCase().split('.').pop();
+                      const ext = filePath.toLowerCase().split('.').pop() || '';
                       return (
                         ext === 'js' ||
                         ext === 'cjs' ||


### PR DESCRIPTION
## Summary
fix: filter the treemap's assets type

Only display assets for JS, CJS, MJS, and CSS and HTML in the treemap.

## Related Links
#
<!--- Provide links of related issues or pages -->
