### PR TITLE
docs: quick start page add Rslib

### DIFF
--- a/packages/document/docs/en/guide/start/quick-start.mdx
+++ b/packages/document/docs/en/guide/start/quick-start.mdx
@@ -8,7 +8,7 @@ import { PackageManagerTabs } from '@theme';
 
 ### Rspack projects
 
-For projects based on Rspack or Rsbuild, install the following dependencies:
+For projects based on Rspack, such as Rsbuild or Rslib, install the following dependencies:
 
 <PackageManagerTabs command="add @rsdoctor/rspack-plugin -D" />
 

--- a/packages/document/docs/zh/guide/start/quick-start.mdx
+++ b/packages/document/docs/zh/guide/start/quick-start.mdx
@@ -8,7 +8,7 @@ import { PackageManagerTabs } from '@theme';
 
 ### Rspack 项目
 
-基于 Rspack 或 Rsbuild 的项目，安装以下依赖：
+基于 Rspack 的项目（比如 Rsbuild 或 Rslib），安装以下依赖：
 
 <PackageManagerTabs command="add @rsdoctor/rspack-plugin -D" />
 


### PR DESCRIPTION
Avoid making new users mistakenly believe that Rslib is incompatible with Rsdoctor.