### PR TITLE
fix(types): relieve original import path

### DIFF
--- a/packages/types/src/sdk/module.ts
+++ b/packages/types/src/sdk/module.ts
@@ -14,7 +14,7 @@ import type {
   VariableData,
   VariableInstance,
 } from './treeShaking';
-import type { StatsModule } from '@/plugin';
+import type { StatsModule } from '../plugin';
 
 export enum DependencyKind {
   Unknown,

--- a/packages/types/src/sdk/server/apis/index.ts
+++ b/packages/types/src/sdk/server/apis/index.ts
@@ -12,7 +12,7 @@ import { GraphAPIResponse, GraphAPIRequestBody } from './graph';
 import { AlertsAPIResponse, AlertsAPIRequestBody } from './alerts';
 import { RsdoctorManifestMappingKeys } from '../../../manifest';
 import { SDK } from '../../../index';
-import { StatsModule } from '@/plugin';
+import { StatsModule } from '../../../plugin';
 
 export * from './pagination';
 


### PR DESCRIPTION
## Summary

This package is building by tsc, but tsc does not change import paths.

@rsdoctor/types@1.2.2 in npm

`@rsdoctor/types/dist/sdk/module.d.ts`
<img width="616" height="417" alt="image" src="https://github.com/user-attachments/assets/31bc5a06-e836-421d-8149-cbefeb7bb2a0" />

`@rsdoctor/types/dist/sdk/server/apis/index.d.ts`
<img width="637" height="601" alt="image" src="https://github.com/user-attachments/assets/754f8285-d2dc-4d51-8341-af5723b76a81" />


## Related Links
none
<!--- Provide links of related issues or pages -->
