### PR TITLE
fix: devtool module file template

### DIFF
--- a/packages/core/src/inner-plugins/plugins/bundle.ts
+++ b/packages/core/src/inner-plugins/plugins/bundle.ts
@@ -1,7 +1,7 @@
 import { Manifest, Plugin } from '@rsdoctor/types';
 import { InternalBasePlugin } from './base';
 import { Chunks } from '@/build-utils/common';
-import { time, timeEnd } from '@rsdoctor/utils/logger';
+import { logger, time, timeEnd } from '@rsdoctor/utils/logger';
 
 export class InternalBundlePlugin<
   T extends Plugin.BaseCompiler,
@@ -45,6 +45,10 @@ export class InternalBundlePlugin<
 
       compiler.options.output.devtoolModuleFilenameTemplate =
         '[absolute-resource-path]';
+
+      logger.warn(
+        `output.devtoolModuleFilenameTemplate has been changed to [absolute-resource-path], this is for bundle analysis.`,
+      );
 
       if (devtool.includes('source-map')) {
         compiler.options.output.devtoolFallbackModuleFilenameTemplate =

--- a/packages/core/src/inner-plugins/plugins/bundle.ts
+++ b/packages/core/src/inner-plugins/plugins/bundle.ts
@@ -15,10 +15,41 @@ export class InternalBundlePlugin<
     try {
       // bundle depends on module graph
       this.scheduler.ensureModulesChunksGraphApplied(compiler);
+
+      compiler.hooks.compilation.tap(
+        {
+          name: 'ChangeDevtoolModuleFilename',
+          stage: -100,
+        },
+        () => {
+          this.changeDevtoolModuleFilename(compiler);
+        },
+      );
+
       compiler.hooks.compilation.tap(this.tapPostOptions, this.thisCompilation);
       compiler.hooks.done.tapPromise(this.tapPreOptions, this.done.bind(this));
     } finally {
       timeEnd('InternalBundlePlugin.apply');
+    }
+  }
+  changeDevtoolModuleFilename(compiler: Plugin.BaseCompiler) {
+    if ('rspack' in compiler) {
+      return;
+    }
+
+    const devtool = compiler.options.devtool;
+    if (devtool) {
+      if (!compiler.options.output) {
+        compiler.options.output = {} as any;
+      }
+
+      compiler.options.output.devtoolModuleFilenameTemplate =
+        '[absolute-resource-path]';
+
+      if (devtool.includes('source-map')) {
+        compiler.options.output.devtoolFallbackModuleFilenameTemplate =
+          '[absolute-resource-path]';
+      }
     }
   }
 

--- a/packages/core/src/inner-plugins/plugins/bundle.ts
+++ b/packages/core/src/inner-plugins/plugins/bundle.ts
@@ -40,7 +40,7 @@ export class InternalBundlePlugin<
     const devtool = compiler.options.devtool;
     if (devtool) {
       if (!compiler.options.output) {
-        compiler.options.output = {} as any;
+        compiler.options.output = {} as typeof compiler.options.output;
       }
 
       compiler.options.output.devtoolModuleFilenameTemplate =


### PR DESCRIPTION
## Summary
fix: devtool module file template

When webpack's output.devtoolModuleFilenameTemplate is set to webpack://[namespace]/[resource-path], it is not possible to obtain the actual locations of the sources in the sourcemap. Therefore, rsdoctor will uniformly set it to '[absolute-resource-path]'.

## Related Links

<!--- Provide links of related issues or pages -->
