### PR TITLE
feat: the config options changes

### DIFF
--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -42,10 +42,6 @@ example: ${bin} ${Commands.Analyze} --profile "${Constants.RsdoctorOutputManifes
         .option('port', {
           type: 'number',
           description: 'port for Rsdoctor Server',
-        })
-        .option('type', {
-          type: 'string',
-          description: 'if need lite bundle mode',
         });
     },
     async action({ profile, open = true, port, type = SDK.ToDataType.Normal }) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
         "./dist/rules/index.d.ts"
       ],
       "types": [
-        "./dist/types/types.d.ts"
+        "./dist/types/index.d.ts"
       ]
     }
   },

--- a/packages/core/src/inner-plugins/utils/index.ts
+++ b/packages/core/src/inner-plugins/utils/index.ts
@@ -6,3 +6,4 @@ export * from './circleDetect';
 export * from './plugin-common';
 export * from './normalize-config';
 export * from './plugin-common';
+export * from './normalize-config';

--- a/packages/core/src/inner-plugins/utils/index.ts
+++ b/packages/core/src/inner-plugins/utils/index.ts
@@ -5,3 +5,4 @@ export * from './config';
 export * from './circleDetect';
 export * from './plugin-common';
 export * from './normalize-config';
+export * from './plugin-common';

--- a/packages/core/src/inner-plugins/utils/index.ts
+++ b/packages/core/src/inner-plugins/utils/index.ts
@@ -4,3 +4,4 @@ export * from './sdk';
 export * from './config';
 export * from './circleDetect';
 export * from './plugin-common';
+export * from './normalize-config';

--- a/packages/core/src/inner-plugins/utils/normalize-config.ts
+++ b/packages/core/src/inner-plugins/utils/normalize-config.ts
@@ -1,0 +1,149 @@
+import { Common, Plugin, SDK } from '@rsdoctor/types';
+import type {
+  RuleSetCondition as RspackRuleSetCondition,
+  RuleSetRule as RspackRuleSetRule,
+} from '@rspack/core';
+import {
+  RuleSetCondition as WebpackRuleSetCondition,
+  RuleSetConditionAbsolute as WebpackRuleSetConditionAbsolute,
+  RuleSetRule as WebpackRuleSetRule,
+} from 'webpack';
+import {
+  BriefModeConfig,
+  BriefModeOptions,
+  IOutput,
+  NewReportCodeType,
+  NormalModeOptions,
+} from '@/types';
+
+/**
+ * Process mode-specific configurations with priority logic
+ */
+export function processModeConfigurations(
+  finalMode: keyof typeof SDK.IMode,
+  output: IOutput,
+  brief: SDK.BriefConfig | undefined,
+) {
+  let finalBrief = {};
+  let finalNormalOptions: NormalModeOptions = {};
+
+  if (finalMode === 'brief') {
+    finalBrief = processBriefHtmlModeConfig(output as BriefModeConfig, brief);
+  } else if (finalMode === 'normal') {
+    finalNormalOptions = {};
+  }
+
+  return { finalBrief, finalNormalOptions };
+}
+
+/**
+ * Process brief mode configuration with priority logic
+ * Priority: output.options.briefOptions > output.brief > default
+ */
+export function processBriefHtmlModeConfig(
+  output: BriefModeConfig,
+  brief: SDK.BriefConfig | undefined,
+): BriefModeOptions {
+  const briefOptions = output?.options as BriefModeOptions;
+  const outputBriefOptions = briefOptions?.htmlOptions;
+  const outputBrief = brief;
+
+  const finalBriefOptions = outputBriefOptions ||
+    outputBrief || {
+      reportHtmlName: undefined,
+      writeDataJson: false,
+    };
+
+  return {
+    type: ['html'],
+    htmlOptions: finalBriefOptions,
+  };
+}
+
+/**
+ * Convert reportCodeType object to NewReportCodeType enum value
+ */
+export function convertReportCodeTypeObject(
+  reportCodeType: any,
+): NewReportCodeType | undefined {
+  if (!reportCodeType) return undefined;
+
+  if (reportCodeType.noCode) {
+    return 'noCode';
+  } else if (reportCodeType.noAssetsAndModuleSource) {
+    return 'noAssetsAndModuleSource';
+  } else if (reportCodeType.noModuleSource) {
+    return 'noModuleSource';
+  }
+
+  return undefined;
+}
+
+// --For loader configs--
+/**
+ * This function recursively processes rule set conditions to ensure they can be
+ * properly serialized to JSON.
+ *
+ * @param item - The rule set condition to make serializable. Can be:
+ *   - RspackRuleSetCondition: Rspack-specific rule conditions
+ *   - WebpackRuleSetConditionAbsolute: Webpack absolute rule conditions
+ *   - WebpackRuleSetCondition: Webpack rule conditions
+ *   - void: Undefined or null values
+ *
+ * @example
+ * ```typescript
+ * const condition = /\.js$/;
+ * JSON.stringify(condition); // Error: Converting circular structure to JSON
+ *
+ * makeRuleSetSerializable(condition);
+ * JSON.stringify(condition); // '"/\\.js$/"'
+ * ```
+ */
+export function makeRuleSetSerializable(
+  item:
+    | RspackRuleSetCondition
+    | WebpackRuleSetConditionAbsolute
+    | WebpackRuleSetCondition
+    | void,
+) {
+  if (!item) return;
+  if (item instanceof RegExp) {
+    // Used by the JSON.stringify method to enable the transformation of an object's data for JavaScript Object Notation (JSON) serialization.
+    (item as Common.PlainObject).toJSON = item.toString;
+  } else if (Array.isArray(item)) {
+    item.forEach((i) => makeRuleSetSerializable(i));
+  } else if (typeof item === 'object') {
+    makeRuleSetSerializable(item.and);
+    makeRuleSetSerializable(item.or);
+    makeRuleSetSerializable(item.not);
+  }
+}
+export function makeRulesSerializable(
+  rules:
+    | Plugin.RuleSetRule[]
+    | RspackRuleSetRule['oneOf']
+    | WebpackRuleSetRule['oneOf'],
+) {
+  if (!Array.isArray(rules)) return;
+  if (!rules.length) return;
+  rules.forEach((rule) => {
+    if (!rule) return;
+    makeRuleSetSerializable(rule.test);
+    makeRuleSetSerializable(rule.resourceQuery);
+    makeRuleSetSerializable(rule.resource);
+    makeRuleSetSerializable(rule.resourceFragment);
+    makeRuleSetSerializable(rule.scheme);
+    makeRuleSetSerializable(rule.issuer);
+    if ('issuerLayer' in rule) {
+      makeRuleSetSerializable(rule.issuerLayer);
+    }
+    makeRuleSetSerializable(rule.include);
+    makeRuleSetSerializable(rule.exclude);
+    if (rule.oneOf) {
+      makeRulesSerializable(rule.oneOf);
+    }
+    if ('rules' in rule && rule.rules) {
+      makeRulesSerializable(rule.rules);
+    }
+  });
+}

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -18,6 +18,86 @@ export type IReportCodeType = {
 
 export type IOutput = {};
 
+enum ReportCodeType {
+  NoModuleSource = 'noModuleSource',
+  NoAssetsAndModuleSource = 'noAssetsAndModuleSource',
+  NoCode = 'noCode',
+}
+
+interface NormalModeOptions {
+  reportCodeType?: ReportCodeType;
+}
+
+// 输出模式枚举
+enum RsdoctorOutputMode {
+  Brief = 'brief',
+  Normal = 'normal', // default
+}
+
+// 输出格式枚举
+enum RsdoctorOutputType {
+  HTML = 'html',
+  JSON = 'json',
+}
+
+// JSON 输出预设
+enum JsonPresetType {
+  Minimal = 'minimal',
+  Normal = 'normal', // default
+}
+
+// JSON 输出配置
+interface JsonOptions {
+  /** 输出预设类型 */
+  preset?: JsonPresetType; // default: 'normal'
+  /** 细粒度的数据输出控制 */
+  sections?: JsonSectionOptions;
+}
+
+// JSON 输出的细粒度控制选项
+interface JsonSectionOptions {
+  /** 模块依赖图数据 */
+  moduleGraph?: boolean; // default: true
+  /** 代码块依赖图数据 */
+  chunkGraph?: boolean; // default: true
+  /** 规则相关数据 */
+  rules?: boolean; // default: true
+}
+
+interface HtmlOptions {
+  /** 自定义报告HTML文件名 */
+  reportHtmlName?: string;
+  /** 是否同时输出数据JSON文件 */
+  writeDataJson?: boolean;
+}
+
+interface BriefModeOptions {
+  /** 输出类型，支持HTML和JSON */
+  type?: RsdoctorOutputType[]; // default: ['html']
+  /** JSON输出相关配置 */
+  jsonOptions?: JsonOptions;
+  /** HTML输出相关配置 */
+  htmlOptions?: HtmlOptions;
+}
+
+// 基础配置接口
+interface BaseConfig {
+  /** 输出目录路径 */
+  outputDir: string;
+}
+
+// Brief 模式完整配置
+interface BriefModeConfig extends BaseConfig {
+  mode: RsdoctorOutputMode.Brief;
+  options?: BriefModeOptions;
+}
+
+// Normal 模式完整配置
+interface NormalModeConfig extends BaseConfig {
+  mode: RsdoctorOutputMode.Normal;
+  options?: NormalModeOptions;
+}
+
 export interface RsdoctorWebpackPluginOptions<
   Rules extends LinterType.ExtendRuleData[],
 > {
@@ -86,31 +166,33 @@ export interface RsdoctorWebpackPluginOptions<
    */
   innerClientPath?: string;
 
-  output?: {
-    /**
-     * The directory where the report files will be output.
-     */
-    reportDir?: string;
+  output?:
+    | ({
+        /**
+         * The directory where the report files will be output.
+         */
+        reportDir?: string;
 
-    /**
-     * Rsdoctor mode option:
-     * - normal: Refers to the normal mode.
-     * - brief: Refers to the brief mode, which only displays the results of the duration analysis and build artifact analysis
-     *    and does not display any part of the code.
-     */
-    mode?: keyof typeof SDK.IMode;
+        /**
+         * Rsdoctor mode option:
+         * - normal: Refers to the normal mode.
+         * - brief: Refers to the brief mode, which only displays the results of the duration analysis and build artifact analysis
+         *    and does not display any part of the code.
+         */
+        mode?: keyof typeof SDK.IMode;
 
-    /**
-     * Control the Rsdoctor reporter codes records.
-     */
-    reportCodeType?: IReportCodeType | undefined;
+        /**
+         * Control the Rsdoctor reporter codes records.
+         */
+        reportCodeType?: IReportCodeType | undefined;
 
-    /**
-     * Configure whether to compress data.
-     * @default false
-     */
-    compressData?: boolean;
-  };
+        /**
+         * Configure whether to compress data.
+         * @default false
+         */
+        compressData?: boolean;
+      } & BriefModeConfig)
+    | NormalModeConfig;
 }
 
 export interface RsdoctorMultiplePluginOptions<

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -31,12 +31,11 @@ export interface RsdoctorWebpackPluginOptions<
     | Array<keyof Plugin.RsdoctorWebpackPluginFeatures>;
 
   /**
+   * @deprecated Now need to use output.mode.
    * Rsdoctor mode option:
    * - normal: Refers to the normal mode.
    * - brief: Refers to the brief mode, which only displays the results of the duration analysis and build artifact analysis
    *    and does not display any part of the code.
-   * - lite: Refers to the lightweight mode,
-   *   which is a lightweight analysis report in the normal mode with the source code display removed.
    */
   mode?: keyof typeof SDK.IMode;
 
@@ -94,6 +93,14 @@ export interface RsdoctorWebpackPluginOptions<
     reportDir?: string;
 
     /**
+     * Rsdoctor mode option:
+     * - normal: Refers to the normal mode.
+     * - brief: Refers to the brief mode, which only displays the results of the duration analysis and build artifact analysis
+     *    and does not display any part of the code.
+     */
+    mode?: keyof typeof SDK.IMode;
+
+    /**
      * Control the Rsdoctor reporter codes records.
      */
     reportCodeType?: IReportCodeType | undefined;
@@ -128,13 +135,20 @@ export interface RsdoctorPluginOptionsNormalized<
 > extends Common.DeepRequired<
     Omit<
       RsdoctorWebpackPluginOptions<Rules>,
-      'sdkInstance' | 'linter' | 'output' | 'supports' | 'port' | 'brief'
+      | 'sdkInstance'
+      | 'linter'
+      | 'output'
+      | 'supports'
+      | 'port'
+      | 'brief'
+      | 'mode'
     >
   > {
   features: Common.DeepRequired<Plugin.RsdoctorWebpackPluginFeatures>;
   linter: Required<LinterType.Options<Rules, InternalRules>>;
   sdkInstance?: RsdoctorSDK;
   output: {
+    mode: keyof typeof SDK.IMode;
     reportCodeType: SDK.ToDataType;
     reportDir: string;
     compressData: boolean;

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -61,12 +61,11 @@ interface OutputBaseConfig {
 }
 
 // Conditional type for reportCodeType based on mode
-type ReportCodeTypeByMode<T extends 'brief' | 'normal' | undefined> =
-  T extends 'brief'
-    ? undefined | 'noCode' | { noCode?: boolean }
-    : T extends 'normal'
-      ? IReportCodeType | undefined | NewReportCodeType
-      : IReportCodeType | undefined | NewReportCodeType;
+type ReportCodeTypeByMode<T extends 'brief' | 'normal'> = T extends 'brief'
+  ? undefined | 'noCode' | { noCode?: boolean }
+  : T extends 'normal'
+    ? IReportCodeType | undefined | NewReportCodeType
+    : IReportCodeType | undefined | NewReportCodeType;
 
 // Brief Mode Type
 export interface BriefModeConfig
@@ -97,7 +96,7 @@ export interface RsdoctorWebpackPluginOptions<
     | Array<keyof Plugin.RsdoctorWebpackPluginFeatures>;
 
   /**
-   * @deprecated Now need to use output.mode.
+   * @deprecated  Use `output.mode` instead, if you're using `lite` mode, please use `output.reportCodeType: 'noCode' or 'noAssetsAndModuleSource'` instead.
    * Rsdoctor mode option:
    * - normal: Refers to the normal mode.
    * - brief: Refers to the brief mode, which only displays the results of the duration analysis and build artifact analysis
@@ -142,7 +141,7 @@ export interface RsdoctorWebpackPluginOptions<
   printLog?: SDK.IPrintLog;
 
   /**
-   * @deprecated
+   * @deprecated  Use `output.options.htmlOptions` instead.
    * Please use the output.options to set the brief options, BriefModeOptions.
    * Options to control brief mode reports.
    */

--- a/packages/rspack-plugin/src/multiple.ts
+++ b/packages/rspack-plugin/src/multiple.ts
@@ -35,7 +35,10 @@ export class RsdoctorRspackMultiplePlugin<
         mode: normallizedOptions.output.mode
           ? normallizedOptions.output.mode
           : undefined,
-        brief: normallizedOptions.brief,
+        brief:
+          'htmlOptions' in normallizedOptions.output.options
+            ? normallizedOptions.output.options.htmlOptions
+            : undefined,
       },
       type: normallizedOptions.output.reportCodeType,
     });

--- a/packages/rspack-plugin/src/multiple.ts
+++ b/packages/rspack-plugin/src/multiple.ts
@@ -32,7 +32,9 @@ export class RsdoctorRspackMultiplePlugin<
       extraConfig: {
         innerClientPath: normallizedOptions.innerClientPath,
         printLog: normallizedOptions.printLog,
-        mode: normallizedOptions.mode ? normallizedOptions.mode : undefined,
+        mode: normallizedOptions.output.mode
+          ? normallizedOptions.output.mode
+          : undefined,
         brief: normallizedOptions.brief,
       },
       type: normallizedOptions.output.reportCodeType,

--- a/packages/rspack-plugin/src/plugin.ts
+++ b/packages/rspack-plugin/src/plugin.ts
@@ -66,7 +66,7 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
         },
       }),
     );
-    const { port, output, innerClientPath, printLog, brief, sdkInstance } =
+    const { port, output, innerClientPath, printLog, sdkInstance } =
       this.options;
 
     this.sdk =
@@ -80,8 +80,10 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
           innerClientPath,
           printLog,
           mode: output.mode ? output.mode : undefined,
-          brief,
-          compressData: output.compressData,
+          brief:
+            'htmlOptions' in output.options
+              ? output.options.htmlOptions
+              : undefined,
         },
       });
     this.outsideInstance = Boolean(sdkInstance);

--- a/packages/rspack-plugin/src/plugin.ts
+++ b/packages/rspack-plugin/src/plugin.ts
@@ -66,22 +66,25 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
         },
       }),
     );
+    const { port, output, innerClientPath, printLog, brief, sdkInstance } =
+      this.options;
+
     this.sdk =
       this.options.sdkInstance ??
       new RsdoctorSDK({
-        port: this.options.port,
+        port,
         name: pluginTapName,
         root: process.cwd(),
-        type: this.options.output.reportCodeType,
+        type: output.reportCodeType,
         config: {
-          innerClientPath: this.options.innerClientPath,
-          printLog: this.options.printLog,
-          mode: this.options.mode ? this.options.mode : undefined,
-          brief: this.options.brief,
-          compressData: this.options.output.compressData,
+          innerClientPath,
+          printLog,
+          mode: output.mode ? output.mode : undefined,
+          brief,
+          compressData: output.compressData,
         },
       });
-    this.outsideInstance = Boolean(this.options.sdkInstance);
+    this.outsideInstance = Boolean(sdkInstance);
     this.modulesGraph = new ModuleGraph();
     this.isRsdoctorPlugin = true;
   }
@@ -240,7 +243,7 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
       await this.sdk.writeStore();
       if (!this.options.disableClientServer) {
         // If it's brief mode, open the static report page instead of the local server page.
-        if (this.options.mode === SDK.IMode[SDK.IMode.brief]) {
+        if (this.options.output.mode === SDK.IMode[SDK.IMode.brief]) {
           // Use extracted common function to handle brief mode
           handleBriefModeReport(
             this.sdk,

--- a/packages/sdk/src/sdk/sdk/core.ts
+++ b/packages/sdk/src/sdk/sdk/core.ts
@@ -1,6 +1,5 @@
 import { Common, Constants, Manifest, SDK } from '@rsdoctor/types';
 import { File, Json, EnvInfo } from '@rsdoctor/utils/build';
-import { Algorithm } from '@rsdoctor/utils/common';
 import path from 'path';
 import { createHash } from 'crypto';
 import process from 'process';
@@ -155,19 +154,11 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
 
       if (Array.isArray(jsonStr)) {
         const urls = jsonStr.map((str, index) => {
-          return this.writeToFolder(
-            str,
-            outputDir,
-            key,
-            this.extraConfig,
-            index + 1,
-          );
+          return this.writeToFolder(str, outputDir, key, index + 1);
         });
         urlsPromiseList.push(...urls);
       } else {
-        urlsPromiseList.push(
-          this.writeToFolder(jsonStr, outputDir, key, this.extraConfig),
-        );
+        urlsPromiseList.push(this.writeToFolder(jsonStr, outputDir, key));
       }
     }
 
@@ -219,13 +210,9 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
     jsonStr: string,
     dir: string,
     key: string,
-    extraConfig: SDK.SDKOptionsType | undefined,
     index?: number,
   ): Promise<DataWithUrl> {
-    const { compressData } = extraConfig || { compressData: true };
-    const sharding = compressData
-      ? new File.FileSharding(Algorithm.compressText(jsonStr))
-      : new File.FileSharding(jsonStr);
+    const sharding = new File.FileSharding(jsonStr);
     const folder = path.resolve(dir, key);
     const writer = sharding.writeStringToFolder(folder, '', index);
     return writer.then((item) => {

--- a/packages/types/src/sdk/instance.ts
+++ b/packages/types/src/sdk/instance.ts
@@ -20,9 +20,9 @@ import { Hooks } from './hooks';
 export type WriteStoreOptionsType = {};
 
 export enum IMode {
-  brief,
-  lite,
-  normal,
+  brief = 'brief',
+  lite = 'lite',
+  normal = 'normal',
 }
 
 export interface RsdoctorBuilderSDKInstance extends RsdoctorSDKInstance {
@@ -114,7 +114,7 @@ export interface IPrintLog {
 }
 
 export interface BriefConfig {
-  reportHtmlName?: string | undefined;
+  reportHtmlName?: string;
   writeDataJson: boolean;
 }
 
@@ -125,7 +125,6 @@ export type SDKOptionsType = {
   printLog?: IPrintLog;
   mode?: keyof typeof IMode;
   brief?: BriefConfig;
-  compressData?: boolean;
 };
 
 /**

--- a/packages/webpack-plugin/src/multiple.ts
+++ b/packages/webpack-plugin/src/multiple.ts
@@ -32,7 +32,9 @@ export class RsdoctorWebpackMultiplePlugin<
       extraConfig: {
         innerClientPath: normallizedOptions.innerClientPath,
         printLog: normallizedOptions.printLog,
-        mode: normallizedOptions.mode ? normallizedOptions.mode : undefined,
+        mode: normallizedOptions.output.mode
+          ? normallizedOptions.output.mode
+          : undefined,
         brief: normallizedOptions.brief,
         compressData: normallizedOptions.output.compressData,
       },

--- a/packages/webpack-plugin/src/multiple.ts
+++ b/packages/webpack-plugin/src/multiple.ts
@@ -35,8 +35,10 @@ export class RsdoctorWebpackMultiplePlugin<
         mode: normallizedOptions.output.mode
           ? normallizedOptions.output.mode
           : undefined,
-        brief: normallizedOptions.brief,
-        compressData: normallizedOptions.output.compressData,
+        brief:
+          'htmlOptions' in normallizedOptions.output.options
+            ? normallizedOptions.output.options.htmlOptions
+            : undefined,
       },
       type: normallizedOptions.output.reportCodeType,
     });

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -56,7 +56,7 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
 
   constructor(options?: RsdoctorWebpackPluginOptions<Rules>) {
     this.options = normalizeUserConfig<Rules>(options);
-    const { port, output, innerClientPath, printLog, brief, sdkInstance } =
+    const { port, output, innerClientPath, printLog, sdkInstance } =
       this.options;
 
     this.sdk =
@@ -70,8 +70,10 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
           innerClientPath: innerClientPath,
           printLog: printLog,
           mode: output.mode,
-          brief: brief,
-          compressData: output.compressData,
+          brief:
+            'htmlOptions' in output.options
+              ? output.options.htmlOptions
+              : undefined,
         },
       });
 

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -56,19 +56,22 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
 
   constructor(options?: RsdoctorWebpackPluginOptions<Rules>) {
     this.options = normalizeUserConfig<Rules>(options);
+    const { port, output, innerClientPath, printLog, brief, sdkInstance } =
+      this.options;
+
     this.sdk =
-      this.options.sdkInstance ??
+      sdkInstance ??
       new RsdoctorSDK({
-        port: this.options.port,
+        port: port,
         name: pluginTapName,
         root: process.cwd(),
-        type: this.options.output.reportCodeType,
+        type: output.reportCodeType,
         config: {
-          innerClientPath: this.options.innerClientPath,
-          printLog: this.options.printLog,
-          mode: this.options.mode,
-          brief: this.options.brief,
-          compressData: this.options.output.compressData,
+          innerClientPath: innerClientPath,
+          printLog: printLog,
+          mode: output.mode,
+          brief: brief,
+          compressData: output.compressData,
         },
       });
 
@@ -175,7 +178,7 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
 
     await this._bootstrapTask.then(() => {
       if (!this.options.disableClientServer && !this.browserIsOpened) {
-        if (this.options.mode !== SDK.IMode[SDK.IMode.brief]) {
+        if (this.options.output.mode !== SDK.IMode[SDK.IMode.brief]) {
           this.browserIsOpened = true;
           this.sdk.server.openClientPage();
         }
@@ -210,7 +213,7 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
           `${Process.getMemoryUsageMessage()}, '[After SDK Dispose]'`,
         );
       } else if (
-        this.options.mode === SDK.IMode[SDK.IMode.brief] &&
+        this.options.output.mode === SDK.IMode[SDK.IMode.brief] &&
         !this.options.disableClientServer
       ) {
         // Use extracted common function to handle brief mode

--- a/packages/webpack-plugin/tests/multiple.test.ts
+++ b/packages/webpack-plugin/tests/multiple.test.ts
@@ -35,4 +35,33 @@ describe('test src/multiple.ts', () => {
       ]);
     });
   });
+
+  describe('test mode configuration', () => {
+    it('should use output.mode when provided', async () => {
+      const { RsdoctorWebpackMultiplePlugin } = await loadMultipleFile();
+      const plugin = new RsdoctorWebpackMultiplePlugin({
+        name: 'TestPlugin',
+        output: {
+          mode: 'lite',
+        },
+      });
+
+      // Verify that the plugin is created successfully with output.mode
+      expect(plugin).toBeDefined();
+    });
+
+    it('should use output.mode over mode when both are provided', async () => {
+      const { RsdoctorWebpackMultiplePlugin } = await loadMultipleFile();
+      const plugin = new RsdoctorWebpackMultiplePlugin({
+        name: 'TestPlugin',
+        mode: 'normal',
+        output: {
+          mode: 'lite',
+        },
+      });
+
+      // Verify that the plugin is created successfully
+      expect(plugin).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
This MR only migrates the existing configuration without introducing any new logic. The main migration points are as follows:

- Changed mode to output.mode, while retaining the original mode configuration and logic, and adding a prompt.
- Added the output.options configuration, which is divided into NormalModeConfig and BriefModeConfig, both following the existing configuration logic.
- Removed the output.compressData configuration since no users were using it, and added a prompt.
- For mode: lite, added a prompt while retaining the original logic.
- Added tests for the new configuration items after migration.

————————————————————————————————————————————————————————
本 MR 只对原有的配置做了迁移，没有新加逻辑，迁移主要有以下几点：
- mode 改为 output.mode, 保留原先 mode 配置及逻辑，同时增加提示。
- 增加 output.options 配置分为：NormalModeConfig 和 BriefModeConfig， 都为原来已有的配置逻辑。
- 删除 output.compressData 配置,因为没有用户使用，同时增加提示。
- mode: lite 增加提示，保留原有逻辑。
- 给迁移后新的配置项增加测试

## Related Links
#1090 
<!--- Provide links of related issues or pages -->
