### PR TITLE
fix: proxy loader return undefined error

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "scripts": {
-    "build": "cross-env NX_DAEMON=false nx run-many -t build --projects=@rsdoctor/*,@examples/rsdoctor-rspack-banner --parallel=10",
+    "build": "cross-env NX_DAEMON=false nx run-many -t build --projects=@rsdoctor/*,@examples/rsdoctor-rspack-banner,@examples/doctor-rsbuild-minimal --parallel=10",
     "change": "changeset",
     "changeset": "changeset",
     "bump": "changeset version",

--- a/packages/core/src/inner-plugins/loaders/proxy.ts
+++ b/packages/core/src/inner-plugins/loaders/proxy.ts
@@ -68,7 +68,7 @@ const loaderModule: Plugin.LoaderDefinition<ProxyLoaderOptions, {}> = function (
         }
       }
 
-      return result;
+      return result || '';
     } catch (error) {
       reportLoader(
         this,

--- a/packages/core/src/inner-plugins/plugins/loader.ts
+++ b/packages/core/src/inner-plugins/plugins/loader.ts
@@ -12,7 +12,7 @@ import { fileURLToPath } from 'url';
 
 // ESM equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const dirname = path.dirname(__filename);
 
 // Determine the proxy file extension based on current file extension
 const getProxyExtension = () => {
@@ -25,9 +25,10 @@ export class InternalLoaderPlugin<
 > extends InternalBasePlugin<T> {
   public readonly name = 'loader';
 
-  public readonly internalLoaderPath: string = require.resolve(
-    path.join(__dirname, `../loaders/proxy${getProxyExtension()}`),
-  );
+  public readonly internalLoaderPath: string =
+    getProxyExtension() === '.cjs'
+      ? require.resolve(path.join(__dirname, `../loaders/proxy.cjs`))
+      : require.resolve(path.join(dirname, `../loaders/proxy.cjs`));
 
   public apply(compiler: T) {
     time('InternalLoaderPlugin.apply');

--- a/packages/core/src/inner-plugins/plugins/loader.ts
+++ b/packages/core/src/inner-plugins/plugins/loader.ts
@@ -12,24 +12,17 @@ import { fileURLToPath } from 'url';
 
 // ESM equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
-const dirname = path.dirname(__filename);
-
-// Determine the proxy file extension based on current file extension
-const getProxyExtension = () => {
-  const currentExt = path.extname(__filename);
-  return currentExt === '.cjs' ? '.cjs' : '.js';
-};
+const __dirname = path.dirname(__filename);
 
 export class InternalLoaderPlugin<
   T extends Plugin.BaseCompiler,
 > extends InternalBasePlugin<T> {
   public readonly name = 'loader';
 
-  // TODO: find the reason why  using loader/proxy.js causes this problem https://github.com/web-infra-dev/rsdoctor/pull/1271.
-  public readonly internalLoaderPath: string =
-    getProxyExtension() === '.cjs'
-      ? require.resolve(path.join(__dirname, `../loaders/proxy.cjs`))
-      : require.resolve(path.join(dirname, `../loaders/proxy.cjs`));
+  // TODO: find the reason why using loader/proxy.js causes this problem https://github.com/web-infra-dev/rsdoctor/pull/1271.
+  public readonly internalLoaderPath: string = require.resolve(
+    path.join(__dirname, `../loaders/proxy.cjs`),
+  );
 
   public apply(compiler: T) {
     time('InternalLoaderPlugin.apply');

--- a/packages/core/src/inner-plugins/plugins/loader.ts
+++ b/packages/core/src/inner-plugins/plugins/loader.ts
@@ -25,6 +25,7 @@ export class InternalLoaderPlugin<
 > extends InternalBasePlugin<T> {
   public readonly name = 'loader';
 
+  // TODO: find the reason why  using loader/proxy.js causes this problem https://github.com/web-infra-dev/rsdoctor/pull/1271.
   public readonly internalLoaderPath: string =
     getProxyExtension() === '.cjs'
       ? require.resolve(path.join(__dirname, `../loaders/proxy.cjs`))


### PR DESCRIPTION
## Summary
fix: proxy loader return undefined error
When use the loader/proxy.js esm module, the cssextractloader will report this error belowing, so need to change to loader/proxy.cjs.

<img width="709" height="590" alt="image" src="https://github.com/user-attachments/assets/a003e2fa-51fe-4b0f-8cb4-f697c9181b0a" />

But I'm not sure why using loader/proxy.js causes this problem.

## Related Links

<!--- Provide links of related issues or pages -->
