### PR TITLE
perf: optimize the stats.toJson's time-consuming

### DIFF
--- a/packages/core/src/inner-plugins/plugins/ensureModulesChunkGraph.ts
+++ b/packages/core/src/inner-plugins/plugins/ensureModulesChunkGraph.ts
@@ -124,8 +124,17 @@ async function doneHandler(
     let cached: Plugin.StatsCompilation | null = null;
     return () => {
       if (cached) return cached as Plugin.StatsCompilation;
-      // TODO: Optimize stats.toJSON options for performance
-      cached = stats.toJson();
+      cached = stats.toJson({
+        all: false,
+        chunks: true,
+        modules: true,
+        chunkModules: true,
+        assets: true,
+        ids: true,
+        hash: true,
+        errors: true,
+        warnings: true,
+      });
       return cached;
     };
   })();

--- a/packages/types/src/plugin/baseStats.ts
+++ b/packages/types/src/plugin/baseStats.ts
@@ -12,6 +12,9 @@ interface StatsOptionsObj {
   errors?: boolean;
   errorsCount?: boolean;
   colors?: boolean;
+  chunkModules: boolean;
+  hash?: boolean;
+  ids?: boolean;
 
   /** Rspack not support below opts */
   cachedAssets?: boolean;

--- a/packages/types/src/plugin/baseStats.ts
+++ b/packages/types/src/plugin/baseStats.ts
@@ -12,7 +12,7 @@ interface StatsOptionsObj {
   errors?: boolean;
   errorsCount?: boolean;
   colors?: boolean;
-  chunkModules: boolean;
+  chunkModules?: boolean;
   hash?: boolean;
   ids?: boolean;
 


### PR DESCRIPTION
## Summary
perf: optimize the stats.toJson's time-consuming

## Related Links

<!--- Provide links of related issues or pages -->
