### PR TITLE
fix: ensure unique collapsible key

### DIFF
--- a/packages/components/src/components/Alerts/collapse-cross-chunks.tsx
+++ b/packages/components/src/components/Alerts/collapse-cross-chunks.tsx
@@ -81,7 +81,7 @@ export const CrossChunksAlertCollapse = (props: {
     };
 
     return {
-      key: d.code,
+      key: `${dupPackage.name}@${dupPackage.version}`,
       label: (
         <LabelComponent
           title={

--- a/packages/components/src/components/Alerts/collapse.tsx
+++ b/packages/components/src/components/Alerts/collapse.tsx
@@ -144,7 +144,7 @@ export const AlertCollapse = (props: {
       };
 
       return {
-        key: data.code,
+        key: name,
         label: (
           <LabelComponent
             title={


### PR DESCRIPTION
## Summary

In Bundle Alerts, we couldn't collapse a section because they were all collapsing instead of maintaining a unique state, which makes scrolling through all the data more difficult. Was it expected? I don't think so.

### Before

https://github.com/user-attachments/assets/926a293c-1e70-466f-bc8f-b42bcfd4d20e

### After

https://github.com/user-attachments/assets/d3285ff0-bf25-47a4-ad0b-c4c338f58ef0

## Related Links

<!--- Provide links of related issues or pages -->
