### PR TITLE
chore: ignore `.rsdoctor` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ log/
 
 .cursor/
 e2e/test-results/
+.rsdoctor/


### PR DESCRIPTION
## Summary

I ran E2E tests locally and ended up with a bunch of new files ready to commit in `e2e/.rsdoctor`, let's add `.rsdoctor` to the `.gitignore`.

## Related Links

<!--- Provide links of related issues or pages -->
