### PR TITLE
chore(deps): declare `@types/fs-extra` as devDependency

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -34,7 +34,6 @@
     "@rsdoctor/graph": "workspace:*",
     "@rsdoctor/types": "workspace:*",
     "@rsdoctor/utils": "workspace:*",
-    "@types/fs-extra": "^11.0.4",
     "safer-buffer": "2.1.2",
     "socket.io": "4.8.1",
     "tapable": "2.2.2"
@@ -43,6 +42,7 @@
     "@types/body-parser": "1.19.6",
     "@types/connect": "3.4.38",
     "@types/cors": "2.8.19",
+    "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.8.1",
     "body-parser": "1.20.3",
     "cors": "2.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -973,9 +973,6 @@ importers:
       '@rsdoctor/utils':
         specifier: workspace:*
         version: link:../utils
-      '@types/fs-extra':
-        specifier: ^11.0.4
-        version: 11.0.4
       safer-buffer:
         specifier: 2.1.2
         version: 2.1.2
@@ -995,6 +992,9 @@ importers:
       '@types/cors':
         specifier: 2.8.19
         version: 2.8.19
+      '@types/fs-extra':
+        specifier: ^11.0.4
+        version: 11.0.4
       '@types/node':
         specifier: ^22.8.1
         version: 22.18.1


### PR DESCRIPTION
## Summary

Declare `@types/fs-extra` as devDependency so that consumers of the library won't need to install it
