### PR TITLE
fix: playground problem

### DIFF
--- a/packages/components/src/pages/Uploader/utils.ts
+++ b/packages/components/src/pages/Uploader/utils.ts
@@ -10,7 +10,7 @@ const defaultEnableRoutes = [
 
 // Build redirect URL
 const buildRedirectUrl = (enableRoutes: string[]) => {
-  const baseUrl = `http://${location.host}${location.pathname}#/overall`;
+  const baseUrl = `//${location.host}${location.pathname}#/overall`;
   const queryParams =
     enableRoutes && enableRoutes.length > 0
       ? `?${Client.RsdoctorClientUrlQuery.EnableRoutes}=${encodeURIComponent(JSON.stringify(enableRoutes))}`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -805,8 +805,6 @@ importers:
         specifier: ^5.97.1
         version: 5.97.1(webpack-cli@5.1.4)
 
-  packages/core/compiled/axios: {}
-
   packages/document:
     dependencies:
       '@rspress/core':
@@ -1040,10 +1038,6 @@ importers:
   packages/sdk/compiled/fs-extra: {}
 
   packages/sdk/compiled/json-cycle: {}
-
-  packages/sdk/compiled/sirv: {}
-
-  packages/sdk/compiled/socket.io: {}
 
   packages/types:
     dependencies:


### PR DESCRIPTION
## Summary
fix: playground problem

The redirectUrl previously included http://, which caused a navigation to a new page. As a result, the data mounted on the window was lost, leading to an error due to missing data on the page.

## Related Links

<!--- Provide links of related issues or pages -->
