### PR TITLE
fix: stats transform to assets graph

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -805,6 +805,10 @@ importers:
         specifier: ^5.97.1
         version: 5.97.1(webpack-cli@5.1.4)
 
+  packages/core/compiled/@rsbuild/plugin-check-syntax: {}
+
+  packages/core/compiled/axios: {}
+
   packages/document:
     dependencies:
       '@rspress/core':
@@ -1038,6 +1042,10 @@ importers:
   packages/sdk/compiled/fs-extra: {}
 
   packages/sdk/compiled/json-cycle: {}
+
+  packages/sdk/compiled/sirv: {}
+
+  packages/sdk/compiled/socket.io: {}
 
   packages/types:
     dependencies:


### PR DESCRIPTION
## Summary
fix: stats transform to assets graph

In some cases, assets will be empty, and you need to collect them from the files of chunk.

## Related Links

<!--- Provide links of related issues or pages -->
