### PR TITLE
fix: rspack stats  analysis don't  must require modules

### DIFF
--- a/packages/components/src/utils/stats.ts
+++ b/packages/components/src/utils/stats.ts
@@ -6,12 +6,7 @@ import { isArray } from 'lodash-es';
 export function isRspackStats(
   json: Common.PlainObject,
 ): json is Plugin.StatsCompilation {
-  return (
-    json.hash &&
-    isArray(json.assets) &&
-    isArray(json.chunks) &&
-    isArray(json.modules)
-  );
+  return isArray(json.assets) && isArray(json.chunks);
 }
 
 export async function loadRspackStats(


### PR DESCRIPTION
## Summary
fix: if rspack stats don't have modules, also can analysis

## Related Links

<!--- Provide links of related issues or pages -->
