### PR TITLE
fix: the nodeExnext type file problem

### DIFF
--- a/scripts/rslib.base.config.ts
+++ b/scripts/rslib.base.config.ts
@@ -66,6 +66,11 @@ export const esmConfig: LibConfig = {
   dts: {
     build: true,
   },
+  redirect: {
+    dts: {
+      extension: true,
+    },
+  },
   output: {
     minify: nodeMinifyConfig,
     filename: {


### PR DESCRIPTION
## Summary
This MR addresses the issue where the .js suffix was not included in index.d.ts. With "module": "NodeNext" and "moduleResolution": "NodeNext", the file extension needs to be specified explicitly. Therefore, this problem is resolved by using rslib's redirect.dts.extension.

## Related Links
#1343 

<!--- Provide links of related issues or pages -->
