### PR TITLE
fix: treemap no modules problem when this asset don't have sourcemap

### DIFF
--- a/packages/components/src/components/Charts/TreeMap.tsx
+++ b/packages/components/src/components/Charts/TreeMap.tsx
@@ -114,7 +114,7 @@ const TreeMapInner: React.FC<TreeMapProps & { forwardedRef?: React.Ref<any> }> =
           return {
             id: node.path ? hashString(node.path) : undefined,
             name: node.name,
-            value: node[valueKey] ?? node.value ?? 0,
+            value: node[valueKey] || node.value || node['sourceSize'] || 0,
             path: node.path,
             sourceSize: node.sourceSize ?? node.value,
             bundledSize: node.bundledSize,


### PR DESCRIPTION
## Summary
When there is no sourcemap in an asset, there is no drill modules in the treemap of the asset to fix this problem.

- before
<img width="2318" height="762" alt="image" src="https://github.com/user-attachments/assets/d613c41b-f246-48c1-8819-02c163346497" />

- after
<img width="2620" height="1374" alt="image" src="https://github.com/user-attachments/assets/0171e920-6b1e-4251-a1ff-98a06c7ada44" />

## Related Links

<!--- Provide links of related issues or pages -->
