### PR TITLE
fix: prevent infinite re-render caused by unstable dependencies

### DIFF
--- a/packages/components/src/utils/hooks.ts
+++ b/packages/components/src/utils/hooks.ts
@@ -1,7 +1,7 @@
 import { Algorithm } from '@rsdoctor/utils/common';
 import { Client, Manifest, Rule, SDK } from '@rsdoctor/types';
 import { uniqBy, defaults } from 'es-toolkit/compat';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useLocation } from 'react-router-dom';
 import parse from 'url-parse';
@@ -47,8 +47,8 @@ export function useRuleIndexNavigate(code: string, link?: string | undefined) {
 
 export function useUrlQuery() {
   const search = useLocation().search || location.search;
-  const { query } = parse(search, true);
-  return query;
+
+  return useMemo(() => parse(search, true).query, [search]);
 }
 
 export function useLoading(defaultLoading = false) {


### PR DESCRIPTION
## Summary

`useUrlQuery` 每次返回新的 `query` 会导致 [packages/components/src/components/Layout/index.tsx#L50-L53](https://github.com/web-infra-dev/rsdoctor/blob/main/packages/components/src/components/Layout/index.tsx#L50-L53) 重复渲染

## Related Links

<!--- Provide links of related issues or pages -->
