### PR TITLE
fix: Remove warning since rsdoctor supports resolver analysis

### DIFF
--- a/packages/rspack-plugin/src/plugin.ts
+++ b/packages/rspack-plugin/src/plugin.ts
@@ -36,7 +36,7 @@ import {
 
 import { ModuleGraph } from '@rsdoctor/graph';
 import { Loader } from '@rsdoctor/utils/common';
-import { chalk, logger, time, timeEnd } from '@rsdoctor/utils/logger';
+import { logger, time, timeEnd } from '@rsdoctor/utils/logger';
 
 export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
   implements RsdoctorRspackPluginInstance<Rules>
@@ -159,14 +159,6 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
         new InternalResolverPlugin<Plugin.BaseCompilerType<'rspack'>>(
           this,
         ).apply(compiler);
-      }
-
-      if (this.options.features.resolver) {
-        logger.info(
-          chalk.yellow(
-            'Rspack currently does not support Resolver capabilities.',
-          ),
-        );
       }
 
       new InternalRulesPlugin(this).apply(compiler);


### PR DESCRIPTION
## Summary

The resolver analysis [is implemented](https://github.com/web-infra-dev/rsdoctor/pull/1426/files#diff-810eb84fc9f9049ae8163cef1d3522df23649c3e6e8db750ad37aa7619decfd4R158) in https://github.com/web-infra-dev/rsdoctor/pull/1397. This warning seems to be redundant now, hence I suggest removing it.

Thank you for the effort of implementing it!
