### PR TITLE
fix: sourcemap tool problem

### DIFF
--- a/packages/core/src/inner-plugins/plugins/bundle.ts
+++ b/packages/core/src/inner-plugins/plugins/bundle.ts
@@ -24,10 +24,6 @@ export class InternalBundlePlugin<
     }
   }
   changeDevtoolModuleFilename(compiler: Plugin.BaseCompiler) {
-    if ('rspack' in compiler) {
-      return;
-    }
-
     const devtool = compiler.options.devtool;
     if (devtool) {
       if (!compiler.options.output) {

--- a/packages/core/src/inner-plugins/plugins/ensureModulesChunkGraph.ts
+++ b/packages/core/src/inner-plugins/plugins/ensureModulesChunkGraph.ts
@@ -141,6 +141,7 @@ async function doneHandler(
               cachedModules: true,
               orphanModules: true,
               runtimeModules: true,
+              optimizationBailout: true,
             });
       return cached;
     };

--- a/packages/sdk/src/sdk/sdk/index.ts
+++ b/packages/sdk/src/sdk/sdk/index.ts
@@ -584,7 +584,7 @@ export class RsdoctorSDK<
     function inlineScripts(basePath: string, scripts: string[]): string {
       return scripts
         .map((src) => {
-          const scriptPath = path.resolve(basePath, src);
+          const scriptPath = resolveFilePath(basePath, src);
           try {
             const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
             return `<script>${scriptContent}</script>`;
@@ -596,11 +596,19 @@ export class RsdoctorSDK<
         .join('');
     }
 
+    function resolveFilePath(basePath: string, filePath: string): string {
+      if (filePath.startsWith('/')) {
+        return path.resolve(basePath, filePath.slice(1));
+      }
+
+      return path.resolve(basePath, filePath);
+    }
+
     // Helper function to inline CSS files
     function inlineCss(basePath: string, cssFiles: string[]): string {
       return cssFiles
         .map((href) => {
-          const cssPath = path.resolve(basePath, href);
+          const cssPath = resolveFilePath(basePath, href);
           try {
             const cssContent = fs.readFileSync(cssPath, 'utf-8');
             return `<style>${cssContent}</style>`;

--- a/packages/types/src/plugin/baseStats.ts
+++ b/packages/types/src/plugin/baseStats.ts
@@ -19,6 +19,7 @@ interface StatsOptionsObj {
   runtimeModules?: boolean;
   cachedModules?: boolean;
   nestedModules?: boolean;
+  optimizationBailout?: boolean;
   /** Rspack not support below opts */
   cachedAssets?: boolean;
   groupAssetsByInfo?: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         version: 0.115.0(@types/react@18.3.27)
       '@lynx-js/rspeedy':
         specifier: ^0.12.1
-        version: 0.12.1(@rspack/core@1.6.6(@swc/helpers@0.5.17))(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(webpack@5.97.1)
+        version: 0.12.1(@rspack/core@1.6.6(@swc/helpers@0.5.17))(typescript@5.9.2)(webpack@5.97.1)
       '@playwright/test':
         specifier: 1.54.2
         version: 1.54.2
@@ -809,8 +809,6 @@ importers:
         specifier: ^5.97.1
         version: 5.97.1(webpack-cli@5.1.4)
 
-  packages/core/compiled/@rsbuild/plugin-check-syntax: {}
-
   packages/core/compiled/axios: {}
 
   packages/document:
@@ -1028,15 +1026,11 @@ importers:
         specifier: ^5.9.2
         version: 5.9.2
 
-  packages/sdk/compiled/body-parser: {}
-
   packages/sdk/compiled/cors: {}
 
   packages/sdk/compiled/dayjs: {}
 
   packages/sdk/compiled/fs-extra: {}
-
-  packages/sdk/compiled/json-cycle: {}
 
   packages/types:
     dependencies:
@@ -12766,7 +12760,7 @@ snapshots:
       '@types/react': 18.3.27
       preact: '@hongzhiyuan/preact@10.24.0-00213bad'
 
-  '@lynx-js/rspeedy@0.12.1(@rspack/core@1.6.6(@swc/helpers@0.5.17))(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(webpack@5.97.1)':
+  '@lynx-js/rspeedy@0.12.1(@rspack/core@1.6.6(@swc/helpers@0.5.17))(typescript@5.9.2)(webpack@5.97.1)':
     dependencies:
       '@lynx-js/cache-events-webpack-plugin': 0.0.2
       '@lynx-js/chunk-loading-webpack-plugin': 0.3.3
@@ -12775,7 +12769,7 @@ snapshots:
       '@lynx-js/websocket': 0.0.4
       '@rsbuild/core': 1.6.9
       '@rsbuild/plugin-css-minimizer': 1.0.3(@rsbuild/core@1.6.9)(webpack@5.97.1)
-      '@rsdoctor/rspack-plugin': 1.2.3(@rsbuild/core@1.6.9)(@rspack/core@1.6.6(@swc/helpers@0.5.17))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(webpack@5.97.1)
+      '@rsdoctor/rspack-plugin': 1.2.3(@rsbuild/core@1.6.9)(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.97.1)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -14165,11 +14159,11 @@ snapshots:
 
   '@rsdoctor/client@1.2.3': {}
 
-  '@rsdoctor/core@1.2.3(@rsbuild/core@1.6.9)(@rspack/core@1.6.6(@swc/helpers@0.5.17))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(webpack@5.97.1)':
+  '@rsdoctor/core@1.2.3(@rsbuild/core@1.6.9)(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.97.1)':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.3.0(@rsbuild/core@1.6.9)
       '@rsdoctor/graph': 1.2.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.97.1)
-      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(webpack@5.97.1)
+      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.97.1)
       '@rsdoctor/types': 1.2.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.97.1)
       '@rsdoctor/utils': 1.2.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.97.1)
       axios: 1.13.2
@@ -14201,11 +14195,11 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.2.3(@rsbuild/core@1.6.9)(@rspack/core@1.6.6(@swc/helpers@0.5.17))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(webpack@5.97.1)':
+  '@rsdoctor/rspack-plugin@1.2.3(@rsbuild/core@1.6.9)(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.97.1)':
     dependencies:
-      '@rsdoctor/core': 1.2.3(@rsbuild/core@1.6.9)(@rspack/core@1.6.6(@swc/helpers@0.5.17))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(webpack@5.97.1)
+      '@rsdoctor/core': 1.2.3(@rsbuild/core@1.6.9)(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.97.1)
       '@rsdoctor/graph': 1.2.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.97.1)
-      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(webpack@5.97.1)
+      '@rsdoctor/sdk': 1.2.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.97.1)
       '@rsdoctor/types': 1.2.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.97.1)
       '@rsdoctor/utils': 1.2.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.97.1)
       lodash: 4.17.21
@@ -14219,7 +14213,7 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.2.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(webpack@5.97.1)':
+  '@rsdoctor/sdk@1.2.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.97.1)':
     dependencies:
       '@rsdoctor/client': 1.2.3
       '@rsdoctor/graph': 1.2.3(@rspack/core@1.6.6(@swc/helpers@0.5.17))(webpack@5.97.1)


### PR DESCRIPTION
## Summary

If output.devtoolModuleFilenameTemplate = (info) => toPosixPath(info), i.e. the sources are relative paths without 'webpack://' or 'file://', that case wasn't handled properly before — this PR adds compatibility for it.

## Related Links

<!--- Provide links of related issues or pages -->
