### PR TITLE
fix: avoid printing the version number multiple times

### DIFF
--- a/packages/rspack-plugin/src/plugin.ts
+++ b/packages/rspack-plugin/src/plugin.ts
@@ -38,6 +38,9 @@ import { ModuleGraph } from '@rsdoctor/graph';
 import { Loader } from '@rsdoctor/utils/common';
 import { logger, time, timeEnd } from '@rsdoctor/utils/logger';
 
+// Static flag to ensure greet message is only printed once per process
+let hasGreeted = false;
+
 export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
   implements RsdoctorRspackPluginInstance<Rules>
 {
@@ -96,8 +99,11 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
   apply(compiler: Plugin.BaseCompilerType<'rspack'>) {
     time('RsdoctorRspackPlugin.apply');
     try {
-      logger.greet(`
+      if (!hasGreeted && !compiler.isChild()) {
+        hasGreeted = true;
+        logger.greet(`
         \nRsdoctor v${pkg.version}\n`);
+      }
 
       // bootstrap sdk in apply()
       // avoid to has different sdk instance in one plugin, because of webpack-chain toConfig() will new every webpack plugins.

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -26,6 +26,9 @@ import type { Compiler } from 'webpack';
 import { pluginTapName, pluginTapPostOptions, pkg } from './constants';
 import path from 'path';
 
+// Static flag to ensure greet message is only printed once per process
+let hasGreeted = false;
+
 export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
   implements RsdoctorPluginInstance<Compiler, Rules>
 {
@@ -79,8 +82,11 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
   apply(compiler: unknown): unknown;
 
   apply(compiler: Compiler) {
-    logger.greet(`
+    if (!hasGreeted && !compiler.isChild()) {
+      hasGreeted = true;
+      logger.greet(`
         \nRsdoctor v${pkg.version}\n`);
+    }
 
     // bootstrap sdk in apply()
     // avoid to has different sdk instance in one plugin, because of webpack-chain toConfig() will new every webpack plugins.


### PR DESCRIPTION
## Summary
fix: avoid printing the version number multiple times
<img width="2446" height="932" alt="image" src="https://github.com/user-attachments/assets/1f1cb6b2-ab7f-4378-b2dd-b7a1c42c9b70" />

## Related Links

<!--- Provide links of related issues or pages -->
