### PR TITLE
perf: optimize the time-consuming of rule[loader-performance-optimization]

### DIFF
--- a/packages/core/src/rules/rules/loader-performance-optimization/index.ts
+++ b/packages/core/src/rules/rules/loader-performance-optimization/index.ts
@@ -43,8 +43,7 @@ export const rule = defineRule<typeof title, Config>(() => {
 
       // flatten loaders
       const loaders: SDK.LoaderTransformData[] = loader
-        .map((el) => el.loaders)
-        .reduce((t, c) => t.concat(c));
+        .flatMap((el) => el.loaders);
 
       for (const item of loader) {
         const { path, ext } = item.resource;


### PR DESCRIPTION
Performance degrades significantly when many loaders are applied across a large number of modules.

[debug]
<img width="1884" height="348" alt="image" src="https://github.com/user-attachments/assets/3bbd49d9-89d7-4e57-9a3a-f7bc79494aca" />
<img width="1898" height="214" alt="image" src="https://github.com/user-attachments/assets/a60ac400-f52f-4ac2-bec2-03ba7849120e" />

[flat-cost]
old:
<img width="906" height="36" alt="image-20260204152749159" src="https://github.com/user-attachments/assets/22b00dc3-2d74-4c1a-bd50-c27d6fa38e48" />
new:
<img width="676" height="36" alt="image-20260204154937460" src="https://github.com/user-attachments/assets/63600ceb-026e-4054-8c50-0e96e5a3f7ef" />
