### PR TITLE
fix: rule cjs-require ignore problem

### DIFF
--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 const { fetchWithTimeoutMock } = rs.hoisted(() => ({
   fetchWithTimeoutMock: rs.fn(),
@@ -9,6 +12,7 @@ rs.mock('./fetch-http', () => ({
 }));
 
 import { fetchText, loadJSON } from './utils';
+import { loadShardingFile, loadShardingFileWithSpinner } from './utils';
 
 describe('cli utils', () => {
   afterEach(() => {
@@ -59,5 +63,62 @@ describe('cli utils', () => {
     );
 
     expect(data).toStrictEqual({ id: 7, name: 'remote' });
+  });
+
+  it('loadJSON() parses local json file', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'rsdoctor-cli-utils-'),
+    );
+    const file = path.join(tempDir, 'data.json');
+    fs.writeFileSync(file, '{"id":8,"name":"local"}', 'utf-8');
+
+    const data = await loadJSON<{ id: number; name: string }>(
+      'data.json',
+      tempDir,
+    );
+
+    expect(data).toStrictEqual({ id: 8, name: 'local' });
+  });
+
+  it('loadShardingFile() supports url, filepath and raw text', async () => {
+    fetchWithTimeoutMock.mockResolvedValue({
+      ok: true,
+      text: async () => 'remote-content',
+    } as Response);
+
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'rsdoctor-cli-sharding-'),
+    );
+    const file = path.join(tempDir, 'local.txt');
+    fs.writeFileSync(file, 'local-content', 'utf-8');
+
+    await expect(
+      loadShardingFile('https://example.com/sharding.txt', process.cwd()),
+    ).resolves.toBe('remote-content');
+    await expect(loadShardingFile(file, tempDir)).resolves.toBe(
+      'local-content',
+    );
+    await expect(
+      loadShardingFile('inline-content', process.cwd()),
+    ).resolves.toBe('inline-content');
+  });
+
+  it('loadShardingFileWithSpinner() updates spinner text', async () => {
+    const spinner = { text: '' };
+
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'rsdoctor-cli-spinner-'),
+    );
+    const file = path.join(tempDir, 'local.txt');
+    fs.writeFileSync(file, 'spinner-content', 'utf-8');
+
+    const content = await loadShardingFileWithSpinner(
+      file,
+      tempDir,
+      spinner as any,
+    );
+
+    expect(content).toBe('spinner-content');
+    expect(spinner.text).toBe(`loaded "${file}"`);
   });
 });

--- a/packages/core/src/rules/rules/cjs-require/index.ts
+++ b/packages/core/src/rules/rules/cjs-require/index.ts
@@ -7,6 +7,11 @@ export type { Config } from './types';
 const title = 'cjs-require';
 
 const CJS_REQUIRE_TYPE = 'cjs require';
+const NODE_MODULES_PATH_REGEXP = /[/\\]node_modules[/\\]/;
+
+function isNodeModulesPath(modulePath: string): boolean {
+  return NODE_MODULES_PATH_REGEXP.test(modulePath);
+}
 
 export const rule = defineRule<typeof title, Config>(() => {
   return {
@@ -16,7 +21,7 @@ export const rule = defineRule<typeof title, Config>(() => {
       category: 'bundle',
       severity: Linter.Severity.Warn,
       defaultConfig: {
-        ignore: ['node_modules'],
+        ignore: [],
       },
     },
     check({ moduleGraph, report, ruleConfig }) {
@@ -28,6 +33,9 @@ export const rule = defineRule<typeof title, Config>(() => {
         }
 
         const issuerPath = dep.module.path;
+        if (isNodeModulesPath(issuerPath)) {
+          continue;
+        }
 
         const requiredModule = dep.dependency;
 

--- a/packages/core/src/rules/rules/cjs-require/index.ts
+++ b/packages/core/src/rules/rules/cjs-require/index.ts
@@ -8,10 +8,6 @@ const title = 'cjs-require';
 
 const CJS_REQUIRE_TYPE = 'cjs require';
 
-function isNodeModulesPath(modulePath: string): boolean {
-  return modulePath.includes('/node_modules/');
-}
-
 export const rule = defineRule<typeof title, Config>(() => {
   return {
     meta: {
@@ -20,7 +16,7 @@ export const rule = defineRule<typeof title, Config>(() => {
       category: 'bundle',
       severity: Linter.Severity.Warn,
       defaultConfig: {
-        ignore: [],
+        ignore: ['node_modules'],
       },
     },
     check({ moduleGraph, report, ruleConfig }) {
@@ -32,9 +28,6 @@ export const rule = defineRule<typeof title, Config>(() => {
         }
 
         const issuerPath = dep.module.path;
-        if (isNodeModulesPath(issuerPath)) {
-          continue;
-        }
 
         const requiredModule = dep.dependency;
 

--- a/packages/core/src/rules/rules/cjs-require/types.ts
+++ b/packages/core/src/rules/rules/cjs-require/types.ts
@@ -1,4 +1,7 @@
 export interface Config {
-  /** Module path patterns to ignore (applied to both issuer and required module paths) */
+  /**
+   * Module path patterns to ignore (applied to both issuer and required module paths).
+   * Defaults to ['node_modules'].
+   */
   ignore: string[];
 }

--- a/packages/core/src/rules/rules/cjs-require/types.ts
+++ b/packages/core/src/rules/rules/cjs-require/types.ts
@@ -1,7 +1,7 @@
 export interface Config {
   /**
    * Module path patterns to ignore (applied to both issuer and required module paths).
-   * Defaults to ['node_modules'].
+   * Defaults to [].
    */
   ignore: string[];
 }

--- a/packages/core/tests/rules/cjs-require.test.ts
+++ b/packages/core/tests/rules/cjs-require.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from '@rstest/core';
+import { rule } from '../../src/rules/rules/cjs-require';
+
+interface RunRuleOptions {
+  issuerPath: string;
+  requiredPath: string;
+  typeString?: string;
+  ignore?: string[];
+}
+
+async function runRule(options: RunRuleOptions) {
+  const {
+    issuerPath,
+    requiredPath,
+    typeString = 'cjs require',
+    ignore = [],
+  } = options;
+
+  const reports: any[] = [];
+
+  const dependency = {
+    typeString,
+    request: 'some-package',
+    module: {
+      id: 1,
+      path: issuerPath,
+      webpackId: '1',
+    },
+    dependency: {
+      id: 2,
+      path: requiredPath,
+      webpackId: '2',
+    },
+  };
+
+  await rule.check({
+    moduleGraph: {
+      getDependencies: () => [dependency],
+    },
+    ruleConfig: {
+      ignore,
+    },
+    report: (data: any) => {
+      reports.push(data);
+    },
+  } as any);
+
+  return reports;
+}
+
+describe('cjs-require rule', () => {
+  it('reports user-code require from node_modules by default', async () => {
+    const reports = await runRule({
+      issuerPath: '/project/src/index.js',
+      requiredPath: '/project/node_modules/some-package/index.js',
+    });
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0].detail.issuerModule.path).toBe('/project/src/index.js');
+    expect(reports[0].detail.requiredModule.path).toBe(
+      '/project/node_modules/some-package/index.js',
+    );
+  });
+
+  it('skips when issuer is in node_modules (posix path)', async () => {
+    const reports = await runRule({
+      issuerPath: '/project/node_modules/pkg/index.js',
+      requiredPath: '/project/node_modules/some-package/index.js',
+    });
+
+    expect(reports).toHaveLength(0);
+  });
+
+  it('skips when issuer is in node_modules (windows path)', async () => {
+    const reports = await runRule({
+      issuerPath: 'C:\\project\\node_modules\\pkg\\index.js',
+      requiredPath: 'C:\\project\\node_modules\\some-package\\index.js',
+    });
+
+    expect(reports).toHaveLength(0);
+  });
+
+  it('still supports ignore filtering on required module path', async () => {
+    const reports = await runRule({
+      issuerPath: '/project/src/index.js',
+      requiredPath: '/project/node_modules/some-package/index.js',
+      ignore: ['some-package'],
+    });
+
+    expect(reports).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
This pull request updates the `cjs-require` rule to improve configurability and simplify the logic for ignoring certain module paths. The main changes include defaulting the `ignore` configuration to `['node_modules']`, removing the hardcoded check for `node_modules` paths, and updating documentation for clarity.

Configuration improvements:

* The default value for the `ignore` option in the rule configuration is now `['node_modules']`, making it easier to customize which module paths are ignored without modifying code.
* The `Config` interface documentation in `types.ts` has been updated to clarify that `ignore` defaults to `['node_modules']`.

## Related Links

<!--- Provide links of related issues or pages -->
