### PR TITLE
chore: add rsdoctor repo's skills

### DIFF
--- a/.agents/skills/code-reviewer/SKILL.md
+++ b/.agents/skills/code-reviewer/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: code-reviewer
+description: Review code changes like a pragmatic senior engineer — focus on functional bugs, regressions, type-safety, and missing tests. Use when performing code reviews on PRs or diffs in the rsdoctor repository.
+---
+
 # Code Reviewer
 
 You are a focused code review subagent for the rsdoctor repository.

--- a/.agents/skills/code-reviewer/code-reviewer.md
+++ b/.agents/skills/code-reviewer/code-reviewer.md
@@ -1,0 +1,88 @@
+# Code Reviewer
+
+You are a focused code review subagent for the rsdoctor repository.
+
+## Mission
+
+Review the user's requested change like a pragmatic senior engineer.
+Prioritize concrete findings over summaries.
+Minimize noise and avoid speculative comments.
+
+## What to look for
+
+1. Functional bugs or incorrect assumptions
+2. Regressions and edge cases
+3. Type-safety issues
+4. Missing or weak tests
+5. Risky behavior changes
+6. Performance or unnecessary complexity when material
+7. Developer experience issues (unclear errors, confusing APIs) when material
+
+## Review process
+
+1. Understand the intent of the change from diff, file context, and nearby usage.
+2. Focus on material risks first (correctness > regressions > safety > testability).
+3. Verify assumptions with concrete evidence in code.
+4. Report only issues that are actionable and likely true.
+5. If confidence depends on runtime behavior, request the lightest meaningful validation.
+
+## Review rules
+
+- Start with findings first.
+- Be specific and evidence-based.
+- Reference files with `path:line` when possible.
+- Prefer concise bullets.
+- Do not praise or summarize unless the user asks.
+- Do not report purely stylistic nits unless they hide real risk.
+- One issue per bullet. Include impact and the expected fix direction.
+- If no issues are found, say that explicitly and mention what you checked.
+
+## Output format
+
+Use this structure:
+
+### Findings
+
+- [severity] `file_path:line` - issue, impact, and fix direction
+
+### Gaps
+
+- Missing tests, validation, or follow-up checks (only if material)
+
+### Verdict
+
+- `approve` if no material issues were found
+- `request-changes` if any material issue was found
+
+### Validation
+
+- Minimal commands/checks needed to raise confidence (only when needed)
+
+## Severity guidance
+
+- `high`: likely bug, broken behavior, or serious regression risk
+- `medium`: plausible bug, incomplete handling, or missing coverage on important paths
+- `low`: minor maintainability issue with limited immediate risk
+
+Escalation rules:
+
+- Prefer `medium` over `low` when user-facing behavior may silently degrade.
+- Use `high` only when there is strong evidence of incorrect behavior or high-risk regression.
+- Do not inflate severity to force changes.
+
+## Evidence checklist
+
+Before raising a finding, verify at least one:
+
+- Control flow or data flow contradiction
+- Type contract mismatch
+- Missing guard for a realistic edge case
+- Test gap on a critical path
+- Inconsistent behavior with nearby repository patterns
+
+## Repo-specific guidance
+
+- Follow existing rsdoctor patterns and avoid speculative architectural advice.
+- Treat user changes as intentional unless evidence in code suggests a problem.
+- Call out the lightest meaningful validation that should be run when confidence depends on it.
+- Keep recommendations compatible with current tooling (pnpm, nx/rstest, existing package scripts).

--- a/.agents/skills/docs-en-improvement/SKILL.md
+++ b/.agents/skills/docs-en-improvement/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: docs-en-improvement
+description: Improve English documentation under `packages/document/docs/en` by rewriting unnatural translated sentences into clear, professional English while preserving meaning. Use when editing or polishing English docs in the Rsdoctor project.
+---
+
+# Docs En Improvement
+
+Rsdoctor documentation is built with **Rspress** and lives in `packages/document/`. Content is written in Markdown / MDX.
+
+## Steps
+
+1. Focus on files in `packages/document/docs/en`.
+
+2. Rewrite only sentences that clearly improve clarity, correctness, or naturalness in English.
+
+3. Preserve original meaning exactly; do not introduce new claims or remove technical details.
+
+4. If a file in `packages/document/docs/en` is updated, check the mirrored file in `packages/document/docs/zh` and apply equivalent updates when needed.
+
+5. Preview changes locally with `cd packages/document && pnpm dev`.
+
+## Constraints
+
+- Limit each PR to 10 documentation files or fewer.
+- Start PR titles with `docs:`.
+- Keep reasonable technical abbreviations (for example, `dev server`).
+- Keep wording simple and readable for non-native English readers.
+- Use sentence case for Markdown headings.
+- Rsdoctor-specific terms should stay consistent: Rsdoctor (capital R), Rspack, webpack (lowercase w), Rsbuild.

--- a/.agents/skills/pr-creator/SKILL.md
+++ b/.agents/skills/pr-creator/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: pr-creator
+description: Use when asked to create a pull request for the Rsdoctor repository. Ensures the PR follows branch safety rules, Conventional Commits title convention, the project's PR template, and concise English writing style.
+---
+
+# Pull Request Creator
+
+## Steps
+
+1. Confirm the current branch with `git branch --show-current`.
+   If it is `main`, create and switch to a new branch before doing anything else.
+   Use a descriptive branch name, for example `feat/add-xxx` or `fix/resolve-xxx`.
+
+2. Review local changes with `git status --short`.
+   Do not revert unrelated user changes.
+   Before creating the PR, ensure the intended changes are committed and never commit directly on `main`.
+
+3. Read `.github/PULL_REQUEST_TEMPLATE.md` and keep its structure exactly. The template has two sections:
+   - `## Summary`
+   - `## Related Links`
+
+4. Draft the PR title in **Conventional Commits** format. Common scopes for Rsdoctor:
+   - `feat(core): add ...`
+   - `fix(rspack-plugin): ...`
+   - `fix(webpack-plugin): ...`
+   - `feat(sdk): ...`
+   - `feat(cli): ...`
+   - `feat(ai): ...`
+   - `docs: ...`
+   - `refactor(graph): ...`
+   - `chore(deps): ...`
+   - `release: v1.5.8`
+
+5. Write the PR body in concise, clear English.
+   - In `Summary`, explain the user-facing problem or maintenance goal first, then the main change.
+   - Keep it short: one compact paragraph or 2-4 bullets is usually enough.
+   - Focus on what changed and why it matters; avoid low-signal implementation detail.
+   - Good background examples:
+     - `This PR adds support for custom logger injection so CLI output can be isolated per instance.`
+     - `This PR fixes incorrect padding in URL labels to keep terminal output aligned across different label lengths.`
+     - `This PR updates the English docs to clarify how the extraction option works and when to enable it.`
+
+6. Fill `Related Links` with issue links, design docs, related PRs, or discussion pages.
+   If the PR upgrades an npm dependency, add a link to the upgraded version's release notes or tag page when available.
+   If there is no relevant link, leave a short note such as `None`.
+
+7. Push the branch only after re-checking the branch name. Never push `main` directly.
+
+8. Create the PR with `gh pr create`.

--- a/.agents/skills/release-core/SKILL.md
+++ b/.agents/skills/release-core/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: release-rsdoctor
+description: Use when asked to release Rsdoctor packages for a specific version. All `@rsdoctor/*` packages (except `@rsdoctor/mcp-server`) are versioned together via changesets.
+---
+
+# Release Rsdoctor
+
+## Input
+
+- Target version, for example `1.5.8`
+
+If the version is missing, ask for it before making changes.
+
+## Steps
+
+1. Check the worktree with `git status --short`. If there are uncommitted edits, stop and ask the user how to proceed.
+
+2. Create and switch to branch `release_v<version>` (underscore, not slash). If the branch already exists, stop and ask the user how to proceed.
+
+3. Run [changesets](https://github.com/changesets/changesets) to bump changed packages:
+
+   ```sh
+   pnpm changeset version
+   ```
+
+   All `@rsdoctor/*` packages (except `@rsdoctor/mcp-server`) move together as a fixed group — see `.changeset/config.json`.
+
+4. Review the diff. Confirm version bumps are correct across packages and `pnpm-lock.yaml` is updated.
+
+5. Commit with this exact message: `release: v<version>`
+
+6. Push the branch, then create a GitHub PR with `gh pr create`. Use the same text for the PR title: `release: v<version>`
+
+7. If `.github/PULL_REQUEST_TEMPLATE.md` exists, keep its structure.
+   Fill it with:
+   - `Summary`: `Release @rsdoctor/* packages v<version>.`
+   - `Related Links`: `https://github.com/web-infra-dev/rsdoctor/releases/tag/v<version>`
+
+8. After the PR is created, a maintainer will run the [release GitHub Action](https://github.com/web-infra-dev/rsdoctor/actions/workflows/release.yml) to publish to npm, then merge the PR to `main`.

--- a/.agents/skills/write-e2e-cases/SKILL.md
+++ b/.agents/skills/write-e2e-cases/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: write-e2e-cases
+description: Use when adding or updating Rsdoctor end-to-end tests in `e2e/cases/`, including new feature coverage, bug reproduction, and regression prevention.
+---
+
+# Write E2E Cases
+
+Rsdoctor E2E tests use **Playwright** and live under `e2e/cases/`. Each bundler has its own directory:
+
+- `e2e/cases/doctor-rspack/` — tests using Rspack compilation
+- `e2e/cases/doctor-webpack/` — tests using webpack compilation
+- `e2e/cases/doctor-rsbuild/` — tests using Rsbuild
+- `e2e/cases/doctor-rspeedy/` — tests using Rspeedy
+
+## Steps
+
+1. Review uncommitted git changes to define test scope and target behavior.
+
+2. Read `e2e/README.md` and follow its conventions.
+
+3. Use helpers from `@scripts/test-helper` (for example `compileByRspack`, `compileByWebpack5`) to compile fixtures. Do **not** call bundler APIs directly.
+
+4. Add Playwright test files under the appropriate `e2e/cases/doctor-*` directory, following existing patterns.
+
+5. Test fixtures (source files, loaders, configs) go in `fixtures/` subdirectories inside each case directory.
+
+6. Keep assertions focused and readable; avoid redundant setup and checks.
+
+7. Run `pnpm e2e` from the repository root to validate.
+
+## Case Structure
+
+- Each test file creates an Rsdoctor plugin instance (e.g., `createRsdoctorPlugin` from a local `test-utils.ts`), compiles a fixture via `compileByRspack` or `compileByWebpack5`, and asserts on the SDK store data.
+- Fixtures are plain JS/TS files and loaders in `fixtures/` — not full application directories.
+- Use `@rsdoctor/core/plugins` for `getSDK` / `setSDK` when inspecting analysis results.
+
+## Constraints
+
+- If tests can pass only after source-code changes, do not change source code directly. Explain the required source change and ask the user before proceeding.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "skills": {
+    "pr-creator": {
+      "source": "rstackjs/agent-skills",
+      "sourceType": "github",
+      "computedHash": "0818eb81ec601e1d410d26c54b44a34231061db173cad0c40ce3b91bfb16f38e"
+    }
+  }
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,10 +1,4 @@
 {
   "version": 1,
-  "skills": {
-    "pr-creator": {
-      "source": "rstackjs/agent-skills",
-      "sourceType": "github",
-      "computedHash": "0818eb81ec601e1d410d26c54b44a34231061db173cad0c40ce3b91bfb16f38e"
-    }
-  }
+  "skills": {}
 }


### PR DESCRIPTION
## Summary
This pull request introduces several new agent skill definitions and supporting documentation to the repository, covering code review, pull request creation, release management, English documentation improvement, and end-to-end test writing. These skills provide detailed, repository-specific guidance for each workflow and are intended to standardize and automate common engineering tasks.

The most important changes include:

**New agent skill definitions:**

* Added `.agents/skills/code-reviewer/code-reviewer.md` to define a focused code review agent with pragmatic review rules, severity guidance, and output structure tailored for the `rsdoctor` repository.
* Added `.agents/skills/pr-creator/SKILL.md` to specify a pull request creation workflow, including branch safety, Conventional Commits format, PR template usage, and concise writing standards.
* Added `.agents/skills/release-core/SKILL.md` to document the release process for Rsdoctor packages, including changeset usage, version bumping, and PR creation steps.
* Added `.agents/skills/docs-en-improvement/SKILL.md` to guide English documentation improvements, focusing on clarity, naturalness, and technical accuracy for files under `packages/document/docs/en`.
* Added `.agents/skills/write-e2e-cases/SKILL.md` to describe conventions and constraints for writing Playwright-based end-to-end tests in the `e2e/cases/` directory.

**Repository configuration:**

* Added `skills-lock.json` to track agent skills and their source hashes for reproducibility and dependency management.
## Related Links

<!--- Provide links of related issues or pages -->
