### PR TITLE
feat: add chunk group graph report api

### DIFF
--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -3,6 +3,7 @@ import { Constants, Manifest as ManifestType, SDK } from '@rsdoctor/types';
 import { RsdoctorSDK } from '@rsdoctor/sdk';
 import ora from 'ora';
 import { cyan, red } from 'picocolors';
+import path from 'node:path';
 import { Command } from '../types';
 import {
   enhanceCommand,
@@ -16,6 +17,33 @@ interface Options {
   open?: boolean;
   port?: number;
   type?: SDK.ToDataType;
+}
+
+export function resolveLocalManifestShardingFiles<
+  T extends Record<string, unknown>,
+>(data: T, profile: string, cwd: string): T {
+  const manifestDir = path.dirname(path.resolve(cwd, profile));
+
+  return Object.fromEntries(
+    Object.entries(data).map(([key, value]) => {
+      if (
+        !Array.isArray(value) ||
+        value.length === 0 ||
+        !value.every((item) => typeof item === 'string')
+      ) {
+        return [key, value];
+      }
+
+      return [
+        key,
+        value.map((item) =>
+          /^(https?:)?\/\//.test(item) || path.isAbsolute(item)
+            ? item
+            : path.resolve(manifestDir, item),
+        ),
+      ];
+    }),
+  ) as T;
 }
 
 export const analyze: Command<Commands.Analyze, Options, RsdoctorSDK> =
@@ -50,16 +78,24 @@ example: ${bin} ${Commands.Analyze} --profile "${Constants.RsdoctorOutputManifes
       spinner.text = `start to loading data...`;
 
       let dataValue: ManifestType.RsdoctorManifestData;
+      const localData = resolveLocalManifestShardingFiles(
+        json.data,
+        profile,
+        cwd,
+      );
+      const localCloudData = json.cloudData
+        ? resolveLocalManifestShardingFiles(json.cloudData, profile, cwd)
+        : undefined;
 
       try {
         dataValue = await Manifest.fetchShardingFiles(
-          json.data,
+          localData,
           (url: string) => loadShardingFileWithSpinner(url, cwd, spinner),
         );
       } catch (error) {
         try {
           dataValue = await Manifest.fetchShardingFiles(
-            json.cloudData || {},
+            localCloudData || {},
             (url: string) => loadShardingFileWithSpinner(url, cwd, spinner),
           );
         } catch (e) {

--- a/packages/cli/tests/analyze.test.ts
+++ b/packages/cli/tests/analyze.test.ts
@@ -1,0 +1,32 @@
+import path from 'node:path';
+import { describe, expect, it } from '@rstest/core';
+import { resolveLocalManifestShardingFiles } from '../src/commands/analyze';
+
+describe('analyze command', () => {
+  it('resolves local manifest shard paths relative to the manifest file', () => {
+    const cwd = path.join(path.sep, 'repo');
+    const manifest = path.join('reports', '.rsdoctor', 'manifest.json');
+
+    const result = resolveLocalManifestShardingFiles(
+      {
+        root: '/repo',
+        summary: ['summary/0'],
+        moduleGraph: ['moduleGraph/0', '/tmp/absolute-shard'],
+        cloudData: 'https://example.com/cloud-shard',
+        errors: [],
+      },
+      manifest,
+      cwd,
+    );
+
+    expect(result.summary).toStrictEqual([
+      path.join(cwd, 'reports', '.rsdoctor', 'summary/0'),
+    ]);
+    expect(result.moduleGraph).toStrictEqual([
+      path.join(cwd, 'reports', '.rsdoctor', 'moduleGraph/0'),
+      '/tmp/absolute-shard',
+    ]);
+    expect(result.cloudData).toBe('https://example.com/cloud-shard');
+    expect(result.errors).toStrictEqual([]);
+  });
+});

--- a/packages/components/src/pages/BundleSize/components/chunk-group-helpers.ts
+++ b/packages/components/src/pages/BundleSize/components/chunk-group-helpers.ts
@@ -1,0 +1,136 @@
+import { SDK } from '@rsdoctor/types';
+
+export type GraphImportSnippetLabel = {
+  file: string;
+  code: string;
+};
+
+export const truncateLabel = (value: string, maxLength = 26) =>
+  value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
+
+export const truncateMiddleLabel = (value: string, maxLength: number) => {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  const tailLength = Math.floor((maxLength - 1) / 2);
+  const headLength = maxLength - tailLength - 1;
+  return `${value.slice(0, headLength)}…${value.slice(-tailLength)}`;
+};
+
+const normalizeGraphLabelText = (value: string) =>
+  value.replace(/[{}]/g, '').replace(/\s+/g, ' ').trim();
+
+export const normalizeGraphLabel = (value: string, maxLength: number) =>
+  truncateLabel(normalizeGraphLabelText(value), maxLength);
+
+const normalizeFileGraphLabel = (value: string, maxLength: number) =>
+  truncateMiddleLabel(normalizeGraphLabelText(value), maxLength);
+
+const stripSnippetLineNumber = (value: string) =>
+  value.replace(/^\d+\s*\|\s*/, '').trim();
+
+const buildImportSnippetCode = (item: SDK.ChunkGroupGraphImportData) => {
+  const snippetLines =
+    item.snippet
+      ?.split('\n')
+      .map((line) => stripSnippetLineNumber(line.trim()))
+      .filter(Boolean) ?? [];
+  const importLineIndex = snippetLines.findIndex((line) =>
+    line.includes('import('),
+  );
+
+  if (importLineIndex >= 0) {
+    const requestLineIndex = item.request
+      ? snippetLines.findIndex((line, index) => {
+          return index >= importLineIndex && line.includes(item.request!);
+        })
+      : -1;
+    const endIndex =
+      requestLineIndex >= 0
+        ? Math.min(snippetLines.length, requestLineIndex + 2)
+        : importLineIndex + 1;
+
+    return snippetLines.slice(importLineIndex, endIndex).join(' ');
+  }
+
+  return item.request ? `import(${JSON.stringify(item.request)})` : '';
+};
+
+const getSourceFileLabel = (item: SDK.ChunkGroupGraphImportData) => {
+  const source = item.sourceModule || item.loc?.replace(/:\d+:\d+$/, '') || '';
+  const fileName = source.split(/[\\/]/).filter(Boolean).pop() || source;
+  const line = item.loc?.match(/:(\d+):\d+$/)?.[1];
+
+  if (!fileName) {
+    return line ? `line ${line}` : 'unknown source';
+  }
+
+  return line ? `${fileName}:${line}` : fileName;
+};
+
+const getImportSnippetLabel = (
+  item: SDK.ChunkGroupGraphImportData,
+): GraphImportSnippetLabel | undefined => {
+  const code = buildImportSnippetCode(item);
+
+  if (!code) {
+    return undefined;
+  }
+
+  return {
+    file: normalizeFileGraphLabel(getSourceFileLabel(item), 42),
+    code: normalizeGraphLabel(code, 72),
+  };
+};
+
+const formatEdgeImportSnippetLabel = (
+  edge: SDK.ChunkGroupGraphEdgeData,
+): GraphImportSnippetLabel | undefined => {
+  const snippets = edge.imports.map(getImportSnippetLabel).filter(Boolean);
+  if (!snippets.length) {
+    return undefined;
+  }
+
+  const first = snippets[0]!;
+  if (edge.imports.length <= 1) {
+    return first;
+  }
+
+  return {
+    file: `${first.file} +${edge.imports.length - 1}`,
+    code: first.code,
+  };
+};
+
+export const getEdgeImportSnippetGraphLabel = (
+  edge: SDK.ChunkGroupGraphEdgeData,
+): GraphImportSnippetLabel | undefined => {
+  const label = formatEdgeImportSnippetLabel(edge);
+  if (!label) {
+    return undefined;
+  }
+
+  return label;
+};
+
+export const getPathParentImportSnippetLabels = (
+  path: Pick<SDK.ChunkGroupGraphPathData, 'edgeIds'>,
+  edgeMap: Map<string, SDK.ChunkGroupGraphEdgeData>,
+) => {
+  const snippets = new Map<string, GraphImportSnippetLabel>();
+
+  for (const edgeId of path.edgeIds) {
+    const edge = edgeMap.get(edgeId);
+    if (!edge) {
+      continue;
+    }
+
+    const snippet = getEdgeImportSnippetGraphLabel(edge);
+    if (snippet) {
+      snippets.set(edge.from, snippet);
+    }
+  }
+
+  return snippets;
+};

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -338,6 +338,43 @@ const scrollElementByWheel = (
   element.scrollTop += deltaY;
 };
 
+const normalizeWheelDelta = (event: WheelEvent) => {
+  let deltaX = event.deltaX;
+  let deltaY = event.deltaY;
+  const legacyEvent = event as WheelEvent & {
+    detail?: number;
+    wheelDelta?: number;
+    wheelDeltaX?: number;
+    wheelDeltaY?: number;
+  };
+
+  if (event.deltaMode === 1) {
+    deltaX *= 16;
+    deltaY *= 16;
+  } else if (event.deltaMode === 2) {
+    deltaX *= window.innerWidth;
+    deltaY *= window.innerHeight;
+  }
+
+  if (!deltaX && legacyEvent.wheelDeltaX) {
+    deltaX = -legacyEvent.wheelDeltaX;
+  }
+  if (!deltaY && legacyEvent.wheelDeltaY) {
+    deltaY = -legacyEvent.wheelDeltaY;
+  }
+  if (!deltaY && legacyEvent.wheelDelta) {
+    deltaY = -legacyEvent.wheelDelta;
+  }
+  if (!deltaY && legacyEvent.detail) {
+    deltaY = legacyEvent.detail * 16;
+  }
+
+  return {
+    deltaX,
+    deltaY,
+  };
+};
+
 const sortPathsByOpportunity = (
   a: SDK.ChunkGroupGraphPathData,
   b: SDK.ChunkGroupGraphPathData,
@@ -716,6 +753,52 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
       window.clearTimeout(timer);
     };
   }, [graphHeight, graphWidth, nodes.length, edges.length]);
+
+  useEffect(() => {
+    const element = graphContainerRef.current;
+    if (!element) {
+      return;
+    }
+
+    const handleGraphWheel = (event: WheelEvent) => {
+      if (event.ctrlKey || event.metaKey) {
+        return;
+      }
+
+      const { deltaX, deltaY } = normalizeWheelDelta(event);
+      if (!deltaX && !deltaY) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+
+      scrollElementByWheel(
+        findScrollContainer(element, deltaX, deltaY),
+        deltaX,
+        deltaY,
+      );
+    };
+    const options: AddEventListenerOptions = {
+      capture: true,
+      passive: false,
+    };
+
+    element.addEventListener('wheel', handleGraphWheel, options);
+    element.addEventListener('mousewheel', handleGraphWheel as EventListener, {
+      ...options,
+    });
+
+    return () => {
+      element.removeEventListener('wheel', handleGraphWheel, options);
+      element.removeEventListener(
+        'mousewheel',
+        handleGraphWheel as EventListener,
+        options,
+      );
+    };
+  }, []);
 
   const hoveredPath = selectedNodePaths.find(
     (path) => path.id === hoveredPathId,
@@ -1204,21 +1287,6 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   const dangerPathCount = overview?.dangerPathCount ?? 0;
   const warningPathCount = overview?.warningPathCount ?? 0;
   const selectedNodeImports = selectedNode?.incomingImports ?? [];
-  const handleGraphWheel = (event: React.WheelEvent<HTMLDivElement>) => {
-    if (event.ctrlKey || event.metaKey) {
-      return;
-    }
-
-    event.preventDefault();
-    event.stopPropagation();
-    event.nativeEvent.stopImmediatePropagation();
-
-    scrollElementByWheel(
-      findScrollContainer(event.currentTarget, event.deltaX, event.deltaY),
-      event.deltaX,
-      event.deltaY,
-    );
-  };
   const selectedNodePathList = selectedNode ? (
     <div>
       <Typography.Title level={5}>
@@ -1430,7 +1498,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
 
           <Row gutter={[16, 16]} align="top">
             <Col xs={24} xl={16}>
-              <div ref={graphContainerRef} onWheelCapture={handleGraphWheel}>
+              <div ref={graphContainerRef}>
                 <Card bodyStyle={{ padding: 0 }}>
                   <ReactEChartsCore
                     ref={chartRef}

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -1,0 +1,1284 @@
+import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
+import ReactEChartsCore from 'echarts-for-react/esm/core';
+import * as echarts from 'echarts/core';
+import { GraphChart, type GraphSeriesOption } from 'echarts/charts';
+import {
+  TooltipComponent,
+  type TooltipComponentOption,
+} from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
+import type { ComposeOption } from 'echarts/core';
+import { SearchOutlined } from '@ant-design/icons';
+import { SDK } from '@rsdoctor/types';
+import {
+  Alert,
+  Card,
+  Col,
+  Empty,
+  Input,
+  Row,
+  Space,
+  Tag,
+  Tooltip,
+  Typography,
+} from 'antd';
+import { formatSize } from 'src/utils';
+
+echarts.use([GraphChart, TooltipComponent, CanvasRenderer]);
+
+type ChunkGroupGraphOption = ComposeOption<
+  GraphSeriesOption | TooltipComponentOption
+>;
+
+type GraphLayout = {
+  height: number;
+  positions: Map<
+    string,
+    {
+      x: number;
+      y: number;
+    }
+  >;
+};
+
+type ChunkGroupGraphPanelProps = {
+  report?: SDK.ChunkGroupGraphData;
+};
+
+const ENTRY_COLOR = '#1f6feb';
+const ENTRY_BORDER = '#58a6ff';
+const ASYNC_COLOR = '#238636';
+const ASYNC_BORDER = '#7ee787';
+const HIGHLIGHT_COLOR = '#f59e0b';
+const WARNING_COLOR = '#f59e0b';
+const DANGER_COLOR = '#ef4444';
+const MUTED_NODE = '#d1d5db';
+const MUTED_BORDER = '#9ca3af';
+const MIN_GRAPH_HEIGHT = 760;
+const LAYOUT_TOP_PADDING = 96;
+const LAYOUT_LEFT_PADDING = 140;
+const LAYOUT_ROW_GAP = 56;
+const LAYOUT_COLUMN_GAP = 380;
+const NODE_LABEL_WIDTH = 180;
+
+const getBaseNodeColor = (node: SDK.ChunkGroupGraphNodeData) =>
+  node.isInitial
+    ? { background: ENTRY_COLOR, border: ENTRY_BORDER }
+    : { background: ASYNC_COLOR, border: ASYNC_BORDER };
+
+const getPathColor = (severity: SDK.ChunkGroupGraphPathSeverity) => {
+  if (severity === 'danger') {
+    return DANGER_COLOR;
+  }
+  if (severity === 'warning') {
+    return WARNING_COLOR;
+  }
+  return HIGHLIGHT_COLOR;
+};
+
+const getSeverityTagColor = (
+  severity: SDK.ChunkGroupGraphPathSeverity,
+) => {
+  if (severity === 'danger') {
+    return 'red';
+  }
+  if (severity === 'warning') {
+    return 'gold';
+  }
+  return 'default';
+};
+
+const formatPercent = (value: number) => `${(value * 100).toFixed(1)}%`;
+
+const buildForwardAdjacency = (
+  edges: SDK.ChunkGroupGraphEdgeData[],
+) => {
+  const map = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (!map.has(edge.from)) {
+      map.set(edge.from, []);
+    }
+    map.get(edge.from)!.push(edge.to);
+  }
+  return map;
+};
+
+const buildReverseAdjacency = (
+  edges: SDK.ChunkGroupGraphEdgeData[],
+) => {
+  const map = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (!map.has(edge.to)) {
+      map.set(edge.to, []);
+    }
+    map.get(edge.to)!.push(edge.from);
+  }
+  return map;
+};
+
+const buildEdgeMap = (edges: SDK.ChunkGroupGraphEdgeData[]) =>
+  new Map(edges.map((edge) => [edge.id, edge]));
+
+const buildNodeMap = (nodes: SDK.ChunkGroupGraphNodeData[]) =>
+  new Map(nodes.map((node) => [node.id, node]));
+
+const getNodeSymbolSize = (
+  node: SDK.ChunkGroupGraphNodeData,
+  maxEmittedSize: number,
+) =>
+  Math.max(
+    38,
+    Math.min(
+      74,
+      38 +
+        36 *
+          Math.sqrt(
+            node.totalEmittedSize / maxEmittedSize,
+          ),
+    ),
+  );
+
+const getNodeLaneHeight = (
+  node: SDK.ChunkGroupGraphNodeData,
+  maxEmittedSize: number,
+  outDegree: number,
+) =>
+  Math.max(
+    124,
+    getNodeSymbolSize(node, maxEmittedSize) + 74 + Math.min(24, outDegree * 6),
+  );
+
+const truncateLabel = (value: string, maxLength = 26) =>
+  value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
+
+const buildLayout = (
+  nodes: SDK.ChunkGroupGraphNodeData[],
+  edges: SDK.ChunkGroupGraphEdgeData[],
+): GraphLayout => {
+  if (!nodes.length) {
+    return {
+      height: MIN_GRAPH_HEIGHT,
+      positions: new Map(),
+    };
+  }
+
+  const indegree = new Map<string, number>(
+    nodes.map((node) => [node.id, 0]),
+  );
+  for (const edge of edges) {
+    indegree.set(edge.to, (indegree.get(edge.to) || 0) + 1);
+  }
+
+  const adjacency = buildForwardAdjacency(edges);
+  const reverseAdjacency = buildReverseAdjacency(edges);
+  const maxEmittedSize = Math.max(
+    1,
+    ...nodes.map((node) => node.totalEmittedSize),
+  );
+  const depth = new Map<string, number>();
+  const queue = nodes
+    .filter((node) => node.isInitial || !indegree.get(node.id))
+    .sort((a, b) => {
+      if (a.isInitial !== b.isInitial) {
+        return a.isInitial ? -1 : 1;
+      }
+      if (a.totalEmittedSize !== b.totalEmittedSize) {
+        return b.totalEmittedSize - a.totalEmittedSize;
+      }
+      return a.name.localeCompare(b.name);
+    })
+    .map((node) => node.id);
+  const remainingIndegree = new Map(indegree);
+  const processedNodes = new Set<string>();
+
+  if (!queue.length && nodes[0]) {
+    queue.push(nodes[0].id);
+  }
+
+  queue.forEach((nodeId) => depth.set(nodeId, 0));
+
+  while (queue.length) {
+    const current = queue.shift()!;
+    if (processedNodes.has(current)) {
+      continue;
+    }
+    processedNodes.add(current);
+    const currentDepth = depth.get(current) || 0;
+    for (const next of adjacency.get(current) ?? []) {
+      const nextDepth = currentDepth + 1;
+      if ((depth.get(next) ?? -1) < nextDepth) {
+        depth.set(next, nextDepth);
+      }
+      const nextIndegree = (remainingIndegree.get(next) || 0) - 1;
+      remainingIndegree.set(next, nextIndegree);
+      if (nextIndegree <= 0) {
+        queue.push(next);
+      }
+    }
+  }
+
+  nodes.forEach((node) => {
+    if (!depth.has(node.id)) {
+      depth.set(node.id, 0);
+    }
+  });
+
+  const nodesByDepth = new Map<number, SDK.ChunkGroupGraphNodeData[]>();
+  for (const node of nodes) {
+    const level = depth.get(node.id) || 0;
+    if (!nodesByDepth.has(level)) {
+      nodesByDepth.set(level, []);
+    }
+    nodesByDepth.get(level)!.push(node);
+  }
+
+  const orderMap = new Map<string, number>();
+  const levelLayouts = new Map<
+    number,
+    Array<{
+      laneHeight: number;
+      node: SDK.ChunkGroupGraphNodeData;
+    }>
+  >();
+  let maxLevelHeight = 0;
+
+  for (const [level, levelNodes] of [...nodesByDepth.entries()].sort(
+    (a, b) => a[0] - b[0],
+  )) {
+    const sortedNodes = [...levelNodes].sort((a, b) => {
+      const aParents = (reverseAdjacency.get(a.id) ?? [])
+        .map((nodeId) => orderMap.get(nodeId))
+        .filter((value): value is number => typeof value === 'number');
+      const bParents = (reverseAdjacency.get(b.id) ?? [])
+        .map((nodeId) => orderMap.get(nodeId))
+        .filter((value): value is number => typeof value === 'number');
+
+      const aParentOrder = aParents.length
+        ? aParents.reduce((sum, value) => sum + value, 0) / aParents.length
+        : Number.POSITIVE_INFINITY;
+      const bParentOrder = bParents.length
+        ? bParents.reduce((sum, value) => sum + value, 0) / bParents.length
+        : Number.POSITIVE_INFINITY;
+
+      if (aParentOrder !== bParentOrder) {
+        return aParentOrder - bParentOrder;
+      }
+      if (a.isInitial !== b.isInitial) {
+        return a.isInitial ? -1 : 1;
+      }
+      if (a.totalEmittedSize !== b.totalEmittedSize) {
+        return b.totalEmittedSize - a.totalEmittedSize;
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+    const levelLayout = sortedNodes.map((node) => ({
+      laneHeight: getNodeLaneHeight(
+        node,
+        maxEmittedSize,
+        (adjacency.get(node.id) ?? []).length,
+      ),
+      node,
+    }));
+    const levelHeight =
+      levelLayout.reduce((sum, item) => sum + item.laneHeight, 0) +
+      Math.max(0, levelLayout.length - 1) * LAYOUT_ROW_GAP;
+
+    levelLayout.forEach((item, index) => {
+      orderMap.set(item.node.id, index);
+    });
+    levelLayouts.set(level, levelLayout);
+    maxLevelHeight = Math.max(maxLevelHeight, levelHeight);
+  }
+
+  const contentHeight = Math.max(
+    MIN_GRAPH_HEIGHT - LAYOUT_TOP_PADDING * 2,
+    maxLevelHeight,
+  );
+  const positions = new Map<
+    string,
+    {
+      x: number;
+      y: number;
+    }
+  >();
+
+  for (const [level, levelNodes] of [...levelLayouts.entries()].sort(
+    (a, b) => a[0] - b[0],
+  )) {
+    const levelHeight =
+      levelNodes.reduce((sum, item) => sum + item.laneHeight, 0) +
+      Math.max(0, levelNodes.length - 1) * LAYOUT_ROW_GAP;
+    let currentY =
+      LAYOUT_TOP_PADDING + (contentHeight - levelHeight) / 2;
+
+    levelNodes.forEach((item) => {
+      positions.set(item.node.id, {
+        x: LAYOUT_LEFT_PADDING + level * LAYOUT_COLUMN_GAP,
+        y: currentY + item.laneHeight / 2,
+      });
+      currentY += item.laneHeight + LAYOUT_ROW_GAP;
+    });
+  }
+
+  return {
+    height: contentHeight + LAYOUT_TOP_PADDING * 2,
+    positions,
+  };
+};
+
+const DetailPlaceholder = () => (
+  <Empty
+    description={
+      <Typography.Text type="secondary">
+        Click a chunk group or edge to inspect its details.
+      </Typography.Text>
+    }
+  />
+);
+
+const ImportCard: React.FC<{
+  fromName?: string;
+  item: SDK.ChunkGroupGraphImportData;
+}> = ({ fromName, item }) => (
+  <div
+    style={{
+      border: '1px solid #f0f0f0',
+      borderRadius: 8,
+      padding: 12,
+      background: '#fafafa',
+    }}
+  >
+    {fromName ? (
+      <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+        from {fromName}
+      </Typography.Text>
+    ) : null}
+    {item.request ? (
+      <div style={{ marginTop: fromName ? 6 : 0 }}>
+        <Tag color="gold">import({JSON.stringify(item.request)})</Tag>
+      </div>
+    ) : null}
+    {item.sourceModule ? (
+      <div style={{ marginTop: 6 }}>
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+          Source module
+        </Typography.Text>
+        <div>
+          <Typography.Text code style={{ fontSize: 12 }}>
+            {item.sourceModule}
+          </Typography.Text>
+        </div>
+      </div>
+    ) : null}
+    {item.loc ? (
+      <div>
+        <Typography.Text code style={{ fontSize: 12 }}>
+          {item.loc}
+        </Typography.Text>
+      </div>
+    ) : null}
+    {item.snippet ? (
+      <pre
+        style={{
+          marginTop: 8,
+          marginBottom: 0,
+          padding: 10,
+          borderRadius: 6,
+          background: '#111827',
+          color: '#f9fafb',
+          fontSize: 12,
+          overflowX: 'auto',
+        }}
+      >
+        {item.snippet}
+      </pre>
+    ) : null}
+  </div>
+);
+
+const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
+  report,
+}) => {
+  const chartRef = useRef<any>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
+  const [hoveredPathId, setHoveredPathId] = useState<string | null>(null);
+  const [expandedPathIds, setExpandedPathIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const nodes = report?.nodes ?? [];
+  const edges = report?.edges ?? [];
+
+  const nodeMap = useMemo(() => buildNodeMap(nodes), [nodes]);
+  const edgeMap = useMemo(() => buildEdgeMap(edges), [edges]);
+  const layout = useMemo(() => buildLayout(nodes, edges), [nodes, edges]);
+  const graphHeight = Math.max(MIN_GRAPH_HEIGHT, layout.height);
+
+  const matchedNodeIds = useMemo(() => {
+    if (!searchQuery.trim()) {
+      return new Set(nodes.map((node) => node.id));
+    }
+
+    const query = searchQuery.trim().toLowerCase();
+    return new Set(
+      nodes
+        .filter((node) => node.searchText.toLowerCase().includes(query))
+        .map((node) => node.id),
+    );
+  }, [nodes, searchQuery]);
+
+  const selectedNode = selectedNodeId ? nodeMap.get(selectedNodeId) : undefined;
+  const selectedEdge = selectedEdgeId ? edgeMap.get(selectedEdgeId) : undefined;
+  const selectedNodePaths = selectedNode?.paths ?? [];
+  const priorityNodes = useMemo(
+    () =>
+      (report?.priorityNodeIds ?? [])
+        .map((nodeId) => nodeMap.get(nodeId))
+        .filter(
+          (node): node is SDK.ChunkGroupGraphNodeData => Boolean(node),
+        )
+        .filter((node) => matchedNodeIds.has(node.id)),
+    [matchedNodeIds, nodeMap, report?.priorityNodeIds],
+  );
+
+  useEffect(() => {
+    setExpandedPathIds(new Set());
+  }, [selectedNode?.id]);
+
+  useEffect(() => {
+    const resizeChart = () => {
+      chartRef.current?.getEchartsInstance?.().resize?.();
+    };
+
+    const rafId = window.requestAnimationFrame(resizeChart);
+    const timer = window.setTimeout(resizeChart, 120);
+
+    return () => {
+      window.cancelAnimationFrame(rafId);
+      window.clearTimeout(timer);
+    };
+  }, [graphHeight, nodes.length, edges.length]);
+
+  const hoveredPath = selectedNodePaths.find((path) => path.id === hoveredPathId);
+
+  const highlightNodeIds = useMemo(() => {
+    if (hoveredPath) {
+      return new Set(hoveredPath.nodeIds);
+    }
+
+    if (selectedNode) {
+      return new Set(selectedNodePaths.flatMap((path) => path.nodeIds));
+    }
+
+    if (selectedEdge) {
+      return new Set([selectedEdge.from, selectedEdge.to]);
+    }
+
+    return new Set<string>();
+  }, [hoveredPath, selectedEdge, selectedNode, selectedNodePaths]);
+
+  const highlightEdgeIds = useMemo(() => {
+    if (hoveredPath) {
+      return new Set(hoveredPath.edgeIds);
+    }
+
+    if (selectedNode) {
+      return new Set(selectedNodePaths.flatMap((path) => path.edgeIds));
+    }
+
+    if (selectedEdge) {
+      return new Set([selectedEdge.id]);
+    }
+
+    return new Set<string>();
+  }, [hoveredPath, selectedEdge, selectedNode, selectedNodePaths]);
+
+  const option = useMemo<ChunkGroupGraphOption>(() => {
+    const hasSelection =
+      Boolean(selectedNode) || Boolean(selectedEdge) || Boolean(hoveredPath);
+    const hoverColor = hoveredPath ? getPathColor(hoveredPath.severity) : HIGHLIGHT_COLOR;
+    const useForceLayout = nodes.length > 12;
+    const maxEmittedSize = Math.max(
+      1,
+      ...nodes.map((item) => item.totalEmittedSize),
+    );
+
+    const graphNodes = nodes.map((node) => {
+      const position = layout.positions.get(node.id) ?? { x: 0, y: 0 };
+      const baseColor = getBaseNodeColor(node);
+      const isMatched = matchedNodeIds.has(node.id);
+      const isOnHighlight = highlightNodeIds.has(node.id);
+      const symbolSize = getNodeSymbolSize(node, maxEmittedSize);
+
+      let opacity = 1;
+      if (hasSelection) {
+        opacity = isOnHighlight ? 1 : 0.16;
+      } else if (searchQuery.trim()) {
+        opacity = isMatched ? 1 : 0.16;
+      }
+
+      const removableRatio =
+        node.groupTotalJSSize > 0
+          ? node.removableJSSize / node.groupTotalJSSize
+          : 0;
+      const borderColor =
+        selectedNode?.id === node.id
+          ? '#111827'
+          : removableRatio > 1 / 3
+            ? DANGER_COLOR
+            : removableRatio > 0
+              ? WARNING_COLOR
+              : baseColor.border;
+
+      return {
+        id: node.id,
+        name: node.name,
+        x: position.x,
+        y: position.y,
+        value: node.totalEmittedSize,
+        symbolSize,
+        itemStyle: {
+          color: hasSelection && !isOnHighlight ? MUTED_NODE : baseColor.background,
+          borderColor:
+            hasSelection && !isOnHighlight ? MUTED_BORDER : borderColor,
+          borderWidth: selectedNode?.id === node.id ? 4 : 2,
+          opacity,
+          shadowBlur: selectedNode?.id === node.id ? 12 : 0,
+          shadowColor: 'rgba(17,24,39,0.25)',
+        },
+        label: {
+          show: opacity > 0.3,
+          position: 'bottom' as const,
+          distance: 10,
+          width: NODE_LABEL_WIDTH,
+          overflow: 'truncate' as const,
+          lineHeight: 16,
+          align: 'center' as const,
+          color: '#111827',
+          fontSize: 12,
+          fontWeight: selectedNode?.id === node.id ? 700 : 500,
+          formatter: `${truncateLabel(node.name)}\n${formatSize(node.totalEmittedSize)}`,
+        },
+      };
+    });
+
+    const graphEdges = edges.map((edge) => {
+      const highlight = highlightEdgeIds.has(edge.id);
+      const matchesSearch =
+        matchedNodeIds.has(edge.from) || matchedNodeIds.has(edge.to);
+      let opacity = 0.6;
+      if (hasSelection) {
+        opacity = highlight ? 0.95 : 0.08;
+      } else if (searchQuery.trim()) {
+        opacity = matchesSearch ? 0.65 : 0.06;
+      }
+
+      return {
+        id: edge.id,
+        source: edge.from,
+        target: edge.to,
+        value: edge.imports.length,
+        lineStyle: {
+          color: highlight ? hoverColor : '#94a3b8',
+          width: highlight ? 3 : 1.5,
+          opacity,
+          curveness: 0.12,
+        },
+        label: {
+          show: edge.imports.length > 1 && opacity > 0.3,
+          formatter: `${edge.imports.length} imports`,
+          color: highlight ? hoverColor : '#64748b',
+          fontSize: 10,
+        },
+      };
+    });
+
+    return {
+      tooltip: {
+        trigger: 'item',
+        backgroundColor: '#111827',
+        borderWidth: 0,
+        textStyle: {
+          color: '#f9fafb',
+        },
+        formatter: (params: any) => {
+          if (params.dataType === 'edge') {
+            const edge = edgeMap.get(params.data.id);
+            if (!edge) {
+              return '';
+            }
+            const fromName = nodeMap.get(edge.from)?.name ?? edge.from;
+            const toName = nodeMap.get(edge.to)?.name ?? edge.to;
+            return `${fromName} → ${toName}<br/>${edge.imports.length} import() call(s)`;
+          }
+
+          const node = nodeMap.get(params.data.id);
+          if (!node) {
+            return '';
+          }
+          return [
+            `<strong>${node.name}</strong>`,
+            `${node.isInitial ? 'Entry' : 'Async'} chunk group`,
+            `Emitted JS: ${formatSize(node.totalEmittedSize)}`,
+            `Incremental removable: ${formatSize(node.removableJSSize)}`,
+            `Group-local removable: ${formatSize(node.localRemovableJSSize)}`,
+          ].join('<br/>');
+        },
+      },
+      animationDuration: 250,
+      animationDurationUpdate: 300,
+      series: [
+        {
+          type: 'graph',
+          layout: useForceLayout ? 'force' : 'none',
+          roam: true,
+          draggable: true,
+          data: graphNodes,
+          links: graphEdges,
+          force: useForceLayout
+            ? {
+                initLayout: 'circular',
+                repulsion: Math.min(3200, Math.max(1200, nodes.length * 110)),
+                edgeLength: [180, 320],
+                gravity: 0.06,
+                friction: 0.5,
+                layoutAnimation: false,
+              }
+            : undefined,
+          lineStyle: {
+            opacity: 0.65,
+            width: 1.5,
+          },
+          emphasis: {
+            focus: 'adjacency',
+          },
+        },
+      ],
+    };
+  }, [
+    edgeMap,
+    edges,
+    highlightEdgeIds,
+    highlightNodeIds,
+    hoveredPath,
+    layout,
+    matchedNodeIds,
+    nodeMap,
+    nodes,
+    searchQuery,
+    selectedEdge,
+    selectedNode,
+  ]);
+
+  if (!nodes.length) {
+    return (
+      <Empty
+        description={
+          <Typography.Text type="secondary">
+            Chunk group analysis is unavailable for this report.
+          </Typography.Text>
+        }
+      />
+    );
+  }
+
+  const overview = report?.overview;
+  const removableGroupCount = overview?.removableGroupCount ?? 0;
+  const totalRemovableSize = overview?.totalRemovableSize ?? 0;
+  const dangerPathCount = overview?.dangerPathCount ?? 0;
+  const warningPathCount = overview?.warningPathCount ?? 0;
+  const selectedNodeImports = selectedNode?.incomingImports ?? [];
+
+  return (
+    <Space direction="vertical" style={{ width: '100%' }} size="middle">
+      <Alert
+        type={removableGroupCount ? 'warning' : 'success'}
+        showIcon
+        message={`Chunk groups: ${nodes.length}`}
+        description={
+          removableGroupCount
+            ? `${removableGroupCount} groups add potentially removable JS-like modules on entry load paths (${formatSize(totalRemovableSize)} total incremental). ${dangerPathCount} path(s) are marked red and ${warningPathCount} path(s) are marked yellow.`
+            : 'No additional potentially removable JS-like modules were detected on current entry load paths.'
+        }
+      />
+
+      <Card
+        title="Chunk Group Graph"
+        extra={
+          <Space>
+            <Tag color="blue">Entry</Tag>
+            <Tag color="green">Async</Tag>
+          </Space>
+        }
+      >
+        <Space direction="vertical" style={{ width: '100%' }} size="middle">
+          <Input
+            allowClear
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search chunk groups..."
+            prefix={<SearchOutlined />}
+          />
+
+          <Row gutter={16} align="top">
+            <Col span={16}>
+              <Card bodyStyle={{ padding: 0 }}>
+                <ReactEChartsCore
+                  ref={chartRef}
+                  echarts={echarts}
+                  option={option}
+                  notMerge
+                  style={{ height: graphHeight, width: '100%' }}
+                  onEvents={{
+                    click: (params: any) => {
+                      if (params.dataType === 'node') {
+                        setSelectedNodeId(params.data.id);
+                        setSelectedEdgeId(null);
+                        setHoveredPathId(null);
+                      } else if (params.dataType === 'edge') {
+                        setSelectedEdgeId(params.data.id);
+                        setSelectedNodeId(null);
+                        setHoveredPathId(null);
+                      }
+                    },
+                  }}
+                />
+              </Card>
+            </Col>
+
+            <Col span={8}>
+              <Card
+                title="Details"
+                extra={
+                  selectedNode || selectedEdge ? (
+                    <Typography.Link
+                      onClick={() => {
+                        setSelectedEdgeId(null);
+                        setSelectedNodeId(null);
+                        setHoveredPathId(null);
+                      }}
+                    >
+                      Reset focus
+                    </Typography.Link>
+                  ) : null
+                }
+                bodyStyle={{
+                  maxHeight: 760,
+                  overflowY: 'auto',
+                }}
+              >
+                {!selectedNode && !selectedEdge ? <DetailPlaceholder /> : null}
+
+                {selectedNode ? (
+                  <Space direction="vertical" style={{ width: '100%' }} size="middle">
+                    <div>
+                      <Typography.Title level={5} style={{ marginBottom: 8 }}>
+                        {selectedNode.name}
+                      </Typography.Title>
+                      <Space wrap>
+                        <Tag color={selectedNode.isInitial ? 'blue' : 'green'}>
+                          {selectedNode.isInitial ? 'Entry' : 'Async'}
+                        </Tag>
+                        <Tag>{formatSize(selectedNode.totalEmittedSize)} emitted</Tag>
+                        <Tag>{formatSize(selectedNode.groupTotalJSSize)} JS total</Tag>
+                        <Tag color={selectedNode.removableJSSize ? 'gold' : 'default'}>
+                          {formatSize(selectedNode.removableJSSize)} removable on path
+                        </Tag>
+                        <Tag color={selectedNode.localRemovableJSSize ? 'default' : 'default'}>
+                          {formatSize(selectedNode.localRemovableJSSize)} in group
+                        </Tag>
+                        {selectedNode.inheritedRemovableJSSize > 0 ? (
+                          <Tag color="cyan">
+                            {formatSize(selectedNode.inheritedRemovableJSSize)} already loaded before
+                          </Tag>
+                        ) : null}
+                      </Space>
+                      <div style={{ marginTop: 8 }}>
+                        <Typography.Text type="secondary">
+                          Reachable modules: {selectedNode.reachableModuleCount} /{' '}
+                          {selectedNode.actualModuleCount}
+                        </Typography.Text>
+                      </div>
+                    </div>
+
+                    <div>
+                      <Typography.Title level={5}>Chunks In This Group</Typography.Title>
+                      <Space direction="vertical" style={{ width: '100%' }}>
+                        {selectedNode.chunks.length ? (
+                          selectedNode.chunks.map((chunk) => (
+                            <div
+                              key={chunk.id}
+                              style={{
+                                border: '1px solid #f0f0f0',
+                                borderRadius: 8,
+                                padding: 12,
+                              }}
+                            >
+                              <Typography.Text strong>{chunk.name}</Typography.Text>
+                              <div style={{ marginTop: 6 }}>
+                                <Space wrap>
+                                  <Tag>{formatSize(chunk.emittedSize)} emitted</Tag>
+                                  <Tag>{formatSize(chunk.totalJSSize)} JS total</Tag>
+                                  <Tag>{chunk.moduleCount} modules</Tag>
+                                </Space>
+                              </div>
+                              {chunk.files.length ? (
+                                <div style={{ marginTop: 8 }}>
+                                  {chunk.files.map((file) => (
+                                    <div key={file}>
+                                      <Typography.Text code>{file}</Typography.Text>
+                                    </div>
+                                  ))}
+                                </div>
+                              ) : null}
+                            </div>
+                          ))
+                        ) : (
+                          <Typography.Text type="secondary">
+                            No JS chunks recorded for this group.
+                          </Typography.Text>
+                        )}
+                      </Space>
+                    </div>
+
+                    <div>
+                      <Typography.Title level={5}>
+                        Dynamic Import Origins ({selectedNodeImports.length})
+                      </Typography.Title>
+                      <Space direction="vertical" style={{ width: '100%' }}>
+                        {selectedNodeImports.length ? (
+                          selectedNodeImports.map((item, index) => (
+                            <ImportCard
+                              key={`${item.edgeId}_${index}`}
+                              fromName={item.fromName}
+                              item={item}
+                            />
+                          ))
+                        ) : (
+                          <Typography.Text type="secondary">
+                            No inbound async import() origins were captured for this group.
+                          </Typography.Text>
+                        )}
+                      </Space>
+                    </div>
+
+                    <div>
+                      <Typography.Title level={5}>
+                        Incremental Removable JS Modules ({selectedNode.removableJSModuleCount})
+                      </Typography.Title>
+                      {selectedNode.inheritedRemovableJSModuleCount > 0 ? (
+                        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                          {formatSize(selectedNode.inheritedRemovableJSSize)} of this group's local removable
+                          JS has already been loaded on every entry path before reaching this group.
+                        </Typography.Text>
+                      ) : null}
+                      {selectedNode.removableJSModules.length > 50 ? (
+                        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                          Showing top 50 modules by size.
+                        </Typography.Text>
+                      ) : null}
+                      <Space direction="vertical" style={{ width: '100%' }}>
+                        {selectedNode.removableJSModules.length ? (
+                          selectedNode.removableJSModules.slice(0, 50).map((module) => (
+                            <div
+                              key={module.id}
+                              style={{
+                                display: 'flex',
+                                justifyContent: 'space-between',
+                                gap: 12,
+                              }}
+                            >
+                              <div style={{ minWidth: 0 }}>
+                                <Typography.Text style={{ display: 'block' }}>
+                                  {module.resource ?? module.name}
+                                </Typography.Text>
+                              </div>
+                              <Typography.Text code>
+                                {formatSize(module.size)}
+                              </Typography.Text>
+                            </div>
+                          ))
+                        ) : (
+                          <Typography.Text type="secondary">
+                            {selectedNode.localRemovableJSModuleCount > 0
+                              ? 'No additional removable JS-like modules are introduced here; the group-local removable modules were already loaded earlier on every entry path.'
+                              : 'No removable JS-like modules were detected in this group.'}
+                          </Typography.Text>
+                        )}
+                      </Space>
+                    </div>
+
+                    {selectedNode.inheritedRemovableJSModules.length ? (
+                      <div>
+                        <Typography.Title level={5}>
+                          Already Loaded Before This Group ({selectedNode.inheritedRemovableJSModuleCount})
+                        </Typography.Title>
+                        <Space direction="vertical" style={{ width: '100%' }}>
+                          {selectedNode.inheritedRemovableJSModules
+                            .slice(0, 50)
+                            .map((module) => (
+                              <div
+                                key={module.id}
+                                style={{
+                                  display: 'flex',
+                                  justifyContent: 'space-between',
+                                  gap: 12,
+                                }}
+                              >
+                                <div style={{ minWidth: 0 }}>
+                                  <Typography.Text style={{ display: 'block' }}>
+                                    {module.resource ?? module.name}
+                                  </Typography.Text>
+                                </div>
+                                <Typography.Text code>
+                                  {formatSize(module.size)}
+                                </Typography.Text>
+                              </div>
+                            ))}
+                        </Space>
+                      </div>
+                    ) : null}
+
+                    <div>
+                      <Typography.Title level={5}>
+                        Load Paths From Entry ({selectedNode.pathCount})
+                      </Typography.Title>
+                      {selectedNode.pathsTruncated ? (
+                        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                          Showing the first {report?.pathLimit ?? selectedNode.pathCount} paths for this
+                          group. The full path set is larger.
+                        </Typography.Text>
+                      ) : null}
+                      <Space direction="vertical" style={{ width: '100%' }}>
+                        {selectedNodePaths.length ? (
+                          selectedNodePaths.map((path) => {
+                            const color = getPathColor(path.severity);
+                            const backgroundColor =
+                              path.severity === 'danger'
+                                ? '#fff1f0'
+                                : path.severity === 'warning'
+                                  ? '#fffbe6'
+                                  : '#fafafa';
+                            const isExpanded = expandedPathIds.has(path.id);
+
+                            const header = (
+                              <div
+                                onMouseEnter={() => setHoveredPathId(path.id)}
+                                onMouseLeave={() => setHoveredPathId(null)}
+                                onClick={() => {
+                                  setExpandedPathIds((prev) => {
+                                    const next = new Set(prev);
+                                    if (next.has(path.id)) {
+                                      next.delete(path.id);
+                                    } else {
+                                      next.add(path.id);
+                                    }
+                                    return next;
+                                  });
+                                }}
+                                style={{
+                                  border: `1px solid ${color}`,
+                                  borderRadius: 8,
+                                  padding: 12,
+                                  background: backgroundColor,
+                                  cursor: 'pointer',
+                                }}
+                              >
+                                <Space
+                                  direction="vertical"
+                                  style={{ width: '100%' }}
+                                  size="small"
+                                >
+                                  <div
+                                    style={{
+                                      display: 'flex',
+                                      justifyContent: 'space-between',
+                                      gap: 12,
+                                      alignItems: 'flex-start',
+                                    }}
+                                  >
+                                    <Typography.Text strong style={{ flex: 1 }}>
+                                      {path.label}
+                                    </Typography.Text>
+                                    <Typography.Text
+                                      type="secondary"
+                                      style={{ fontSize: 12, whiteSpace: 'nowrap' }}
+                                    >
+                                      {isExpanded ? 'Collapse' : 'Expand'}
+                                    </Typography.Text>
+                                  </div>
+                                  <Space wrap>
+                                    <Tag color="default">
+                                      {formatSize(path.totalEmittedSize)} loaded
+                                    </Tag>
+                                    <Tag color="default">
+                                      {path.chunkIds.length} unique chunks
+                                    </Tag>
+                                    <Tag color="default">
+                                      {formatSize(path.totalJSSize)} JS total
+                                    </Tag>
+                                    {path.unnecessarySize > 0 ? (
+                                      <Tag color={path.severity === 'danger' ? 'red' : 'gold'}>
+                                        {formatSize(path.unnecessarySize)} unnecessary
+                                      </Tag>
+                                    ) : null}
+                                    {path.unnecessarySize > 0 ? (
+                                      <Tag color={path.severity === 'danger' ? 'red' : 'gold'}>
+                                        {formatPercent(path.ratio)}
+                                      </Tag>
+                                    ) : null}
+                                    {path.unnecessaryModuleCount > path.topUnnecessaryModules.length ? (
+                                      <Tag color="default">
+                                        top {path.topUnnecessaryModules.length} /{' '}
+                                        {path.unnecessaryModuleCount} modules
+                                      </Tag>
+                                    ) : null}
+                                  </Space>
+                                  {isExpanded ? (
+                                    <>
+                                      <div>
+                                        <Typography.Text
+                                          type="secondary"
+                                          style={{ fontSize: 12 }}
+                                        >
+                                          Chunks
+                                        </Typography.Text>
+                                        {path.chunks.map((chunk) => (
+                                          <div
+                                            key={chunk.id}
+                                            style={{
+                                              display: 'flex',
+                                              justifyContent: 'space-between',
+                                              gap: 12,
+                                            }}
+                                          >
+                                            <Typography.Text style={{ fontSize: 12 }}>
+                                              {chunk.name}
+                                            </Typography.Text>
+                                            <Typography.Text code style={{ fontSize: 12 }}>
+                                              {formatSize(chunk.emittedSize)}
+                                            </Typography.Text>
+                                          </div>
+                                        ))}
+                                      </div>
+                                      {path.topUnnecessaryModules.length ? (
+                                        <div>
+                                          <Typography.Text
+                                            type="secondary"
+                                            style={{ fontSize: 12 }}
+                                          >
+                                            Top unnecessary modules
+                                          </Typography.Text>
+                                          {path.topUnnecessaryModules
+                                            .slice(0, 5)
+                                            .map((module) => (
+                                            <div
+                                              key={module.id}
+                                              style={{
+                                                display: 'flex',
+                                                justifyContent: 'space-between',
+                                                gap: 12,
+                                              }}
+                                            >
+                                              <Typography.Text style={{ fontSize: 12 }}>
+                                                {module.resource ?? module.name}
+                                              </Typography.Text>
+                                              <Typography.Text code style={{ fontSize: 12 }}>
+                                                {formatSize(module.size)}
+                                              </Typography.Text>
+                                            </div>
+                                          ))}
+                                        </div>
+                                      ) : null}
+                                    </>
+                                  ) : null}
+                                </Space>
+                              </div>
+                            );
+
+                            if (path.severity !== 'danger') {
+                              return <React.Fragment key={path.id}>{header}</React.Fragment>;
+                            }
+
+                            return (
+                              <Tooltip title="非必要依赖过多" key={path.id}>
+                                {header}
+                              </Tooltip>
+                            );
+                          })
+                        ) : (
+                          <Typography.Text type="secondary">
+                            No load path from entry was found for the selected chunk group.
+                          </Typography.Text>
+                        )}
+                      </Space>
+                    </div>
+                  </Space>
+                ) : null}
+
+                {selectedEdge ? (
+                  <Space direction="vertical" style={{ width: '100%' }} size="middle">
+                    <div>
+                      <Typography.Title level={5} style={{ marginBottom: 8 }}>
+                        {selectedEdge.fromName + ' → ' + selectedEdge.toName}
+                      </Typography.Title>
+                      <Tag>{selectedEdge.imports.length} import() call(s)</Tag>
+                    </div>
+
+                    <Space direction="vertical" style={{ width: '100%' }}>
+                      {selectedEdge.imports.map((item, index) => (
+                        <ImportCard key={`${selectedEdge.id}_${index}`} item={item} />
+                      ))}
+                    </Space>
+                  </Space>
+                ) : null}
+              </Card>
+            </Col>
+          </Row>
+
+          <Card
+            title={`Chunk Group List (${priorityNodes.length})`}
+            extra={
+              <Typography.Text type="secondary">
+                Sorted by unnecessary size on load paths
+              </Typography.Text>
+            }
+          >
+            <Space direction="vertical" style={{ width: '100%' }} size="small">
+              {priorityNodes.length ? (
+                priorityNodes.map((node) => {
+                  const isSelected = selectedNode?.id === node.id;
+                  const topPath = node.paths[0];
+                  const severity = node.worstPathSeverity;
+                  const borderColor =
+                    severity === 'danger'
+                      ? DANGER_COLOR
+                      : severity === 'warning'
+                        ? WARNING_COLOR
+                        : '#d9d9d9';
+                  const backgroundColor =
+                    severity === 'danger'
+                      ? '#fff1f0'
+                      : severity === 'warning'
+                        ? '#fffbe6'
+                        : '#ffffff';
+
+                  return (
+                    <div
+                      key={node.id}
+                      onClick={() => {
+                        setSelectedNodeId(node.id);
+                        setSelectedEdgeId(null);
+                        setHoveredPathId(null);
+                      }}
+                      style={{
+                        border: `1px solid ${isSelected ? '#111827' : borderColor}`,
+                        borderRadius: 10,
+                        padding: 14,
+                        background: backgroundColor,
+                        cursor: 'pointer',
+                        boxShadow: isSelected
+                          ? '0 0 0 2px rgba(17,24,39,0.08)'
+                          : 'none',
+                      }}
+                    >
+                      <Space
+                        direction="vertical"
+                        style={{ width: '100%' }}
+                        size="small"
+                      >
+                        <div
+                          style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            gap: 12,
+                            alignItems: 'flex-start',
+                          }}
+                        >
+                          <div style={{ minWidth: 0, flex: 1 }}>
+                            <Typography.Text strong style={{ display: 'block' }}>
+                              {node.name}
+                            </Typography.Text>
+                            {topPath ? (
+                              <Typography.Text
+                                type="secondary"
+                                style={{ fontSize: 12 }}
+                              >
+                                {topPath.label}
+                              </Typography.Text>
+                            ) : null}
+                          </div>
+                          <Space wrap size={[4, 4]}>
+                            <Tag color={node.isInitial ? 'blue' : 'green'}>
+                              {node.isInitial ? 'Entry' : 'Async'}
+                            </Tag>
+                            <Tag color={getSeverityTagColor(severity)}>
+                              {severity === 'danger'
+                                ? 'Red path'
+                                : severity === 'warning'
+                                  ? 'Yellow path'
+                                  : 'No path risk'}
+                            </Tag>
+                          </Space>
+                        </div>
+
+                        <Space wrap>
+                          <Tag>{formatSize(node.totalEmittedSize)} emitted</Tag>
+                          <Tag>{formatSize(node.groupTotalJSSize)} JS total</Tag>
+                          <Tag color={node.removableJSSize ? 'gold' : 'default'}>
+                            {formatSize(node.removableJSSize)} incremental removable
+                          </Tag>
+                          <Tag color={getSeverityTagColor(severity)}>
+                            {formatSize(node.maxPathUnnecessarySize)} worst path unnecessary
+                          </Tag>
+                          <Tag>{node.pathCount} path(s)</Tag>
+                          <Tag>{node.incomingImports.length} import(s)</Tag>
+                        </Space>
+
+                        {topPath ? (
+                          <div
+                            style={{
+                              display: 'flex',
+                              justifyContent: 'space-between',
+                              gap: 12,
+                              flexWrap: 'wrap',
+                            }}
+                          >
+                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                              Worst path ratio {formatPercent(topPath.ratio)}
+                            </Typography.Text>
+                            {topPath.topUnnecessaryModules[0] ? (
+                              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                                Top module:{' '}
+                                {topPath.topUnnecessaryModules[0].resource ??
+                                  topPath.topUnnecessaryModules[0].name}{' '}
+                                ({formatSize(topPath.topUnnecessaryModules[0].size)})
+                              </Typography.Text>
+                            ) : null}
+                          </div>
+                        ) : null}
+                      </Space>
+                    </div>
+                  );
+                })
+              ) : (
+                <Empty
+                  description={
+                    <Typography.Text type="secondary">
+                      No chunk groups match the current search.
+                    </Typography.Text>
+                  }
+                />
+              )}
+            </Space>
+          </Card>
+        </Space>
+      </Card>
+    </Space>
+  );
+};
+
+export const ChunkGroupGraphPanel = memo(ChunkGroupGraphPanelBase);

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -58,11 +58,13 @@ const MIN_GRAPH_HEIGHT = 520;
 const MAX_GRAPH_HEIGHT = 620;
 const LAYOUT_TOP_PADDING = 64;
 const LAYOUT_LEFT_PADDING = 120;
-const LAYOUT_ROW_GAP = 32;
-const LAYOUT_COLUMN_GAP = 320;
-const LAYOUT_SUBCOLUMN_GAP = 250;
-const MAX_LAYOUT_ROWS_PER_LEVEL = 6;
+const LAYOUT_ROW_GAP = 96;
+const LAYOUT_COLUMN_GAP = 640;
+const LAYOUT_SUBCOLUMN_GAP = 520;
+const MAX_LAYOUT_ROWS_PER_LEVEL = 7;
+const LARGE_GRAPH_NODE_SCALE = 0.44;
 const NODE_LABEL_WIDTH = 180;
+const GRAPH_BOUNDARY_NODE_ID_PREFIX = '__chunk-group-graph-boundary__';
 
 const getBaseNodeColor = (node: SDK.ChunkGroupGraphNodeData) =>
   node.isInitial
@@ -538,7 +540,8 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
       const isMatched = matchedNodeIds.has(node.id);
       const isOnHighlight = highlightNodeIds.has(node.id);
       const symbolSize =
-        getNodeSymbolSize(node, maxEmittedSize) * (isLargeGraph ? 0.78 : 1);
+        getNodeSymbolSize(node, maxEmittedSize) *
+        (isLargeGraph ? LARGE_GRAPH_NODE_SCALE : 1);
 
       let opacity = 1;
       if (hasSelection) {
@@ -599,6 +602,41 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
         },
       };
     });
+    const positionedNodes = [...layout.positions.values()];
+    const boundaryPadding = isLargeGraph ? 720 : 240;
+    const positionedXs = positionedNodes.map((position) => position.x);
+    const positionedYs = positionedNodes.map((position) => position.y);
+    const boundaryMinX = Math.min(...positionedXs) - boundaryPadding;
+    const boundaryMaxX = Math.max(...positionedXs) + boundaryPadding;
+    const boundaryMinY = Math.min(...positionedYs) - boundaryPadding;
+    const boundaryMaxY = Math.max(...positionedYs) + boundaryPadding;
+    const graphBoundaryNodes = positionedNodes.length
+      ? [
+          [boundaryMinX, boundaryMinY],
+          [boundaryMaxX, boundaryMinY],
+          [boundaryMinX, boundaryMaxY],
+          [boundaryMaxX, boundaryMaxY],
+        ].map(([x, y], index) => ({
+          id: `${GRAPH_BOUNDARY_NODE_ID_PREFIX}${index}`,
+          name: '',
+          x,
+          y,
+          silent: true,
+          symbolSize: 1,
+          itemStyle: {
+            opacity: 0,
+          },
+          label: {
+            show: false,
+          },
+          tooltip: {
+            show: false,
+          },
+          emphasis: {
+            disabled: true,
+          },
+        }))
+      : [];
 
     const graphEdges = edges.map((edge) => {
       const highlight = highlightEdgeIds.has(edge.id);
@@ -671,20 +709,22 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
       series: [
         {
           type: 'graph',
+          left: 8,
+          right: 8,
+          top: 8,
+          bottom: 8,
           layout: 'none',
           roam: true,
           draggable: false,
-          zoom: isLargeGraph ? 1.15 : 1,
-          center: isLargeGraph
-            ? [LAYOUT_LEFT_PADDING + 520, LAYOUT_TOP_PADDING + 1000]
-            : undefined,
+          nodeScaleRatio: (isLargeGraph ? 0.24 : 0.6) as any,
+          zoom: isLargeGraph ? 0.72 : 1,
           scaleLimit: {
-            min: 0.25,
+            min: 0.2,
             max: 4,
           },
           edgeSymbol: ['none', 'arrow'],
           edgeSymbolSize: [0, 8],
-          data: graphNodes,
+          data: [...graphNodes, ...graphBoundaryNodes],
           links: graphEdges,
           lineStyle: {
             opacity: 0.65,
@@ -941,15 +981,15 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
             prefix={<SearchOutlined />}
           />
 
-          <Row gutter={16} align="top">
-            <Col span={16}>
+          <Row gutter={[16, 16]} align="top">
+            <Col xs={24} xl={16}>
               <Card bodyStyle={{ padding: 0 }}>
                 <ReactEChartsCore
                   ref={chartRef}
                   echarts={echarts}
                   option={option}
                   notMerge
-                  style={{ height: graphHeight, width: '100%' }}
+                  style={{ cursor: 'grab', height: graphHeight, width: '100%' }}
                   onEvents={{
                     click: (params: any) => {
                       if (params.dataType === 'node') {
@@ -967,7 +1007,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
               </Card>
             </Col>
 
-            <Col span={8}>
+            <Col xs={24} xl={8}>
               <Card
                 title="Details"
                 extra={

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -278,103 +278,6 @@ const getZRenderEventPoint = (event: any) => ({
         : 0,
 });
 
-const getScrollableAxes = (element: HTMLElement) => {
-  const { overflowY, overflowX } = window.getComputedStyle(element);
-  const canScrollY =
-    /(auto|scroll|overlay)/.test(overflowY) &&
-    element.scrollHeight > element.clientHeight;
-  const canScrollX =
-    /(auto|scroll|overlay)/.test(overflowX) &&
-    element.scrollWidth > element.clientWidth;
-
-  return {
-    x: canScrollX,
-    y: canScrollY,
-  };
-};
-
-const findScrollContainer = (
-  element: HTMLElement,
-  deltaX: number,
-  deltaY: number,
-) => {
-  let current = element.parentElement;
-  const shouldScrollY = Math.abs(deltaY) >= Math.abs(deltaX);
-
-  while (current && current !== document.body) {
-    const scrollable = getScrollableAxes(current);
-    if (
-      (shouldScrollY && scrollable.y) ||
-      (!shouldScrollY && scrollable.x) ||
-      (deltaY !== 0 && scrollable.y) ||
-      (deltaX !== 0 && scrollable.x)
-    ) {
-      return current;
-    }
-    current = current.parentElement;
-  }
-
-  return document.scrollingElement ?? document.documentElement;
-};
-
-const scrollElementByWheel = (
-  element: Element,
-  deltaX: number,
-  deltaY: number,
-) => {
-  if (
-    element === document.scrollingElement ||
-    element === document.documentElement
-  ) {
-    window.scrollBy({
-      left: deltaX,
-      top: deltaY,
-      behavior: 'auto',
-    });
-    return;
-  }
-
-  element.scrollLeft += deltaX;
-  element.scrollTop += deltaY;
-};
-
-const normalizeWheelDelta = (event: WheelEvent) => {
-  let deltaX = event.deltaX;
-  let deltaY = event.deltaY;
-  const legacyEvent = event as WheelEvent & {
-    detail?: number;
-    wheelDelta?: number;
-    wheelDeltaX?: number;
-    wheelDeltaY?: number;
-  };
-
-  if (event.deltaMode === 1) {
-    deltaX *= 16;
-    deltaY *= 16;
-  } else if (event.deltaMode === 2) {
-    deltaX *= window.innerWidth;
-    deltaY *= window.innerHeight;
-  }
-
-  if (!deltaX && legacyEvent.wheelDeltaX) {
-    deltaX = -legacyEvent.wheelDeltaX;
-  }
-  if (!deltaY && legacyEvent.wheelDeltaY) {
-    deltaY = -legacyEvent.wheelDeltaY;
-  }
-  if (!deltaY && legacyEvent.wheelDelta) {
-    deltaY = -legacyEvent.wheelDelta;
-  }
-  if (!deltaY && legacyEvent.detail) {
-    deltaY = legacyEvent.detail * 16;
-  }
-
-  return {
-    deltaX,
-    deltaY,
-  };
-};
-
 const sortPathsByOpportunity = (
   a: SDK.ChunkGroupGraphPathData,
   b: SDK.ChunkGroupGraphPathData,
@@ -765,24 +668,13 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
         return;
       }
 
-      const { deltaX, deltaY } = normalizeWheelDelta(event);
-      if (!deltaX && !deltaY) {
-        return;
-      }
-
-      event.preventDefault();
+      // Keep normal wheel scrolling native, but keep ECharts from treating it
+      // as graph zoom. Ctrl/Cmd + wheel is still forwarded for graph zoom.
       event.stopPropagation();
       event.stopImmediatePropagation();
-
-      scrollElementByWheel(
-        findScrollContainer(element, deltaX, deltaY),
-        deltaX,
-        deltaY,
-      );
     };
     const options: AddEventListenerOptions = {
       capture: true,
-      passive: false,
     };
 
     element.addEventListener('wheel', handleGraphWheel, options);

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -45,6 +45,11 @@ type ChunkGroupGraphPanelProps = {
   report?: SDK.ChunkGroupGraphData;
 };
 
+type GraphImportSnippetLabel = {
+  file: string;
+  code: string;
+};
+
 const ENTRY_COLOR = '#1f6feb';
 const ASYNC_COLOR = '#238636';
 const HIGHLIGHT_COLOR = '#f59e0b';
@@ -152,38 +157,110 @@ const getNodeLaneHeight = (
 const truncateLabel = (value: string, maxLength = 26) =>
   value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
 
-const normalizeGraphLabel = (value: string, maxLength: number) =>
-  truncateLabel(
-    value.replace(/[{}]/g, '').replace(/\s+/g, ' ').trim(),
-    maxLength,
-  );
-
-const getImportSnippetLabel = (item: SDK.ChunkGroupGraphImportData) => {
-  const snippetLine = item.snippet
-    ?.split('\n')
-    .map((line) => line.trim())
-    .find((line) => line.includes('import('));
-
-  if (snippetLine) {
-    return normalizeGraphLabel(snippetLine, 64);
+const truncateMiddleLabel = (value: string, maxLength: number) => {
+  if (value.length <= maxLength) {
+    return value;
   }
 
-  if (item.request) {
-    return normalizeGraphLabel(`import(${JSON.stringify(item.request)})`, 64);
-  }
-
-  return '';
+  const tailLength = Math.floor((maxLength - 1) / 2);
+  const headLength = maxLength - tailLength - 1;
+  return `${value.slice(0, headLength)}…${value.slice(-tailLength)}`;
 };
 
-const getEdgeImportSnippetLabel = (edge: SDK.ChunkGroupGraphEdgeData) => {
-  const snippets = edge.imports.map(getImportSnippetLabel).filter(Boolean);
-  if (!snippets.length) {
-    return '';
+const normalizeGraphLabelText = (value: string) =>
+  value.replace(/[{}]/g, '').replace(/\s+/g, ' ').trim();
+
+const normalizeGraphLabel = (value: string, maxLength: number) =>
+  truncateLabel(normalizeGraphLabelText(value), maxLength);
+
+const normalizeFileGraphLabel = (value: string, maxLength: number) =>
+  truncateMiddleLabel(normalizeGraphLabelText(value), maxLength);
+
+const stripSnippetLineNumber = (value: string) =>
+  value.replace(/^\d+\s*\|\s*/, '').trim();
+
+const buildImportSnippetCode = (item: SDK.ChunkGroupGraphImportData) => {
+  const snippetLines =
+    item.snippet
+      ?.split('\n')
+      .map((line) => stripSnippetLineNumber(line.trim()))
+      .filter(Boolean) ?? [];
+  const importLineIndex = snippetLines.findIndex((line) =>
+    line.includes('import('),
+  );
+
+  if (importLineIndex >= 0) {
+    const requestLineIndex = item.request
+      ? snippetLines.findIndex((line, index) => {
+          return index >= importLineIndex && line.includes(item.request!);
+        })
+      : -1;
+    const endIndex =
+      requestLineIndex >= 0
+        ? Math.min(snippetLines.length, requestLineIndex + 2)
+        : importLineIndex + 1;
+
+    return snippetLines.slice(importLineIndex, endIndex).join(' ');
   }
 
-  return edge.imports.length > 1
-    ? `${snippets[0]} +${edge.imports.length - 1}`
-    : snippets[0];
+  return item.request ? `import(${JSON.stringify(item.request)})` : '';
+};
+
+const getSourceFileLabel = (item: SDK.ChunkGroupGraphImportData) => {
+  const source = item.sourceModule || item.loc?.replace(/:\d+:\d+$/, '') || '';
+  const fileName = source.split(/[\\/]/).filter(Boolean).pop() || source;
+  const line = item.loc?.match(/:(\d+):\d+$/)?.[1];
+
+  if (!fileName) {
+    return line ? `line ${line}` : 'unknown source';
+  }
+
+  return line ? `${fileName}:${line}` : fileName;
+};
+
+const getImportSnippetLabel = (
+  item: SDK.ChunkGroupGraphImportData,
+): GraphImportSnippetLabel | undefined => {
+  const code = buildImportSnippetCode(item);
+
+  if (!code) {
+    return undefined;
+  }
+
+  return {
+    file: normalizeFileGraphLabel(getSourceFileLabel(item), 42),
+    code: normalizeGraphLabel(code, 72),
+  };
+};
+
+const formatEdgeImportSnippetLabel = (
+  edge: SDK.ChunkGroupGraphEdgeData,
+): GraphImportSnippetLabel | undefined => {
+  const snippets = edge.imports.map(getImportSnippetLabel).filter(Boolean);
+  if (!snippets.length) {
+    return undefined;
+  }
+
+  const first = snippets[0]!;
+  if (edge.imports.length <= 1) {
+    return first;
+  }
+
+  return {
+    file: `${first.file} +${edge.imports.length - 1}`,
+    code: first.code,
+  };
+};
+
+const getEdgeImportSnippetGraphLabel = (
+  edge: SDK.ChunkGroupGraphEdgeData,
+): GraphImportSnippetLabel | undefined => {
+  const label = formatEdgeImportSnippetLabel(edge);
+  if (!label) {
+    return undefined;
+  }
+
+  return label;
 };
 
 const getZRenderEventPoint = (event: any) => ({
@@ -587,7 +664,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
     ? (hoveredPath ?? selectedNodePaths[0])
     : undefined;
   const activePathImportSnippets = useMemo(() => {
-    const snippets = new Map<string, string>();
+    const snippets = new Map<string, GraphImportSnippetLabel>();
     if (!activeSnippetPath) {
       return snippets;
     }
@@ -597,7 +674,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
       if (!edge) {
         continue;
       }
-      const snippet = getEdgeImportSnippetLabel(edge);
+      const snippet = getEdgeImportSnippetGraphLabel(edge);
       if (snippet) {
         snippets.set(edge.to, snippet);
       }
@@ -729,7 +806,9 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
         node.totalEmittedSize,
       )}`;
       const labelFormatter = shouldShowImportSnippet
-        ? `{snippet|${importSnippet}}\n{name|${normalizeGraphLabel(
+        ? `{file|${importSnippet!.file}}\n{snippet|${
+            importSnippet!.code
+          }}\n{name|${normalizeGraphLabel(
             node.name,
             30,
           )}}\n{size|${formatSize(node.totalEmittedSize)}}`
@@ -759,7 +838,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
             ? ('top' as const)
             : ('bottom' as const),
           distance: shouldShowImportSnippet ? 14 : 10,
-          width: shouldShowImportSnippet ? 260 : NODE_LABEL_WIDTH,
+          width: shouldShowImportSnippet ? 320 : NODE_LABEL_WIDTH,
           overflow: 'truncate' as const,
           lineHeight: shouldShowImportSnippet ? 18 : 16,
           align: 'center' as const,
@@ -776,6 +855,16 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
               fontFamily: 'monospace',
               fontSize: 11,
               lineHeight: 18,
+            },
+            file: {
+              color: '#e2e8f0',
+              backgroundColor: 'rgba(15, 23, 42, 0.92)',
+              borderRadius: 4,
+              padding: [4, 6, 0, 6],
+              fontFamily: 'monospace',
+              fontSize: 11,
+              fontWeight: 700,
+              lineHeight: 16,
             },
             name: {
               color: '#111827',
@@ -914,7 +1003,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
             width: 1.5,
           },
           labelLayout: {
-            hideOverlap: true,
+            hideOverlap: activePathImportSnippets.size === 0,
           },
           emphasis: {
             focus: 'adjacency',

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -78,6 +78,9 @@ const GRAPH_BOUNDARY_NODE_ID_PREFIX = '__chunk-group-graph-boundary__';
 const GRAPH_MIN_ZOOM = 0.2;
 const GRAPH_MAX_ZOOM = 4;
 const GRAPH_ZOOM_STEP = 0.25;
+const GRAPH_WHEEL_ZOOM_SENSITIVITY = 0.002;
+const WHEEL_DELTA_LINE_MODE = 1;
+const WHEEL_DELTA_PAGE_MODE = 2;
 
 const getBaseNodeColor = (node: SDK.ChunkGroupGraphNodeData) =>
   node.isInitial
@@ -105,6 +108,19 @@ const getSeverityTagColor = (severity: SDK.ChunkGroupGraphPathSeverity) => {
 };
 
 const formatPercent = (value: number) => `${(value * 100).toFixed(1)}%`;
+
+const clampGraphZoom = (zoom: number) =>
+  Math.max(GRAPH_MIN_ZOOM, Math.min(GRAPH_MAX_ZOOM, zoom));
+
+const normalizeWheelDelta = (event: WheelEvent, fallbackHeight: number) => {
+  if (event.deltaMode === WHEEL_DELTA_LINE_MODE) {
+    return event.deltaY * 16;
+  }
+  if (event.deltaMode === WHEEL_DELTA_PAGE_MODE) {
+    return event.deltaY * fallbackHeight;
+  }
+  return event.deltaY;
+};
 
 const buildForwardAdjacency = (edges: SDK.ChunkGroupGraphEdgeData[]) => {
   const map = new Map<string, string[]>();
@@ -621,7 +637,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   );
 
   const updateGraphZoom = (nextZoom: number) => {
-    setGraphZoom(Math.max(GRAPH_MIN_ZOOM, Math.min(GRAPH_MAX_ZOOM, nextZoom)));
+    setGraphZoom(clampGraphZoom(nextZoom));
   };
 
   useEffect(() => {
@@ -657,6 +673,37 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
       observer.disconnect();
     };
   }, []);
+
+  useEffect(() => {
+    const element = graphContainerRef.current;
+    if (!element) {
+      return;
+    }
+
+    const handleWheel = (event: WheelEvent) => {
+      if (!event.ctrlKey && !event.metaKey) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const normalizedDelta = normalizeWheelDelta(event, graphHeight);
+      const zoomRatio = Math.exp(
+        -normalizedDelta * GRAPH_WHEEL_ZOOM_SENSITIVITY,
+      );
+      setGraphZoom((currentZoom) => clampGraphZoom(currentZoom * zoomRatio));
+    };
+
+    element.addEventListener('wheel', handleWheel, {
+      capture: true,
+      passive: false,
+    });
+
+    return () => {
+      element.removeEventListener('wheel', handleWheel, { capture: true });
+    };
+  }, [graphHeight]);
 
   useEffect(() => {
     const resizeChart = () => {

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -54,11 +54,14 @@ const WARNING_COLOR = '#f59e0b';
 const DANGER_COLOR = '#ef4444';
 const MUTED_NODE = '#d1d5db';
 const MUTED_BORDER = '#9ca3af';
-const MIN_GRAPH_HEIGHT = 760;
-const LAYOUT_TOP_PADDING = 96;
-const LAYOUT_LEFT_PADDING = 140;
-const LAYOUT_ROW_GAP = 56;
-const LAYOUT_COLUMN_GAP = 380;
+const MIN_GRAPH_HEIGHT = 520;
+const MAX_GRAPH_HEIGHT = 620;
+const LAYOUT_TOP_PADDING = 64;
+const LAYOUT_LEFT_PADDING = 120;
+const LAYOUT_ROW_GAP = 32;
+const LAYOUT_COLUMN_GAP = 320;
+const LAYOUT_SUBCOLUMN_GAP = 250;
+const MAX_LAYOUT_ROWS_PER_LEVEL = 6;
 const NODE_LABEL_WIDTH = 180;
 
 const getBaseNodeColor = (node: SDK.ChunkGroupGraphNodeData) =>
@@ -76,9 +79,7 @@ const getPathColor = (severity: SDK.ChunkGroupGraphPathSeverity) => {
   return HIGHLIGHT_COLOR;
 };
 
-const getSeverityTagColor = (
-  severity: SDK.ChunkGroupGraphPathSeverity,
-) => {
+const getSeverityTagColor = (severity: SDK.ChunkGroupGraphPathSeverity) => {
   if (severity === 'danger') {
     return 'red';
   }
@@ -90,9 +91,7 @@ const getSeverityTagColor = (
 
 const formatPercent = (value: number) => `${(value * 100).toFixed(1)}%`;
 
-const buildForwardAdjacency = (
-  edges: SDK.ChunkGroupGraphEdgeData[],
-) => {
+const buildForwardAdjacency = (edges: SDK.ChunkGroupGraphEdgeData[]) => {
   const map = new Map<string, string[]>();
   for (const edge of edges) {
     if (!map.has(edge.from)) {
@@ -103,9 +102,7 @@ const buildForwardAdjacency = (
   return map;
 };
 
-const buildReverseAdjacency = (
-  edges: SDK.ChunkGroupGraphEdgeData[],
-) => {
+const buildReverseAdjacency = (edges: SDK.ChunkGroupGraphEdgeData[]) => {
   const map = new Map<string, string[]>();
   for (const edge of edges) {
     if (!map.has(edge.to)) {
@@ -128,14 +125,7 @@ const getNodeSymbolSize = (
 ) =>
   Math.max(
     38,
-    Math.min(
-      74,
-      38 +
-        36 *
-          Math.sqrt(
-            node.totalEmittedSize / maxEmittedSize,
-          ),
-    ),
+    Math.min(74, 38 + 36 * Math.sqrt(node.totalEmittedSize / maxEmittedSize)),
   );
 
 const getNodeLaneHeight = (
@@ -144,12 +134,21 @@ const getNodeLaneHeight = (
   outDegree: number,
 ) =>
   Math.max(
-    124,
-    getNodeSymbolSize(node, maxEmittedSize) + 74 + Math.min(24, outDegree * 6),
+    96,
+    getNodeSymbolSize(node, maxEmittedSize) + 50 + Math.min(18, outDegree * 4),
   );
 
 const truncateLabel = (value: string, maxLength = 26) =>
   value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
+
+const sortPathsByOpportunity = (
+  a: SDK.ChunkGroupGraphPathData,
+  b: SDK.ChunkGroupGraphPathData,
+) =>
+  b.unnecessarySize - a.unnecessarySize ||
+  b.ratio - a.ratio ||
+  b.totalEmittedSize - a.totalEmittedSize ||
+  a.label.localeCompare(b.label);
 
 const buildLayout = (
   nodes: SDK.ChunkGroupGraphNodeData[],
@@ -162,9 +161,7 @@ const buildLayout = (
     };
   }
 
-  const indegree = new Map<string, number>(
-    nodes.map((node) => [node.id, 0]),
-  );
+  const indegree = new Map<string, number>(nodes.map((node) => [node.id, 0]));
   for (const edge of edges) {
     indegree.set(edge.to, (indegree.get(edge.to) || 0) + 1);
   }
@@ -235,10 +232,16 @@ const buildLayout = (
   const orderMap = new Map<string, number>();
   const levelLayouts = new Map<
     number,
-    Array<{
-      laneHeight: number;
-      node: SDK.ChunkGroupGraphNodeData;
-    }>
+    {
+      height: number;
+      items: Array<{
+        laneHeight: number;
+        node: SDK.ChunkGroupGraphNodeData;
+      }>;
+      rowCount: number;
+      rowHeight: number;
+      width: number;
+    }
   >();
   let maxLevelHeight = 0;
 
@@ -280,14 +283,26 @@ const buildLayout = (
       ),
       node,
     }));
-    const levelHeight =
-      levelLayout.reduce((sum, item) => sum + item.laneHeight, 0) +
-      Math.max(0, levelLayout.length - 1) * LAYOUT_ROW_GAP;
+    const columnCount = Math.max(
+      1,
+      Math.ceil(levelLayout.length / MAX_LAYOUT_ROWS_PER_LEVEL),
+    );
+    const rowCount = Math.max(1, Math.ceil(levelLayout.length / columnCount));
+    const rowHeight =
+      Math.max(...levelLayout.map((item) => item.laneHeight)) + LAYOUT_ROW_GAP;
+    const levelHeight = rowCount * rowHeight - LAYOUT_ROW_GAP;
+    const levelWidth = Math.max(0, (columnCount - 1) * LAYOUT_SUBCOLUMN_GAP);
 
     levelLayout.forEach((item, index) => {
       orderMap.set(item.node.id, index);
     });
-    levelLayouts.set(level, levelLayout);
+    levelLayouts.set(level, {
+      height: levelHeight,
+      items: levelLayout,
+      rowCount,
+      rowHeight,
+      width: levelWidth,
+    });
     maxLevelHeight = Math.max(maxLevelHeight, levelHeight);
   }
 
@@ -303,22 +318,24 @@ const buildLayout = (
     }
   >();
 
-  for (const [level, levelNodes] of [...levelLayouts.entries()].sort(
+  let currentX = LAYOUT_LEFT_PADDING;
+  for (const [, levelLayout] of [...levelLayouts.entries()].sort(
     (a, b) => a[0] - b[0],
   )) {
-    const levelHeight =
-      levelNodes.reduce((sum, item) => sum + item.laneHeight, 0) +
-      Math.max(0, levelNodes.length - 1) * LAYOUT_ROW_GAP;
-    let currentY =
-      LAYOUT_TOP_PADDING + (contentHeight - levelHeight) / 2;
+    const currentY = LAYOUT_TOP_PADDING;
 
-    levelNodes.forEach((item) => {
+    levelLayout.items.forEach((item, index) => {
+      const column = Math.floor(index / levelLayout.rowCount);
+      const row = index % levelLayout.rowCount;
       positions.set(item.node.id, {
-        x: LAYOUT_LEFT_PADDING + level * LAYOUT_COLUMN_GAP,
-        y: currentY + item.laneHeight / 2,
+        x: currentX + column * LAYOUT_SUBCOLUMN_GAP,
+        y: currentY + row * levelLayout.rowHeight + levelLayout.rowHeight / 2,
       });
-      currentY += item.laneHeight + LAYOUT_ROW_GAP;
     });
+    currentX += Math.max(
+      LAYOUT_COLUMN_GAP,
+      levelLayout.width + LAYOUT_COLUMN_GAP,
+    );
   }
 
   return {
@@ -415,7 +432,10 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   const nodeMap = useMemo(() => buildNodeMap(nodes), [nodes]);
   const edgeMap = useMemo(() => buildEdgeMap(edges), [edges]);
   const layout = useMemo(() => buildLayout(nodes, edges), [nodes, edges]);
-  const graphHeight = Math.max(MIN_GRAPH_HEIGHT, layout.height);
+  const graphHeight = Math.min(
+    MAX_GRAPH_HEIGHT,
+    Math.max(MIN_GRAPH_HEIGHT, layout.height),
+  );
 
   const matchedNodeIds = useMemo(() => {
     if (!searchQuery.trim()) {
@@ -432,14 +452,15 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
 
   const selectedNode = selectedNodeId ? nodeMap.get(selectedNodeId) : undefined;
   const selectedEdge = selectedEdgeId ? edgeMap.get(selectedEdgeId) : undefined;
-  const selectedNodePaths = selectedNode?.paths ?? [];
+  const selectedNodePaths = useMemo(
+    () => [...(selectedNode?.paths ?? [])].sort(sortPathsByOpportunity),
+    [selectedNode?.paths],
+  );
   const priorityNodes = useMemo(
     () =>
       (report?.priorityNodeIds ?? [])
         .map((nodeId) => nodeMap.get(nodeId))
-        .filter(
-          (node): node is SDK.ChunkGroupGraphNodeData => Boolean(node),
-        )
+        .filter((node): node is SDK.ChunkGroupGraphNodeData => Boolean(node))
         .filter((node) => matchedNodeIds.has(node.id)),
     [matchedNodeIds, nodeMap, report?.priorityNodeIds],
   );
@@ -462,7 +483,9 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
     };
   }, [graphHeight, nodes.length, edges.length]);
 
-  const hoveredPath = selectedNodePaths.find((path) => path.id === hoveredPathId);
+  const hoveredPath = selectedNodePaths.find(
+    (path) => path.id === hoveredPathId,
+  );
 
   const highlightNodeIds = useMemo(() => {
     if (hoveredPath) {
@@ -499,8 +522,11 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   const option = useMemo<ChunkGroupGraphOption>(() => {
     const hasSelection =
       Boolean(selectedNode) || Boolean(selectedEdge) || Boolean(hoveredPath);
-    const hoverColor = hoveredPath ? getPathColor(hoveredPath.severity) : HIGHLIGHT_COLOR;
-    const useForceLayout = nodes.length > 12;
+    const hoverColor = hoveredPath
+      ? getPathColor(hoveredPath.severity)
+      : HIGHLIGHT_COLOR;
+    const hasSearch = Boolean(searchQuery.trim());
+    const isLargeGraph = nodes.length > 80;
     const maxEmittedSize = Math.max(
       1,
       ...nodes.map((item) => item.totalEmittedSize),
@@ -511,14 +537,22 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
       const baseColor = getBaseNodeColor(node);
       const isMatched = matchedNodeIds.has(node.id);
       const isOnHighlight = highlightNodeIds.has(node.id);
-      const symbolSize = getNodeSymbolSize(node, maxEmittedSize);
+      const symbolSize =
+        getNodeSymbolSize(node, maxEmittedSize) * (isLargeGraph ? 0.78 : 1);
 
       let opacity = 1;
       if (hasSelection) {
         opacity = isOnHighlight ? 1 : 0.16;
-      } else if (searchQuery.trim()) {
+      } else if (hasSearch) {
         opacity = isMatched ? 1 : 0.16;
       }
+      const shouldShowLabel =
+        opacity > 0.3 &&
+        (!isLargeGraph ||
+          node.isInitial ||
+          node.removableJSSize > 0 ||
+          isOnHighlight ||
+          (hasSearch && isMatched));
 
       const removableRatio =
         node.groupTotalJSSize > 0
@@ -541,7 +575,8 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
         value: node.totalEmittedSize,
         symbolSize,
         itemStyle: {
-          color: hasSelection && !isOnHighlight ? MUTED_NODE : baseColor.background,
+          color:
+            hasSelection && !isOnHighlight ? MUTED_NODE : baseColor.background,
           borderColor:
             hasSelection && !isOnHighlight ? MUTED_BORDER : borderColor,
           borderWidth: selectedNode?.id === node.id ? 4 : 2,
@@ -550,7 +585,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
           shadowColor: 'rgba(17,24,39,0.25)',
         },
         label: {
-          show: opacity > 0.3,
+          show: shouldShowLabel,
           position: 'bottom' as const,
           distance: 10,
           width: NODE_LABEL_WIDTH,
@@ -572,7 +607,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
       let opacity = 0.6;
       if (hasSelection) {
         opacity = highlight ? 0.95 : 0.08;
-      } else if (searchQuery.trim()) {
+      } else if (hasSearch) {
         opacity = matchesSearch ? 0.65 : 0.06;
       }
 
@@ -588,7 +623,10 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
           curveness: 0.12,
         },
         label: {
-          show: edge.imports.length > 1 && opacity > 0.3,
+          show:
+            edge.imports.length > 1 &&
+            opacity > 0.3 &&
+            (!isLargeGraph || highlight),
           formatter: `${edge.imports.length} imports`,
           color: highlight ? hoverColor : '#64748b',
           fontSize: 10,
@@ -633,24 +671,27 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
       series: [
         {
           type: 'graph',
-          layout: useForceLayout ? 'force' : 'none',
+          layout: 'none',
           roam: true,
-          draggable: true,
+          draggable: false,
+          zoom: isLargeGraph ? 1.15 : 1,
+          center: isLargeGraph
+            ? [LAYOUT_LEFT_PADDING + 520, LAYOUT_TOP_PADDING + 1000]
+            : undefined,
+          scaleLimit: {
+            min: 0.25,
+            max: 4,
+          },
+          edgeSymbol: ['none', 'arrow'],
+          edgeSymbolSize: [0, 8],
           data: graphNodes,
           links: graphEdges,
-          force: useForceLayout
-            ? {
-                initLayout: 'circular',
-                repulsion: Math.min(3200, Math.max(1200, nodes.length * 110)),
-                edgeLength: [180, 320],
-                gravity: 0.06,
-                friction: 0.5,
-                layoutAnimation: false,
-              }
-            : undefined,
           lineStyle: {
             opacity: 0.65,
             width: 1.5,
+          },
+          labelLayout: {
+            hideOverlap: true,
           },
           emphasis: {
             focus: 'adjacency',
@@ -691,6 +732,183 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   const dangerPathCount = overview?.dangerPathCount ?? 0;
   const warningPathCount = overview?.warningPathCount ?? 0;
   const selectedNodeImports = selectedNode?.incomingImports ?? [];
+  const selectedNodePathList = selectedNode ? (
+    <div>
+      <Typography.Title level={5}>
+        Load Paths From Entry ({selectedNode.pathCount})
+      </Typography.Title>
+      {selectedNode.pathsTruncated ? (
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+          Showing the first {report?.pathLimit ?? selectedNode.pathCount} paths
+          for this group. The full path set is larger.
+        </Typography.Text>
+      ) : null}
+      <Space direction="vertical" style={{ width: '100%' }}>
+        {selectedNodePaths.length ? (
+          selectedNodePaths.map((path) => {
+            const color = getPathColor(path.severity);
+            const backgroundColor =
+              path.severity === 'danger'
+                ? '#fff1f0'
+                : path.severity === 'warning'
+                  ? '#fffbe6'
+                  : '#fafafa';
+            const isExpanded = expandedPathIds.has(path.id);
+
+            const header = (
+              <div
+                onMouseEnter={() => setHoveredPathId(path.id)}
+                onMouseLeave={() => setHoveredPathId(null)}
+                onClick={() => {
+                  setExpandedPathIds((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(path.id)) {
+                      next.delete(path.id);
+                    } else {
+                      next.add(path.id);
+                    }
+                    return next;
+                  });
+                }}
+                style={{
+                  border: `1px solid ${color}`,
+                  borderRadius: 8,
+                  padding: 12,
+                  background: backgroundColor,
+                  cursor: 'pointer',
+                }}
+              >
+                <Space
+                  direction="vertical"
+                  style={{ width: '100%' }}
+                  size="small"
+                >
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      gap: 12,
+                      alignItems: 'flex-start',
+                    }}
+                  >
+                    <Typography.Text strong style={{ flex: 1 }}>
+                      {path.label}
+                    </Typography.Text>
+                    <Typography.Text
+                      type="secondary"
+                      style={{ fontSize: 12, whiteSpace: 'nowrap' }}
+                    >
+                      {isExpanded ? 'Collapse' : 'Expand'}
+                    </Typography.Text>
+                  </div>
+                  <Space wrap>
+                    <Tag color="default">
+                      {formatSize(path.totalEmittedSize)} loaded
+                    </Tag>
+                    <Tag color="default">
+                      {path.chunkIds.length} unique chunks
+                    </Tag>
+                    <Tag color="default">
+                      {formatSize(path.totalJSSize)} JS total
+                    </Tag>
+                    {path.unnecessarySize > 0 ? (
+                      <Tag color={path.severity === 'danger' ? 'red' : 'gold'}>
+                        {formatSize(path.unnecessarySize)} unnecessary
+                      </Tag>
+                    ) : null}
+                    {path.unnecessarySize > 0 ? (
+                      <Tag color={path.severity === 'danger' ? 'red' : 'gold'}>
+                        {formatPercent(path.ratio)}
+                      </Tag>
+                    ) : null}
+                    {path.unnecessaryModuleCount >
+                    path.topUnnecessaryModules.length ? (
+                      <Tag color="default">
+                        top {path.topUnnecessaryModules.length} /{' '}
+                        {path.unnecessaryModuleCount} modules
+                      </Tag>
+                    ) : null}
+                  </Space>
+                  {isExpanded ? (
+                    <>
+                      <div>
+                        <Typography.Text
+                          type="secondary"
+                          style={{ fontSize: 12 }}
+                        >
+                          Chunks
+                        </Typography.Text>
+                        {path.chunks.map((chunk) => (
+                          <div
+                            key={chunk.id}
+                            style={{
+                              display: 'flex',
+                              justifyContent: 'space-between',
+                              gap: 12,
+                            }}
+                          >
+                            <Typography.Text style={{ fontSize: 12 }}>
+                              {chunk.name}
+                            </Typography.Text>
+                            <Typography.Text code style={{ fontSize: 12 }}>
+                              {formatSize(chunk.emittedSize)}
+                            </Typography.Text>
+                          </div>
+                        ))}
+                      </div>
+                      {path.topUnnecessaryModules.length ? (
+                        <div>
+                          <Typography.Text
+                            type="secondary"
+                            style={{ fontSize: 12 }}
+                          >
+                            Top unnecessary modules
+                          </Typography.Text>
+                          {path.topUnnecessaryModules
+                            .slice(0, 5)
+                            .map((module) => (
+                              <div
+                                key={module.id}
+                                style={{
+                                  display: 'flex',
+                                  justifyContent: 'space-between',
+                                  gap: 12,
+                                }}
+                              >
+                                <Typography.Text style={{ fontSize: 12 }}>
+                                  {module.resource ?? module.name}
+                                </Typography.Text>
+                                <Typography.Text code style={{ fontSize: 12 }}>
+                                  {formatSize(module.size)}
+                                </Typography.Text>
+                              </div>
+                            ))}
+                        </div>
+                      ) : null}
+                    </>
+                  ) : null}
+                </Space>
+              </div>
+            );
+
+            if (path.severity !== 'danger') {
+              return <React.Fragment key={path.id}>{header}</React.Fragment>;
+            }
+
+            return (
+              <Tooltip title="非必要依赖过多" key={path.id}>
+                {header}
+              </Tooltip>
+            );
+          })
+        ) : (
+          <Typography.Text type="secondary">
+            No load path from entry was found for the selected chunk group.
+          </Typography.Text>
+        )}
+      </Space>
+    </div>
+  ) : null;
 
   return (
     <Space direction="vertical" style={{ width: '100%' }} size="middle">
@@ -773,7 +991,13 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
                 {!selectedNode && !selectedEdge ? <DetailPlaceholder /> : null}
 
                 {selectedNode ? (
-                  <Space direction="vertical" style={{ width: '100%' }} size="middle">
+                  <Space
+                    direction="vertical"
+                    style={{ width: '100%' }}
+                    size="middle"
+                  >
+                    {selectedNodePathList}
+
                     <div>
                       <Typography.Title level={5} style={{ marginBottom: 8 }}>
                         {selectedNode.name}
@@ -782,30 +1006,49 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
                         <Tag color={selectedNode.isInitial ? 'blue' : 'green'}>
                           {selectedNode.isInitial ? 'Entry' : 'Async'}
                         </Tag>
-                        <Tag>{formatSize(selectedNode.totalEmittedSize)} emitted</Tag>
-                        <Tag>{formatSize(selectedNode.groupTotalJSSize)} JS total</Tag>
-                        <Tag color={selectedNode.removableJSSize ? 'gold' : 'default'}>
-                          {formatSize(selectedNode.removableJSSize)} removable on path
+                        <Tag>
+                          {formatSize(selectedNode.totalEmittedSize)} emitted
                         </Tag>
-                        <Tag color={selectedNode.localRemovableJSSize ? 'default' : 'default'}>
-                          {formatSize(selectedNode.localRemovableJSSize)} in group
+                        <Tag>
+                          {formatSize(selectedNode.groupTotalJSSize)} JS total
+                        </Tag>
+                        <Tag
+                          color={
+                            selectedNode.removableJSSize ? 'gold' : 'default'
+                          }
+                        >
+                          {formatSize(selectedNode.removableJSSize)} removable
+                          on path
+                        </Tag>
+                        <Tag
+                          color={
+                            selectedNode.localRemovableJSSize
+                              ? 'default'
+                              : 'default'
+                          }
+                        >
+                          {formatSize(selectedNode.localRemovableJSSize)} in
+                          group
                         </Tag>
                         {selectedNode.inheritedRemovableJSSize > 0 ? (
                           <Tag color="cyan">
-                            {formatSize(selectedNode.inheritedRemovableJSSize)} already loaded before
+                            {formatSize(selectedNode.inheritedRemovableJSSize)}{' '}
+                            already loaded before
                           </Tag>
                         ) : null}
                       </Space>
                       <div style={{ marginTop: 8 }}>
                         <Typography.Text type="secondary">
-                          Reachable modules: {selectedNode.reachableModuleCount} /{' '}
-                          {selectedNode.actualModuleCount}
+                          Reachable modules: {selectedNode.reachableModuleCount}{' '}
+                          / {selectedNode.actualModuleCount}
                         </Typography.Text>
                       </div>
                     </div>
 
                     <div>
-                      <Typography.Title level={5}>Chunks In This Group</Typography.Title>
+                      <Typography.Title level={5}>
+                        Chunks In This Group
+                      </Typography.Title>
                       <Space direction="vertical" style={{ width: '100%' }}>
                         {selectedNode.chunks.length ? (
                           selectedNode.chunks.map((chunk) => (
@@ -817,11 +1060,17 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
                                 padding: 12,
                               }}
                             >
-                              <Typography.Text strong>{chunk.name}</Typography.Text>
+                              <Typography.Text strong>
+                                {chunk.name}
+                              </Typography.Text>
                               <div style={{ marginTop: 6 }}>
                                 <Space wrap>
-                                  <Tag>{formatSize(chunk.emittedSize)} emitted</Tag>
-                                  <Tag>{formatSize(chunk.totalJSSize)} JS total</Tag>
+                                  <Tag>
+                                    {formatSize(chunk.emittedSize)} emitted
+                                  </Tag>
+                                  <Tag>
+                                    {formatSize(chunk.totalJSSize)} JS total
+                                  </Tag>
                                   <Tag>{chunk.moduleCount} modules</Tag>
                                 </Space>
                               </div>
@@ -829,7 +1078,9 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
                                 <div style={{ marginTop: 8 }}>
                                   {chunk.files.map((file) => (
                                     <div key={file}>
-                                      <Typography.Text code>{file}</Typography.Text>
+                                      <Typography.Text code>
+                                        {file}
+                                      </Typography.Text>
                                     </div>
                                   ))}
                                 </div>
@@ -859,7 +1110,8 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
                           ))
                         ) : (
                           <Typography.Text type="secondary">
-                            No inbound async import() origins were captured for this group.
+                            No inbound async import() origins were captured for
+                            this group.
                           </Typography.Text>
                         )}
                       </Space>
@@ -867,40 +1119,50 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
 
                     <div>
                       <Typography.Title level={5}>
-                        Incremental Removable JS Modules ({selectedNode.removableJSModuleCount})
+                        Incremental Removable JS Modules (
+                        {selectedNode.removableJSModuleCount})
                       </Typography.Title>
                       {selectedNode.inheritedRemovableJSModuleCount > 0 ? (
-                        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                          {formatSize(selectedNode.inheritedRemovableJSSize)} of this group's local removable
-                          JS has already been loaded on every entry path before reaching this group.
+                        <Typography.Text
+                          type="secondary"
+                          style={{ fontSize: 12 }}
+                        >
+                          {formatSize(selectedNode.inheritedRemovableJSSize)} of
+                          this group's local removable JS has already been
+                          loaded on every entry path before reaching this group.
                         </Typography.Text>
                       ) : null}
                       {selectedNode.removableJSModules.length > 50 ? (
-                        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                        <Typography.Text
+                          type="secondary"
+                          style={{ fontSize: 12 }}
+                        >
                           Showing top 50 modules by size.
                         </Typography.Text>
                       ) : null}
                       <Space direction="vertical" style={{ width: '100%' }}>
                         {selectedNode.removableJSModules.length ? (
-                          selectedNode.removableJSModules.slice(0, 50).map((module) => (
-                            <div
-                              key={module.id}
-                              style={{
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                                gap: 12,
-                              }}
-                            >
-                              <div style={{ minWidth: 0 }}>
-                                <Typography.Text style={{ display: 'block' }}>
-                                  {module.resource ?? module.name}
+                          selectedNode.removableJSModules
+                            .slice(0, 50)
+                            .map((module) => (
+                              <div
+                                key={module.id}
+                                style={{
+                                  display: 'flex',
+                                  justifyContent: 'space-between',
+                                  gap: 12,
+                                }}
+                              >
+                                <div style={{ minWidth: 0 }}>
+                                  <Typography.Text style={{ display: 'block' }}>
+                                    {module.resource ?? module.name}
+                                  </Typography.Text>
+                                </div>
+                                <Typography.Text code>
+                                  {formatSize(module.size)}
                                 </Typography.Text>
                               </div>
-                              <Typography.Text code>
-                                {formatSize(module.size)}
-                              </Typography.Text>
-                            </div>
-                          ))
+                            ))
                         ) : (
                           <Typography.Text type="secondary">
                             {selectedNode.localRemovableJSModuleCount > 0
@@ -914,7 +1176,8 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
                     {selectedNode.inheritedRemovableJSModules.length ? (
                       <div>
                         <Typography.Title level={5}>
-                          Already Loaded Before This Group ({selectedNode.inheritedRemovableJSModuleCount})
+                          Already Loaded Before This Group (
+                          {selectedNode.inheritedRemovableJSModuleCount})
                         </Typography.Title>
                         <Space direction="vertical" style={{ width: '100%' }}>
                           {selectedNode.inheritedRemovableJSModules
@@ -941,186 +1204,15 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
                         </Space>
                       </div>
                     ) : null}
-
-                    <div>
-                      <Typography.Title level={5}>
-                        Load Paths From Entry ({selectedNode.pathCount})
-                      </Typography.Title>
-                      {selectedNode.pathsTruncated ? (
-                        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                          Showing the first {report?.pathLimit ?? selectedNode.pathCount} paths for this
-                          group. The full path set is larger.
-                        </Typography.Text>
-                      ) : null}
-                      <Space direction="vertical" style={{ width: '100%' }}>
-                        {selectedNodePaths.length ? (
-                          selectedNodePaths.map((path) => {
-                            const color = getPathColor(path.severity);
-                            const backgroundColor =
-                              path.severity === 'danger'
-                                ? '#fff1f0'
-                                : path.severity === 'warning'
-                                  ? '#fffbe6'
-                                  : '#fafafa';
-                            const isExpanded = expandedPathIds.has(path.id);
-
-                            const header = (
-                              <div
-                                onMouseEnter={() => setHoveredPathId(path.id)}
-                                onMouseLeave={() => setHoveredPathId(null)}
-                                onClick={() => {
-                                  setExpandedPathIds((prev) => {
-                                    const next = new Set(prev);
-                                    if (next.has(path.id)) {
-                                      next.delete(path.id);
-                                    } else {
-                                      next.add(path.id);
-                                    }
-                                    return next;
-                                  });
-                                }}
-                                style={{
-                                  border: `1px solid ${color}`,
-                                  borderRadius: 8,
-                                  padding: 12,
-                                  background: backgroundColor,
-                                  cursor: 'pointer',
-                                }}
-                              >
-                                <Space
-                                  direction="vertical"
-                                  style={{ width: '100%' }}
-                                  size="small"
-                                >
-                                  <div
-                                    style={{
-                                      display: 'flex',
-                                      justifyContent: 'space-between',
-                                      gap: 12,
-                                      alignItems: 'flex-start',
-                                    }}
-                                  >
-                                    <Typography.Text strong style={{ flex: 1 }}>
-                                      {path.label}
-                                    </Typography.Text>
-                                    <Typography.Text
-                                      type="secondary"
-                                      style={{ fontSize: 12, whiteSpace: 'nowrap' }}
-                                    >
-                                      {isExpanded ? 'Collapse' : 'Expand'}
-                                    </Typography.Text>
-                                  </div>
-                                  <Space wrap>
-                                    <Tag color="default">
-                                      {formatSize(path.totalEmittedSize)} loaded
-                                    </Tag>
-                                    <Tag color="default">
-                                      {path.chunkIds.length} unique chunks
-                                    </Tag>
-                                    <Tag color="default">
-                                      {formatSize(path.totalJSSize)} JS total
-                                    </Tag>
-                                    {path.unnecessarySize > 0 ? (
-                                      <Tag color={path.severity === 'danger' ? 'red' : 'gold'}>
-                                        {formatSize(path.unnecessarySize)} unnecessary
-                                      </Tag>
-                                    ) : null}
-                                    {path.unnecessarySize > 0 ? (
-                                      <Tag color={path.severity === 'danger' ? 'red' : 'gold'}>
-                                        {formatPercent(path.ratio)}
-                                      </Tag>
-                                    ) : null}
-                                    {path.unnecessaryModuleCount > path.topUnnecessaryModules.length ? (
-                                      <Tag color="default">
-                                        top {path.topUnnecessaryModules.length} /{' '}
-                                        {path.unnecessaryModuleCount} modules
-                                      </Tag>
-                                    ) : null}
-                                  </Space>
-                                  {isExpanded ? (
-                                    <>
-                                      <div>
-                                        <Typography.Text
-                                          type="secondary"
-                                          style={{ fontSize: 12 }}
-                                        >
-                                          Chunks
-                                        </Typography.Text>
-                                        {path.chunks.map((chunk) => (
-                                          <div
-                                            key={chunk.id}
-                                            style={{
-                                              display: 'flex',
-                                              justifyContent: 'space-between',
-                                              gap: 12,
-                                            }}
-                                          >
-                                            <Typography.Text style={{ fontSize: 12 }}>
-                                              {chunk.name}
-                                            </Typography.Text>
-                                            <Typography.Text code style={{ fontSize: 12 }}>
-                                              {formatSize(chunk.emittedSize)}
-                                            </Typography.Text>
-                                          </div>
-                                        ))}
-                                      </div>
-                                      {path.topUnnecessaryModules.length ? (
-                                        <div>
-                                          <Typography.Text
-                                            type="secondary"
-                                            style={{ fontSize: 12 }}
-                                          >
-                                            Top unnecessary modules
-                                          </Typography.Text>
-                                          {path.topUnnecessaryModules
-                                            .slice(0, 5)
-                                            .map((module) => (
-                                            <div
-                                              key={module.id}
-                                              style={{
-                                                display: 'flex',
-                                                justifyContent: 'space-between',
-                                                gap: 12,
-                                              }}
-                                            >
-                                              <Typography.Text style={{ fontSize: 12 }}>
-                                                {module.resource ?? module.name}
-                                              </Typography.Text>
-                                              <Typography.Text code style={{ fontSize: 12 }}>
-                                                {formatSize(module.size)}
-                                              </Typography.Text>
-                                            </div>
-                                          ))}
-                                        </div>
-                                      ) : null}
-                                    </>
-                                  ) : null}
-                                </Space>
-                              </div>
-                            );
-
-                            if (path.severity !== 'danger') {
-                              return <React.Fragment key={path.id}>{header}</React.Fragment>;
-                            }
-
-                            return (
-                              <Tooltip title="非必要依赖过多" key={path.id}>
-                                {header}
-                              </Tooltip>
-                            );
-                          })
-                        ) : (
-                          <Typography.Text type="secondary">
-                            No load path from entry was found for the selected chunk group.
-                          </Typography.Text>
-                        )}
-                      </Space>
-                    </div>
                   </Space>
                 ) : null}
 
                 {selectedEdge ? (
-                  <Space direction="vertical" style={{ width: '100%' }} size="middle">
+                  <Space
+                    direction="vertical"
+                    style={{ width: '100%' }}
+                    size="middle"
+                  >
                     <div>
                       <Typography.Title level={5} style={{ marginBottom: 8 }}>
                         {selectedEdge.fromName + ' → ' + selectedEdge.toName}
@@ -1130,7 +1222,10 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
 
                     <Space direction="vertical" style={{ width: '100%' }}>
                       {selectedEdge.imports.map((item, index) => (
-                        <ImportCard key={`${selectedEdge.id}_${index}`} item={item} />
+                        <ImportCard
+                          key={`${selectedEdge.id}_${index}`}
+                          item={item}
+                        />
                       ))}
                     </Space>
                   </Space>
@@ -1199,7 +1294,10 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
                           }}
                         >
                           <div style={{ minWidth: 0, flex: 1 }}>
-                            <Typography.Text strong style={{ display: 'block' }}>
+                            <Typography.Text
+                              strong
+                              style={{ display: 'block' }}
+                            >
                               {node.name}
                             </Typography.Text>
                             {topPath ? (
@@ -1227,12 +1325,18 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
 
                         <Space wrap>
                           <Tag>{formatSize(node.totalEmittedSize)} emitted</Tag>
-                          <Tag>{formatSize(node.groupTotalJSSize)} JS total</Tag>
-                          <Tag color={node.removableJSSize ? 'gold' : 'default'}>
-                            {formatSize(node.removableJSSize)} incremental removable
+                          <Tag>
+                            {formatSize(node.groupTotalJSSize)} JS total
+                          </Tag>
+                          <Tag
+                            color={node.removableJSSize ? 'gold' : 'default'}
+                          >
+                            {formatSize(node.removableJSSize)} incremental
+                            removable
                           </Tag>
                           <Tag color={getSeverityTagColor(severity)}>
-                            {formatSize(node.maxPathUnnecessarySize)} worst path unnecessary
+                            {formatSize(node.maxPathUnnecessarySize)} worst path
+                            unnecessary
                           </Tag>
                           <Tag>{node.pathCount} path(s)</Tag>
                           <Tag>{node.incomingImports.length} import(s)</Tag>
@@ -1247,15 +1351,25 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
                               flexWrap: 'wrap',
                             }}
                           >
-                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                            <Typography.Text
+                              type="secondary"
+                              style={{ fontSize: 12 }}
+                            >
                               Worst path ratio {formatPercent(topPath.ratio)}
                             </Typography.Text>
                             {topPath.topUnnecessaryModules[0] ? (
-                              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                              <Typography.Text
+                                type="secondary"
+                                style={{ fontSize: 12 }}
+                              >
                                 Top module:{' '}
                                 {topPath.topUnnecessaryModules[0].resource ??
                                   topPath.topUnnecessaryModules[0].name}{' '}
-                                ({formatSize(topPath.topUnnecessaryModules[0].size)})
+                                (
+                                {formatSize(
+                                  topPath.topUnnecessaryModules[0].size,
+                                )}
+                                )
                               </Typography.Text>
                             ) : null}
                           </div>

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -73,6 +73,12 @@ const LAYOUT_COLUMN_TOP_VARIANCE = 140;
 const LAYOUT_NODE_X_JITTER = 170;
 const LAYOUT_NODE_Y_JITTER = 32;
 const MAX_LAYOUT_ROWS_PER_LEVEL = 12;
+const DRAG_ADAPT_PRIMARY_STRENGTH = 0.34;
+const DRAG_ADAPT_SECONDARY_STRENGTH = 0.14;
+const DRAG_ADAPT_MAX_FOLLOW_DISTANCE = 320;
+const DRAG_REPEL_RADIUS = 230;
+const DRAG_REPEL_STRENGTH = 0.42;
+const DRAG_MAX_REPEL_DISTANCE = 96;
 const LARGE_GRAPH_NODE_SCALE = 0.52;
 const NODE_LABEL_WIDTH = 180;
 const MIN_NODE_SYMBOL_SIZE = 30;
@@ -179,6 +185,19 @@ const stableSignedRatio = (value: string) => stableRatio(value) * 2 - 1;
 
 const clampNumber = (value: number, min: number, max: number) =>
   Math.max(min, Math.min(max, value));
+
+const limitVector = (position: GraphPosition, maxDistance: number) => {
+  const distance = Math.hypot(position.x, position.y);
+  if (!distance || distance <= maxDistance) {
+    return position;
+  }
+
+  const scale = maxDistance / distance;
+  return {
+    x: position.x * scale,
+    y: position.y * scale,
+  };
+};
 
 const truncateLabel = (value: string, maxLength = 26) =>
   value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
@@ -804,21 +823,127 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
       return;
     }
 
+    const nextDraggedPosition = {
+      x: layoutPosition[0],
+      y: layoutPosition[1],
+    };
+
     setDraggedNodePositions((currentPositions) => {
-      const current = currentPositions.get(nodeId);
+      const basePositions = new Map(layout.positions);
+      currentPositions.forEach((position, currentNodeId) => {
+        basePositions.set(currentNodeId, position);
+      });
+
+      const previousPosition = basePositions.get(nodeId);
       if (
-        current &&
-        Math.abs(current.x - layoutPosition[0]) < 0.5 &&
-        Math.abs(current.y - layoutPosition[1]) < 0.5
+        previousPosition &&
+        Math.abs(previousPosition.x - nextDraggedPosition.x) < 0.5 &&
+        Math.abs(previousPosition.y - nextDraggedPosition.y) < 0.5
       ) {
         return currentPositions;
       }
 
-      const nextPositions = new Map(currentPositions);
-      nextPositions.set(nodeId, {
-        x: layoutPosition[0],
-        y: layoutPosition[1],
+      const delta = previousPosition
+        ? {
+            x: nextDraggedPosition.x - previousPosition.x,
+            y: nextDraggedPosition.y - previousPosition.y,
+          }
+        : { x: 0, y: 0 };
+      const followDelta = limitVector(delta, DRAG_ADAPT_MAX_FOLLOW_DISTANCE);
+      const adjacency = buildForwardAdjacency(edges);
+      const reverseAdjacency = buildReverseAdjacency(edges);
+      const firstHopNodeIds = new Set([
+        ...(adjacency.get(nodeId) ?? []),
+        ...(reverseAdjacency.get(nodeId) ?? []),
+      ]);
+      const adaptiveStrengthByNodeId = new Map<string, number>();
+
+      firstHopNodeIds.forEach((connectedNodeId) => {
+        adaptiveStrengthByNodeId.set(
+          connectedNodeId,
+          DRAG_ADAPT_PRIMARY_STRENGTH,
+        );
+        [
+          ...(adjacency.get(connectedNodeId) ?? []),
+          ...(reverseAdjacency.get(connectedNodeId) ?? []),
+        ].forEach((secondaryNodeId) => {
+          if (
+            secondaryNodeId !== nodeId &&
+            !firstHopNodeIds.has(secondaryNodeId)
+          ) {
+            adaptiveStrengthByNodeId.set(
+              secondaryNodeId,
+              Math.max(
+                adaptiveStrengthByNodeId.get(secondaryNodeId) ?? 0,
+                DRAG_ADAPT_SECONDARY_STRENGTH,
+              ),
+            );
+          }
+        });
       });
+
+      const nextPositions = new Map(currentPositions);
+      nextPositions.set(nodeId, nextDraggedPosition);
+
+      adaptiveStrengthByNodeId.forEach((strength, adaptiveNodeId) => {
+        const currentPosition =
+          nextPositions.get(adaptiveNodeId) ??
+          basePositions.get(adaptiveNodeId);
+        if (!currentPosition) {
+          return;
+        }
+
+        nextPositions.set(adaptiveNodeId, {
+          x: currentPosition.x + followDelta.x * strength,
+          y: currentPosition.y + followDelta.y * strength,
+        });
+      });
+
+      nodes.forEach((node) => {
+        if (node.id === nodeId) {
+          return;
+        }
+
+        const currentPosition =
+          nextPositions.get(node.id) ?? basePositions.get(node.id);
+        if (!currentPosition) {
+          return;
+        }
+
+        const vector = {
+          x: currentPosition.x - nextDraggedPosition.x,
+          y: currentPosition.y - nextDraggedPosition.y,
+        };
+        const distance = Math.hypot(vector.x, vector.y);
+        if (distance >= DRAG_REPEL_RADIUS) {
+          return;
+        }
+
+        const fallbackDirection = stableSignedRatio(`${node.id}:drag-repel`);
+        const unitVector =
+          distance > 0.1
+            ? {
+                x: vector.x / distance,
+                y: vector.y / distance,
+              }
+            : {
+                x: fallbackDirection,
+                y: stableSignedRatio(`${node.id}:drag-repel-y`),
+              };
+        const connectedStrength = adaptiveStrengthByNodeId.get(node.id) ?? 0;
+        const repelDistance = Math.min(
+          DRAG_MAX_REPEL_DISTANCE,
+          (DRAG_REPEL_RADIUS - distance) *
+            DRAG_REPEL_STRENGTH *
+            (1 - connectedStrength * 0.6),
+        );
+
+        nextPositions.set(node.id, {
+          x: currentPosition.x + unitVector.x * repelDistance,
+          y: currentPosition.y + unitVector.y * repelDistance,
+        });
+      });
+
       return nextPositions;
     });
   };
@@ -1683,6 +1808,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
                     }}
                     onEvents={{
                       graphRoam: syncGraphZoomFromChart,
+                      drag: storeDraggedNodePosition,
                       mouseup: storeDraggedNodePosition,
                       dragend: storeDraggedNodePosition,
                       click: (params: any) => {

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -46,14 +46,16 @@ type ChunkGroupGraphPanelProps = {
 };
 
 const ENTRY_COLOR = '#1f6feb';
-const ENTRY_BORDER = '#58a6ff';
 const ASYNC_COLOR = '#238636';
-const ASYNC_BORDER = '#7ee787';
 const HIGHLIGHT_COLOR = '#f59e0b';
 const WARNING_COLOR = '#f59e0b';
 const DANGER_COLOR = '#ef4444';
 const MUTED_NODE = '#d1d5db';
 const MUTED_BORDER = '#9ca3af';
+const NODE_BORDER = '#94a3b8';
+const NODE_SELECTED_BORDER = '#334155';
+const EDGE_COLOR = '#94a3b8';
+const EDGE_HIGHLIGHT_COLOR = '#64748b';
 const MIN_GRAPH_HEIGHT = 520;
 const MAX_GRAPH_HEIGHT = 620;
 const LAYOUT_TOP_PADDING = 64;
@@ -70,8 +72,8 @@ const GRAPH_BOUNDARY_NODE_ID_PREFIX = '__chunk-group-graph-boundary__';
 
 const getBaseNodeColor = (node: SDK.ChunkGroupGraphNodeData) =>
   node.isInitial
-    ? { background: ENTRY_COLOR, border: ENTRY_BORDER }
-    : { background: ASYNC_COLOR, border: ASYNC_BORDER };
+    ? { background: ENTRY_COLOR, border: NODE_BORDER }
+    : { background: ASYNC_COLOR, border: NODE_BORDER };
 
 const getPathColor = (severity: SDK.ChunkGroupGraphPathSeverity) => {
   if (severity === 'danger') {
@@ -149,6 +151,55 @@ const getNodeLaneHeight = (
 
 const truncateLabel = (value: string, maxLength = 26) =>
   value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
+
+const normalizeGraphLabel = (value: string, maxLength: number) =>
+  truncateLabel(
+    value.replace(/[{}]/g, '').replace(/\s+/g, ' ').trim(),
+    maxLength,
+  );
+
+const getImportSnippetLabel = (item: SDK.ChunkGroupGraphImportData) => {
+  const snippetLine = item.snippet
+    ?.split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.includes('import('));
+
+  if (snippetLine) {
+    return normalizeGraphLabel(snippetLine, 64);
+  }
+
+  if (item.request) {
+    return normalizeGraphLabel(`import(${JSON.stringify(item.request)})`, 64);
+  }
+
+  return '';
+};
+
+const getEdgeImportSnippetLabel = (edge: SDK.ChunkGroupGraphEdgeData) => {
+  const snippets = edge.imports.map(getImportSnippetLabel).filter(Boolean);
+  if (!snippets.length) {
+    return '';
+  }
+
+  return edge.imports.length > 1
+    ? `${snippets[0]} +${edge.imports.length - 1}`
+    : snippets[0];
+};
+
+const getZRenderEventPoint = (event: any) => ({
+  x:
+    typeof event.offsetX === 'number'
+      ? event.offsetX
+      : typeof event.zrX === 'number'
+        ? event.zrX
+        : 0,
+  y:
+    typeof event.offsetY === 'number'
+      ? event.offsetY
+      : typeof event.zrY === 'number'
+        ? event.zrY
+        : 0,
+});
 
 const sortPathsByOpportunity = (
   a: SDK.ChunkGroupGraphPathData,
@@ -428,6 +479,11 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
 }) => {
   const chartRef = useRef<any>(null);
   const graphContainerRef = useRef<HTMLDivElement>(null);
+  const blankPointerRef = useRef<{
+    x: number;
+    y: number;
+    dragged: boolean;
+  } | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [graphWidth, setGraphWidth] = useState(0);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
@@ -527,6 +583,28 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   const hoveredPath = selectedNodePaths.find(
     (path) => path.id === hoveredPathId,
   );
+  const activeSnippetPath = selectedNode
+    ? (hoveredPath ?? selectedNodePaths[0])
+    : undefined;
+  const activePathImportSnippets = useMemo(() => {
+    const snippets = new Map<string, string>();
+    if (!activeSnippetPath) {
+      return snippets;
+    }
+
+    for (const edgeId of activeSnippetPath.edgeIds) {
+      const edge = edgeMap.get(edgeId);
+      if (!edge) {
+        continue;
+      }
+      const snippet = getEdgeImportSnippetLabel(edge);
+      if (snippet) {
+        snippets.set(edge.to, snippet);
+      }
+    }
+
+    return snippets;
+  }, [activeSnippetPath, edgeMap]);
 
   const highlightNodeIds = useMemo(() => {
     if (hoveredPath) {
@@ -563,9 +641,6 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   const option = useMemo<ChunkGroupGraphOption>(() => {
     const hasSelection =
       Boolean(selectedNode) || Boolean(selectedEdge) || Boolean(hoveredPath);
-    const hoverColor = hoveredPath
-      ? getPathColor(hoveredPath.severity)
-      : HIGHLIGHT_COLOR;
     const hasSearch = Boolean(searchQuery.trim());
     const isLargeGraph = nodes.length > 80;
     const maxEmittedSize = Math.max(
@@ -642,18 +717,23 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
           isOnHighlight ||
           (hasSearch && isMatched));
 
-      const removableRatio =
-        node.groupTotalJSSize > 0
-          ? node.removableJSSize / node.groupTotalJSSize
-          : 0;
       const borderColor =
         selectedNode?.id === node.id
-          ? '#111827'
-          : removableRatio > 1 / 3
-            ? DANGER_COLOR
-            : removableRatio > 0
-              ? WARNING_COLOR
-              : baseColor.border;
+          ? NODE_SELECTED_BORDER
+          : isOnHighlight
+            ? EDGE_HIGHLIGHT_COLOR
+            : baseColor.border;
+      const importSnippet = activePathImportSnippets.get(node.id);
+      const shouldShowImportSnippet = Boolean(importSnippet) && isOnHighlight;
+      const baseLabel = `${normalizeGraphLabel(node.name, 30)}\n${formatSize(
+        node.totalEmittedSize,
+      )}`;
+      const labelFormatter = shouldShowImportSnippet
+        ? `{snippet|${importSnippet}}\n{name|${normalizeGraphLabel(
+            node.name,
+            30,
+          )}}\n{size|${formatSize(node.totalEmittedSize)}}`
+        : baseLabel;
 
       return {
         id: node.id,
@@ -674,17 +754,41 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
           shadowColor: 'rgba(17,24,39,0.25)',
         },
         label: {
-          show: shouldShowLabel,
-          position: 'bottom' as const,
-          distance: 10,
-          width: NODE_LABEL_WIDTH,
+          show: shouldShowLabel || shouldShowImportSnippet,
+          position: shouldShowImportSnippet
+            ? ('top' as const)
+            : ('bottom' as const),
+          distance: shouldShowImportSnippet ? 14 : 10,
+          width: shouldShowImportSnippet ? 260 : NODE_LABEL_WIDTH,
           overflow: 'truncate' as const,
-          lineHeight: 16,
+          lineHeight: shouldShowImportSnippet ? 18 : 16,
           align: 'center' as const,
           color: '#111827',
           fontSize: 12,
           fontWeight: selectedNode?.id === node.id ? 700 : 500,
-          formatter: `${truncateLabel(node.name)}\n${formatSize(node.totalEmittedSize)}`,
+          formatter: labelFormatter,
+          rich: {
+            snippet: {
+              color: '#f9fafb',
+              backgroundColor: 'rgba(15, 23, 42, 0.92)',
+              borderRadius: 4,
+              padding: [4, 6],
+              fontFamily: 'monospace',
+              fontSize: 11,
+              lineHeight: 18,
+            },
+            name: {
+              color: '#111827',
+              fontWeight: 700,
+              fontSize: 12,
+              lineHeight: 18,
+            },
+            size: {
+              color: '#111827',
+              fontSize: 12,
+              lineHeight: 16,
+            },
+          },
         },
       };
     });
@@ -736,19 +840,13 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
         target: edge.to,
         value: edge.imports.length,
         lineStyle: {
-          color: highlight ? hoverColor : '#94a3b8',
+          color: highlight ? EDGE_HIGHLIGHT_COLOR : EDGE_COLOR,
           width: highlight ? 3 : 1.5,
           opacity,
           curveness: 0.12,
         },
         label: {
-          show:
-            edge.imports.length > 1 &&
-            opacity > 0.3 &&
-            (!isLargeGraph || highlight),
-          formatter: `${edge.imports.length} imports`,
-          color: highlight ? hoverColor : '#64748b',
-          fontSize: 10,
+          show: false,
         },
       };
     });
@@ -806,6 +904,9 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
           },
           edgeSymbol: ['none', 'arrow'],
           edgeSymbolSize: [0, 8],
+          edgeLabel: {
+            show: false,
+          },
           data: [...graphNodes, ...graphBoundaryNodes],
           links: graphEdges,
           lineStyle: {
@@ -817,11 +918,15 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
           },
           emphasis: {
             focus: 'adjacency',
+            edgeLabel: {
+              show: false,
+            },
           },
         },
       ],
     };
   }, [
+    activePathImportSnippets,
     edgeMap,
     edges,
     graphHeight,
@@ -870,6 +975,67 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
       window.clearTimeout(timer);
     };
   }, [graphHeight, graphWidth, option]);
+
+  useEffect(() => {
+    const chart = chartRef.current?.getEchartsInstance?.();
+    const zr = chart?.getZr?.();
+    if (!zr) {
+      return;
+    }
+
+    const handleMouseDown = (event: any) => {
+      if (event.target) {
+        blankPointerRef.current = null;
+        return;
+      }
+
+      const point = getZRenderEventPoint(event);
+      blankPointerRef.current = {
+        x: point.x,
+        y: point.y,
+        dragged: false,
+      };
+    };
+
+    const handleMouseMove = (event: any) => {
+      const pointer = blankPointerRef.current;
+      if (!pointer) {
+        return;
+      }
+
+      const point = getZRenderEventPoint(event);
+      if (Math.hypot(point.x - pointer.x, point.y - pointer.y) > 5) {
+        pointer.dragged = true;
+      }
+    };
+
+    const handleMouseUp = (event: any) => {
+      const pointer = blankPointerRef.current;
+      blankPointerRef.current = null;
+      if (!pointer || event.target || pointer.dragged) {
+        return;
+      }
+
+      const point = getZRenderEventPoint(event);
+      if (Math.hypot(point.x - pointer.x, point.y - pointer.y) > 5) {
+        return;
+      }
+
+      setSelectedEdgeId(null);
+      setSelectedNodeId(null);
+      setHoveredPathId(null);
+    };
+
+    zr.on('mousedown', handleMouseDown);
+    zr.on('mousemove', handleMouseMove);
+    zr.on('mouseup', handleMouseUp);
+
+    return () => {
+      zr.off('mousedown', handleMouseDown);
+      zr.off('mousemove', handleMouseMove);
+      zr.off('mouseup', handleMouseUp);
+    };
+  }, [option]);
 
   if (!nodes.length) {
     return (

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -78,9 +78,6 @@ const GRAPH_BOUNDARY_NODE_ID_PREFIX = '__chunk-group-graph-boundary__';
 const GRAPH_MIN_ZOOM = 0.2;
 const GRAPH_MAX_ZOOM = 4;
 const GRAPH_ZOOM_STEP = 0.25;
-const GRAPH_WHEEL_ZOOM_SENSITIVITY = 0.002;
-const WHEEL_DELTA_LINE_MODE = 1;
-const WHEEL_DELTA_PAGE_MODE = 2;
 
 const getBaseNodeColor = (node: SDK.ChunkGroupGraphNodeData) =>
   node.isInitial
@@ -111,16 +108,6 @@ const formatPercent = (value: number) => `${(value * 100).toFixed(1)}%`;
 
 const clampGraphZoom = (zoom: number) =>
   Math.max(GRAPH_MIN_ZOOM, Math.min(GRAPH_MAX_ZOOM, zoom));
-
-const normalizeWheelDelta = (event: WheelEvent, fallbackHeight: number) => {
-  if (event.deltaMode === WHEEL_DELTA_LINE_MODE) {
-    return event.deltaY * 16;
-  }
-  if (event.deltaMode === WHEEL_DELTA_PAGE_MODE) {
-    return event.deltaY * fallbackHeight;
-  }
-  return event.deltaY;
-};
 
 const buildForwardAdjacency = (edges: SDK.ChunkGroupGraphEdgeData[]) => {
   const map = new Map<string, string[]>();
@@ -576,6 +563,8 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
 }) => {
   const chartRef = useRef<any>(null);
   const graphContainerRef = useRef<HTMLDivElement>(null);
+  const graphZoomRef = useRef<number | null>(null);
+  const graphZoomSyncRafRef = useRef<number | null>(null);
   const blankPointerRef = useRef<{
     x: number;
     y: number;
@@ -605,7 +594,22 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   const defaultGraphZoom = isLargeGraph ? 0.72 : 1;
 
   useEffect(() => {
+    graphZoomRef.current = defaultGraphZoom;
     setGraphZoom(defaultGraphZoom);
+    chartRef.current?.getEchartsInstance?.().setOption?.(
+      {
+        series: [
+          {
+            zoom: defaultGraphZoom,
+          },
+        ],
+      },
+      {
+        lazyUpdate: false,
+        notMerge: false,
+        silent: true,
+      },
+    );
   }, [defaultGraphZoom]);
 
   const matchedNodeIds = useMemo(() => {
@@ -636,8 +640,84 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
     [matchedNodeIds, nodeMap, report?.priorityNodeIds],
   );
 
+  const syncGraphZoomState = (nextZoom: number) => {
+    const zoom = clampGraphZoom(nextZoom);
+    graphZoomRef.current = zoom;
+    setGraphZoom((currentZoom) =>
+      Math.abs(currentZoom - zoom) < 0.005 ? currentZoom : zoom,
+    );
+  };
+
+  const getChartGraphZoom = (chart: any) => {
+    const series = chart?.getOption?.()?.series?.[0];
+    const zoom = Array.isArray(series?.zoom) ? series.zoom[0] : series?.zoom;
+    return typeof zoom === 'number' ? zoom : graphZoomRef.current;
+  };
+
+  const syncGraphZoomFromChart = () => {
+    if (graphZoomSyncRafRef.current !== null) {
+      return;
+    }
+
+    graphZoomSyncRafRef.current = window.requestAnimationFrame(() => {
+      graphZoomSyncRafRef.current = null;
+      const chart = chartRef.current?.getEchartsInstance?.();
+      const zoom = getChartGraphZoom(chart);
+      if (typeof zoom === 'number') {
+        syncGraphZoomState(zoom);
+      }
+    });
+  };
+
+  const configureGraphRoamController = () => {
+    const chart = chartRef.current?.getEchartsInstance?.();
+    if (!chart) {
+      return;
+    }
+
+    const graphView = (chart as any)._chartsViews?.find(
+      (view: any) => view?.type === 'graph',
+    );
+    const controller = graphView?._controller;
+    if (!controller?.setPointerChecker) {
+      return;
+    }
+
+    controller.enable?.(true, {
+      moveOnMouseMove: true,
+      moveOnMouseWheel: false,
+      preventDefaultMouseMove: true,
+      zoomOnMouseWheel: 'ctrl',
+    });
+
+    // ECharts graph only roams inside the graph group's bounding rect by
+    // default; the chunk graph needs the whole canvas to be draggable. Zoom
+    // remains restricted to pinch or Ctrl+wheel so page scroll still works.
+    controller.setPointerChecker((_event: any, x: number, y: number) => {
+      const width = chart.getWidth?.() ?? graphWidth;
+      const height = chart.getHeight?.() ?? graphHeight;
+      return x >= 0 && x <= width && y >= 0 && y <= height;
+    });
+  };
+
   const updateGraphZoom = (nextZoom: number) => {
-    setGraphZoom(clampGraphZoom(nextZoom));
+    const nextClampedZoom = clampGraphZoom(nextZoom);
+    syncGraphZoomState(nextClampedZoom);
+    chartRef.current?.getEchartsInstance?.().setOption?.(
+      {
+        series: [
+          {
+            zoom: nextClampedZoom,
+          },
+        ],
+      },
+      {
+        lazyUpdate: false,
+        notMerge: false,
+        silent: true,
+      },
+    );
+    window.requestAnimationFrame(configureGraphRoamController);
   };
 
   useEffect(() => {
@@ -674,36 +754,14 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
     };
   }, []);
 
-  useEffect(() => {
-    const element = graphContainerRef.current;
-    if (!element) {
-      return;
-    }
-
-    const handleWheel = (event: WheelEvent) => {
-      if (!event.ctrlKey && !event.metaKey) {
-        return;
+  useEffect(
+    () => () => {
+      if (graphZoomSyncRafRef.current !== null) {
+        window.cancelAnimationFrame(graphZoomSyncRafRef.current);
       }
-
-      event.preventDefault();
-      event.stopPropagation();
-
-      const normalizedDelta = normalizeWheelDelta(event, graphHeight);
-      const zoomRatio = Math.exp(
-        -normalizedDelta * GRAPH_WHEEL_ZOOM_SENSITIVITY,
-      );
-      setGraphZoom((currentZoom) => clampGraphZoom(currentZoom * zoomRatio));
-    };
-
-    element.addEventListener('wheel', handleWheel, {
-      capture: true,
-      passive: false,
-    });
-
-    return () => {
-      element.removeEventListener('wheel', handleWheel, { capture: true });
-    };
-  }, [graphHeight]);
+    },
+    [],
+  );
 
   useEffect(() => {
     const resizeChart = () => {
@@ -1046,8 +1104,8 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
           layout: 'none',
           roam: 'move',
           draggable: false,
-          nodeScaleRatio: (isLargeGraph ? 0.24 : 0.6) as any,
-          zoom: graphZoom,
+          nodeScaleRatio: 0 as any,
+          zoom: graphZoomRef.current ?? defaultGraphZoom,
           scaleLimit: {
             min: GRAPH_MIN_ZOOM,
             max: GRAPH_MAX_ZOOM,
@@ -1079,9 +1137,9 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
     activePathImportSnippets,
     edgeMap,
     edges,
+    defaultGraphZoom,
     graphHeight,
     graphWidth,
-    graphZoom,
     highlightEdgeIds,
     highlightNodeIds,
     hoveredPath,
@@ -1096,31 +1154,8 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   ]);
 
   useEffect(() => {
-    const chart = chartRef.current?.getEchartsInstance?.();
-    if (!chart) {
-      return;
-    }
-
-    const expandGraphRoamArea = () => {
-      const graphView = (chart as any)._chartsViews?.find(
-        (view: any) => view?.type === 'graph',
-      );
-      const controller = graphView?._controller;
-      if (!controller?.setPointerChecker) {
-        return;
-      }
-
-      // ECharts graph only roams inside the graph group's bounding rect by
-      // default; the chunk graph needs the whole canvas to be draggable/zoomable.
-      controller.setPointerChecker((_event: any, x: number, y: number) => {
-        const width = chart.getWidth?.() ?? graphWidth;
-        const height = chart.getHeight?.() ?? graphHeight;
-        return x >= 0 && x <= width && y >= 0 && y <= height;
-      });
-    };
-
-    const rafId = window.requestAnimationFrame(expandGraphRoamArea);
-    const timer = window.setTimeout(expandGraphRoamArea, 120);
+    const rafId = window.requestAnimationFrame(configureGraphRoamController);
+    const timer = window.setTimeout(configureGraphRoamController, 120);
 
     return () => {
       window.cancelAnimationFrame(rafId);
@@ -1476,6 +1511,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
                       width: '100%',
                     }}
                     onEvents={{
+                      graphRoam: syncGraphZoomFromChart,
                       click: (params: any) => {
                         if (params.dataType === 'node') {
                           setSelectedNodeId(params.data.id);

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -62,8 +62,10 @@ const LAYOUT_ROW_GAP = 96;
 const LAYOUT_COLUMN_GAP = 640;
 const LAYOUT_SUBCOLUMN_GAP = 520;
 const MAX_LAYOUT_ROWS_PER_LEVEL = 7;
-const LARGE_GRAPH_NODE_SCALE = 0.44;
+const LARGE_GRAPH_NODE_SCALE = 0.52;
 const NODE_LABEL_WIDTH = 180;
+const MIN_NODE_SYMBOL_SIZE = 30;
+const MAX_NODE_SYMBOL_SIZE = 112;
 const GRAPH_BOUNDARY_NODE_ID_PREFIX = '__chunk-group-graph-boundary__';
 
 const getBaseNodeColor = (node: SDK.ChunkGroupGraphNodeData) =>
@@ -126,8 +128,13 @@ const getNodeSymbolSize = (
   maxEmittedSize: number,
 ) =>
   Math.max(
-    38,
-    Math.min(74, 38 + 36 * Math.sqrt(node.totalEmittedSize / maxEmittedSize)),
+    MIN_NODE_SYMBOL_SIZE,
+    Math.min(
+      MAX_NODE_SYMBOL_SIZE,
+      MIN_NODE_SYMBOL_SIZE +
+        (MAX_NODE_SYMBOL_SIZE - MIN_NODE_SYMBOL_SIZE) *
+          Math.sqrt(node.totalEmittedSize / maxEmittedSize),
+    ),
   );
 
 const getNodeLaneHeight = (
@@ -420,7 +427,9 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   report,
 }) => {
   const chartRef = useRef<any>(null);
+  const graphContainerRef = useRef<HTMLDivElement>(null);
   const [searchQuery, setSearchQuery] = useState('');
+  const [graphWidth, setGraphWidth] = useState(0);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
   const [hoveredPathId, setHoveredPathId] = useState<string | null>(null);
@@ -472,6 +481,36 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   }, [selectedNode?.id]);
 
   useEffect(() => {
+    const element = graphContainerRef.current;
+    if (!element) {
+      return;
+    }
+
+    const updateGraphWidth = () => {
+      const nextWidth = Math.round(element.getBoundingClientRect().width);
+      setGraphWidth((currentWidth) =>
+        currentWidth === nextWidth ? currentWidth : nextWidth,
+      );
+    };
+
+    updateGraphWidth();
+
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', updateGraphWidth);
+      return () => {
+        window.removeEventListener('resize', updateGraphWidth);
+      };
+    }
+
+    const observer = new ResizeObserver(updateGraphWidth);
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
     const resizeChart = () => {
       chartRef.current?.getEchartsInstance?.().resize?.();
     };
@@ -483,7 +522,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
       window.cancelAnimationFrame(rafId);
       window.clearTimeout(timer);
     };
-  }, [graphHeight, nodes.length, edges.length]);
+  }, [graphHeight, graphWidth, nodes.length, edges.length]);
 
   const hoveredPath = selectedNodePaths.find(
     (path) => path.id === hoveredPathId,
@@ -533,6 +572,52 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
       1,
       ...nodes.map((item) => item.totalEmittedSize),
     );
+    const positionedNodes = [...layout.positions.values()];
+    const boundaryPadding = isLargeGraph ? 720 : 240;
+    const positionedXs = positionedNodes.map((position) => position.x);
+    const positionedYs = positionedNodes.map((position) => position.y);
+    let boundaryMinX = positionedNodes.length
+      ? Math.min(...positionedXs) - boundaryPadding
+      : 0;
+    let boundaryMaxX = positionedNodes.length
+      ? Math.max(...positionedXs) + boundaryPadding
+      : 1;
+    let boundaryMinY = positionedNodes.length
+      ? Math.min(...positionedYs) - boundaryPadding
+      : 0;
+    let boundaryMaxY = positionedNodes.length
+      ? Math.max(...positionedYs) + boundaryPadding
+      : 1;
+    const viewAspect = Math.max(
+      1,
+      (graphWidth || (graphHeight * 16) / 9) / Math.max(1, graphHeight),
+    );
+    const boundaryWidth = Math.max(1, boundaryMaxX - boundaryMinX);
+    const boundaryHeight = Math.max(1, boundaryMaxY - boundaryMinY);
+    const boundaryAspect = boundaryWidth / boundaryHeight;
+
+    if (boundaryAspect > viewAspect) {
+      const nextHeight = boundaryWidth / viewAspect;
+      const heightOffset = (nextHeight - boundaryHeight) / 2;
+      boundaryMinY -= heightOffset;
+      boundaryMaxY += heightOffset;
+    } else {
+      const nextWidth = boundaryHeight * viewAspect;
+      const widthOffset = (nextWidth - boundaryWidth) / 2;
+      boundaryMinX -= widthOffset;
+      boundaryMaxX += widthOffset;
+    }
+
+    const dataAspect =
+      (boundaryMaxX - boundaryMinX) / Math.max(1, boundaryMaxY - boundaryMinY);
+    const nodeShapeStretch = Math.max(
+      0.25,
+      Math.min(4, dataAspect / viewAspect),
+    );
+    const getCircleSymbolSize = (diameter: number): [number, number] => [
+      diameter,
+      diameter / nodeShapeStretch,
+    ];
 
     const graphNodes = nodes.map((node) => {
       const position = layout.positions.get(node.id) ?? { x: 0, y: 0 };
@@ -573,10 +658,11 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
       return {
         id: node.id,
         name: node.name,
+        symbol: 'circle' as const,
         x: position.x,
         y: position.y,
         value: node.totalEmittedSize,
-        symbolSize,
+        symbolSize: getCircleSymbolSize(symbolSize),
         itemStyle: {
           color:
             hasSelection && !isOnHighlight ? MUTED_NODE : baseColor.background,
@@ -602,42 +688,37 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
         },
       };
     });
-    const positionedNodes = [...layout.positions.values()];
-    const boundaryPadding = isLargeGraph ? 720 : 240;
-    const positionedXs = positionedNodes.map((position) => position.x);
-    const positionedYs = positionedNodes.map((position) => position.y);
-    const boundaryMinX = Math.min(...positionedXs) - boundaryPadding;
-    const boundaryMaxX = Math.max(...positionedXs) + boundaryPadding;
-    const boundaryMinY = Math.min(...positionedYs) - boundaryPadding;
-    const boundaryMaxY = Math.max(...positionedYs) + boundaryPadding;
-    const graphBoundaryNodes = positionedNodes.length
+    const boundaryPoints = positionedNodes.length
       ? [
           [boundaryMinX, boundaryMinY],
           [boundaryMaxX, boundaryMinY],
           [boundaryMinX, boundaryMaxY],
           [boundaryMaxX, boundaryMaxY],
-        ].map(([x, y], index) => ({
-          id: `${GRAPH_BOUNDARY_NODE_ID_PREFIX}${index}`,
-          name: '',
-          x,
-          y,
-          silent: true,
-          symbolSize: 1,
-          itemStyle: {
-            opacity: 0,
-          },
-          label: {
-            show: false,
-          },
-          tooltip: {
-            show: false,
-          },
-          emphasis: {
-            disabled: true,
-          },
-        }))
+        ]
       : [];
-
+    const graphBoundaryNodes = boundaryPoints.map(([x, y], index) => ({
+      id: `${GRAPH_BOUNDARY_NODE_ID_PREFIX}${index}`,
+      name: '',
+      x,
+      y,
+      silent: true,
+      symbol: 'circle' as const,
+      symbolSize: 2,
+      itemStyle: {
+        borderColor: 'rgba(0,0,0,0)',
+        color: 'rgba(0,0,0,0.001)',
+        opacity: 0.001,
+      },
+      label: {
+        show: false,
+      },
+      tooltip: {
+        show: false,
+      },
+      emphasis: {
+        disabled: true,
+      },
+    }));
     const graphEdges = edges.map((edge) => {
       const highlight = highlightEdgeIds.has(edge.id);
       const matchesSearch =
@@ -709,6 +790,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
       series: [
         {
           type: 'graph',
+          symbol: 'circle',
           left: 8,
           right: 8,
           top: 8,
@@ -742,6 +824,8 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   }, [
     edgeMap,
     edges,
+    graphHeight,
+    graphWidth,
     highlightEdgeIds,
     highlightNodeIds,
     hoveredPath,
@@ -753,6 +837,39 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
     selectedEdge,
     selectedNode,
   ]);
+
+  useEffect(() => {
+    const chart = chartRef.current?.getEchartsInstance?.();
+    if (!chart) {
+      return;
+    }
+
+    const expandGraphRoamArea = () => {
+      const graphView = (chart as any)._chartsViews?.find(
+        (view: any) => view?.type === 'graph',
+      );
+      const controller = graphView?._controller;
+      if (!controller?.setPointerChecker) {
+        return;
+      }
+
+      // ECharts graph only roams inside the graph group's bounding rect by
+      // default; the chunk graph needs the whole canvas to be draggable/zoomable.
+      controller.setPointerChecker((_event: any, x: number, y: number) => {
+        const width = chart.getWidth?.() ?? graphWidth;
+        const height = chart.getHeight?.() ?? graphHeight;
+        return x >= 0 && x <= width && y >= 0 && y <= height;
+      });
+    };
+
+    const rafId = window.requestAnimationFrame(expandGraphRoamArea);
+    const timer = window.setTimeout(expandGraphRoamArea, 120);
+
+    return () => {
+      window.cancelAnimationFrame(rafId);
+      window.clearTimeout(timer);
+    };
+  }, [graphHeight, graphWidth, option]);
 
   if (!nodes.length) {
     return (
@@ -983,28 +1100,34 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
 
           <Row gutter={[16, 16]} align="top">
             <Col xs={24} xl={16}>
-              <Card bodyStyle={{ padding: 0 }}>
-                <ReactEChartsCore
-                  ref={chartRef}
-                  echarts={echarts}
-                  option={option}
-                  notMerge
-                  style={{ cursor: 'grab', height: graphHeight, width: '100%' }}
-                  onEvents={{
-                    click: (params: any) => {
-                      if (params.dataType === 'node') {
-                        setSelectedNodeId(params.data.id);
-                        setSelectedEdgeId(null);
-                        setHoveredPathId(null);
-                      } else if (params.dataType === 'edge') {
-                        setSelectedEdgeId(params.data.id);
-                        setSelectedNodeId(null);
-                        setHoveredPathId(null);
-                      }
-                    },
-                  }}
-                />
-              </Card>
+              <div ref={graphContainerRef}>
+                <Card bodyStyle={{ padding: 0 }}>
+                  <ReactEChartsCore
+                    ref={chartRef}
+                    echarts={echarts}
+                    option={option}
+                    notMerge
+                    style={{
+                      cursor: 'grab',
+                      height: graphHeight,
+                      width: '100%',
+                    }}
+                    onEvents={{
+                      click: (params: any) => {
+                        if (params.dataType === 'node') {
+                          setSelectedNodeId(params.data.id);
+                          setSelectedEdgeId(null);
+                          setHoveredPathId(null);
+                        } else if (params.dataType === 'edge') {
+                          setSelectedEdgeId(params.data.id);
+                          setSelectedNodeId(null);
+                          setHoveredPathId(null);
+                        }
+                      },
+                    }}
+                  />
+                </Card>
+              </div>
             </Col>
 
             <Col xs={24} xl={8}>

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -66,10 +66,14 @@ const MIN_GRAPH_HEIGHT = 520;
 const MAX_GRAPH_HEIGHT = 620;
 const LAYOUT_TOP_PADDING = 64;
 const LAYOUT_LEFT_PADDING = 120;
-const LAYOUT_ROW_GAP = 96;
 const LAYOUT_COLUMN_GAP = 640;
-const LAYOUT_SUBCOLUMN_GAP = 520;
-const MAX_LAYOUT_ROWS_PER_LEVEL = 7;
+const LAYOUT_SUBCOLUMN_GAP = 360;
+const LAYOUT_PACKED_ROW_GAP = 50;
+const LAYOUT_PACKED_ROW_GAP_VARIANCE = 64;
+const LAYOUT_COLUMN_TOP_VARIANCE = 140;
+const LAYOUT_NODE_X_JITTER = 170;
+const LAYOUT_NODE_Y_JITTER = 32;
+const MAX_LAYOUT_ROWS_PER_LEVEL = 12;
 const LARGE_GRAPH_NODE_SCALE = 0.52;
 const NODE_LABEL_WIDTH = 180;
 const MIN_NODE_SYMBOL_SIZE = 30;
@@ -160,6 +164,22 @@ const getNodeLaneHeight = (
     96,
     getNodeSymbolSize(node, maxEmittedSize) + 50 + Math.min(18, outDegree * 4),
   );
+
+const stableHash = (value: string) => {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+};
+
+const stableRatio = (value: string) => (stableHash(value) % 10000) / 9999;
+
+const stableSignedRatio = (value: string) => stableRatio(value) * 2 - 1;
+
+const clampNumber = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
 
 const truncateLabel = (value: string, maxLength = 26) =>
   value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
@@ -379,11 +399,11 @@ const buildLayout = (
     {
       height: number;
       items: Array<{
+        column: number;
         laneHeight: number;
         node: SDK.ChunkGroupGraphNodeData;
+        y: number;
       }>;
-      rowCount: number;
-      rowHeight: number;
       width: number;
     }
   >();
@@ -431,10 +451,73 @@ const buildLayout = (
       1,
       Math.ceil(levelLayout.length / MAX_LAYOUT_ROWS_PER_LEVEL),
     );
-    const rowCount = Math.max(1, Math.ceil(levelLayout.length / columnCount));
-    const rowHeight =
-      Math.max(...levelLayout.map((item) => item.laneHeight)) + LAYOUT_ROW_GAP;
-    const levelHeight = rowCount * rowHeight - LAYOUT_ROW_GAP;
+    const columns = Array.from({ length: columnCount }, (_, columnIndex) => ({
+      count: 0,
+      height:
+        columnCount > 1
+          ? stableRatio(`${level}:${columnIndex}:top`) *
+            LAYOUT_COLUMN_TOP_VARIANCE
+          : 0,
+    }));
+    const placedItems: Array<{
+      column: number;
+      laneHeight: number;
+      node: SDK.ChunkGroupGraphNodeData;
+      y: number;
+    }> = [];
+
+    levelLayout.forEach((item, index) => {
+      const preferredColumn =
+        columnCount <= 1
+          ? 0
+          : Math.min(
+              columnCount - 1,
+              Math.max(
+                0,
+                Math.round(
+                  ((index + stableSignedRatio(`${item.node.id}:column`) * 0.4) /
+                    Math.max(1, levelLayout.length - 1)) *
+                    (columnCount - 1),
+                ),
+              ),
+            );
+      const column = columns.reduce(
+        (bestColumn, currentColumn, currentIndex) => {
+          const currentScore =
+            currentColumn.height +
+            Math.abs(currentIndex - preferredColumn) * 130 +
+            currentColumn.count * 12;
+          const best = columns[bestColumn];
+          const bestScore =
+            best.height +
+            Math.abs(bestColumn - preferredColumn) * 130 +
+            best.count * 12;
+
+          return currentScore < bestScore ? currentIndex : bestColumn;
+        },
+        0,
+      );
+      const yJitter =
+        stableSignedRatio(`${item.node.id}:y`) * LAYOUT_NODE_Y_JITTER;
+      const y = columns[column].height + item.laneHeight / 2 + yJitter;
+      const gap =
+        LAYOUT_PACKED_ROW_GAP +
+        stableRatio(`${item.node.id}:gap`) * LAYOUT_PACKED_ROW_GAP_VARIANCE;
+
+      placedItems.push({
+        column,
+        laneHeight: item.laneHeight,
+        node: item.node,
+        y,
+      });
+      columns[column].height += item.laneHeight + gap;
+      columns[column].count += 1;
+    });
+
+    const levelHeight = Math.max(
+      ...columns.map((column) => column.height),
+      ...placedItems.map((item) => item.y + item.laneHeight / 2),
+    );
     const levelWidth = Math.max(0, (columnCount - 1) * LAYOUT_SUBCOLUMN_GAP);
 
     levelLayout.forEach((item, index) => {
@@ -442,17 +525,18 @@ const buildLayout = (
     });
     levelLayouts.set(level, {
       height: levelHeight,
-      items: levelLayout,
-      rowCount,
-      rowHeight,
+      items: placedItems,
       width: levelWidth,
     });
     maxLevelHeight = Math.max(maxLevelHeight, levelHeight);
   }
 
+  const organicContentHeight =
+    nodes.length > 60 ? 420 + Math.sqrt(nodes.length) * 72 : 0;
   const contentHeight = Math.max(
     MIN_GRAPH_HEIGHT - LAYOUT_TOP_PADDING * 2,
     maxLevelHeight,
+    Math.min(1200, organicContentHeight),
   );
   const positions = new Map<
     string,
@@ -463,17 +547,34 @@ const buildLayout = (
   >();
 
   let currentX = LAYOUT_LEFT_PADDING;
-  for (const [, levelLayout] of [...levelLayouts.entries()].sort(
+  for (const [level, levelLayout] of [...levelLayouts.entries()].sort(
     (a, b) => a[0] - b[0],
   )) {
     const currentY = LAYOUT_TOP_PADDING;
+    const availableY = Math.max(0, contentHeight - levelLayout.height);
+    const levelWaveRatio =
+      Math.sin(level * 1.17) * 0.36 +
+      stableSignedRatio(`${level}:level-y`) * 0.18;
+    const levelOffsetY = clampNumber(
+      availableY / 2 + levelWaveRatio * availableY,
+      0,
+      availableY,
+    );
 
-    levelLayout.items.forEach((item, index) => {
-      const column = Math.floor(index / levelLayout.rowCount);
-      const row = index % levelLayout.rowCount;
+    levelLayout.items.forEach((item) => {
+      const xJitter =
+        stableSignedRatio(`${item.node.id}:x`) *
+        (levelLayout.width > 0
+          ? LAYOUT_NODE_X_JITTER
+          : LAYOUT_NODE_X_JITTER / 2);
+      const xWave =
+        levelLayout.width > 0
+          ? stableSignedRatio(`${item.column}:wave:${currentX}`) *
+            LAYOUT_NODE_X_JITTER
+          : 0;
       positions.set(item.node.id, {
-        x: currentX + column * LAYOUT_SUBCOLUMN_GAP,
-        y: currentY + row * levelLayout.rowHeight + levelLayout.rowHeight / 2,
+        x: currentX + item.column * LAYOUT_SUBCOLUMN_GAP + xJitter + xWave,
+        y: currentY + levelOffsetY + item.y,
       });
     });
     currentX += Math.max(

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -657,41 +657,6 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
     };
   }, [graphHeight, graphWidth, nodes.length, edges.length]);
 
-  useEffect(() => {
-    const element = graphContainerRef.current;
-    if (!element) {
-      return;
-    }
-
-    const handleGraphWheel = (event: WheelEvent) => {
-      if (event.ctrlKey || event.metaKey) {
-        return;
-      }
-
-      // Keep normal wheel scrolling native, but keep ECharts from treating it
-      // as graph zoom. Ctrl/Cmd + wheel is still forwarded for graph zoom.
-      event.stopPropagation();
-      event.stopImmediatePropagation();
-    };
-    const options: AddEventListenerOptions = {
-      capture: true,
-    };
-
-    element.addEventListener('wheel', handleGraphWheel, options);
-    element.addEventListener('mousewheel', handleGraphWheel as EventListener, {
-      ...options,
-    });
-
-    return () => {
-      element.removeEventListener('wheel', handleGraphWheel, options);
-      element.removeEventListener(
-        'mousewheel',
-        handleGraphWheel as EventListener,
-        options,
-      );
-    };
-  }, []);
-
   const hoveredPath = selectedNodePaths.find(
     (path) => path.id === hoveredPathId,
   );
@@ -1018,7 +983,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
           top: 8,
           bottom: 8,
           layout: 'none',
-          roam: true,
+          roam: 'move',
           draggable: false,
           nodeScaleRatio: (isLargeGraph ? 0.24 : 0.6) as any,
           zoom: isLargeGraph ? 0.72 : 1,

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -12,6 +12,7 @@ import { SearchOutlined } from '@ant-design/icons';
 import { SDK } from '@rsdoctor/types';
 import {
   Alert,
+  Button,
   Card,
   Col,
   Empty,
@@ -74,6 +75,9 @@ const NODE_LABEL_WIDTH = 180;
 const MIN_NODE_SYMBOL_SIZE = 30;
 const MAX_NODE_SYMBOL_SIZE = 112;
 const GRAPH_BOUNDARY_NODE_ID_PREFIX = '__chunk-group-graph-boundary__';
+const GRAPH_MIN_ZOOM = 0.2;
+const GRAPH_MAX_ZOOM = 4;
+const GRAPH_ZOOM_STEP = 0.25;
 
 const getBaseNodeColor = (node: SDK.ChunkGroupGraphNodeData) =>
   node.isInitial
@@ -566,6 +570,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
   const [hoveredPathId, setHoveredPathId] = useState<string | null>(null);
+  const [graphZoom, setGraphZoom] = useState(1);
   const [expandedPathIds, setExpandedPathIds] = useState<Set<string>>(
     () => new Set(),
   );
@@ -580,6 +585,12 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
     MAX_GRAPH_HEIGHT,
     Math.max(MIN_GRAPH_HEIGHT, layout.height),
   );
+  const isLargeGraph = nodes.length > 80;
+  const defaultGraphZoom = isLargeGraph ? 0.72 : 1;
+
+  useEffect(() => {
+    setGraphZoom(defaultGraphZoom);
+  }, [defaultGraphZoom]);
 
   const matchedNodeIds = useMemo(() => {
     if (!searchQuery.trim()) {
@@ -608,6 +619,10 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
         .filter((node) => matchedNodeIds.has(node.id)),
     [matchedNodeIds, nodeMap, report?.priorityNodeIds],
   );
+
+  const updateGraphZoom = (nextZoom: number) => {
+    setGraphZoom(Math.max(GRAPH_MIN_ZOOM, Math.min(GRAPH_MAX_ZOOM, nextZoom)));
+  };
 
   useEffect(() => {
     setExpandedPathIds(new Set());
@@ -719,7 +734,6 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
     const hasSelection =
       Boolean(selectedNode) || Boolean(selectedEdge) || Boolean(hoveredPath);
     const hasSearch = Boolean(searchQuery.trim());
-    const isLargeGraph = nodes.length > 80;
     const maxEmittedSize = Math.max(
       1,
       ...nodes.map((item) => item.totalEmittedSize),
@@ -986,10 +1000,10 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
           roam: 'move',
           draggable: false,
           nodeScaleRatio: (isLargeGraph ? 0.24 : 0.6) as any,
-          zoom: isLargeGraph ? 0.72 : 1,
+          zoom: graphZoom,
           scaleLimit: {
-            min: 0.2,
-            max: 4,
+            min: GRAPH_MIN_ZOOM,
+            max: GRAPH_MAX_ZOOM,
           },
           edgeSymbol: ['none', 'arrow'],
           edgeSymbolSize: [0, 8],
@@ -1020,9 +1034,11 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
     edges,
     graphHeight,
     graphWidth,
+    graphZoom,
     highlightEdgeIds,
     highlightNodeIds,
     hoveredPath,
+    isLargeGraph,
     layout,
     matchedNodeIds,
     nodeMap,
@@ -1356,7 +1372,52 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
           <Row gutter={[16, 16]} align="top">
             <Col xs={24} xl={16}>
               <div ref={graphContainerRef}>
-                <Card bodyStyle={{ padding: 0 }}>
+                <Card bodyStyle={{ padding: 0, position: 'relative' }}>
+                  <div
+                    style={{
+                      position: 'absolute',
+                      top: 12,
+                      right: 12,
+                      zIndex: 2,
+                      padding: '6px 8px',
+                      borderRadius: 8,
+                      background: 'rgba(255, 255, 255, 0.92)',
+                      boxShadow: '0 4px 12px rgba(15, 23, 42, 0.12)',
+                    }}
+                  >
+                    <Space size="small">
+                      <Button
+                        size="small"
+                        onClick={() =>
+                          updateGraphZoom(graphZoom - GRAPH_ZOOM_STEP)
+                        }
+                        disabled={graphZoom <= GRAPH_MIN_ZOOM}
+                      >
+                        -
+                      </Button>
+                      <Typography.Text
+                        type="secondary"
+                        style={{ minWidth: 48, textAlign: 'center' }}
+                      >
+                        {Math.round(graphZoom * 100)}%
+                      </Typography.Text>
+                      <Button
+                        size="small"
+                        onClick={() =>
+                          updateGraphZoom(graphZoom + GRAPH_ZOOM_STEP)
+                        }
+                        disabled={graphZoom >= GRAPH_MAX_ZOOM}
+                      >
+                        +
+                      </Button>
+                      <Button
+                        size="small"
+                        onClick={() => updateGraphZoom(defaultGraphZoom)}
+                      >
+                        Reset zoom
+                      </Button>
+                    </Space>
+                  </div>
                   <ReactEChartsCore
                     ref={chartRef}
                     echarts={echarts}

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -278,6 +278,66 @@ const getZRenderEventPoint = (event: any) => ({
         : 0,
 });
 
+const getScrollableAxes = (element: HTMLElement) => {
+  const { overflowY, overflowX } = window.getComputedStyle(element);
+  const canScrollY =
+    /(auto|scroll|overlay)/.test(overflowY) &&
+    element.scrollHeight > element.clientHeight;
+  const canScrollX =
+    /(auto|scroll|overlay)/.test(overflowX) &&
+    element.scrollWidth > element.clientWidth;
+
+  return {
+    x: canScrollX,
+    y: canScrollY,
+  };
+};
+
+const findScrollContainer = (
+  element: HTMLElement,
+  deltaX: number,
+  deltaY: number,
+) => {
+  let current = element.parentElement;
+  const shouldScrollY = Math.abs(deltaY) >= Math.abs(deltaX);
+
+  while (current && current !== document.body) {
+    const scrollable = getScrollableAxes(current);
+    if (
+      (shouldScrollY && scrollable.y) ||
+      (!shouldScrollY && scrollable.x) ||
+      (deltaY !== 0 && scrollable.y) ||
+      (deltaX !== 0 && scrollable.x)
+    ) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+
+  return document.scrollingElement ?? document.documentElement;
+};
+
+const scrollElementByWheel = (
+  element: Element,
+  deltaX: number,
+  deltaY: number,
+) => {
+  if (
+    element === document.scrollingElement ||
+    element === document.documentElement
+  ) {
+    window.scrollBy({
+      left: deltaX,
+      top: deltaY,
+      behavior: 'auto',
+    });
+    return;
+  }
+
+  element.scrollLeft += deltaX;
+  element.scrollTop += deltaY;
+};
+
 const sortPathsByOpportunity = (
   a: SDK.ChunkGroupGraphPathData,
   b: SDK.ChunkGroupGraphPathData,
@@ -1144,6 +1204,21 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   const dangerPathCount = overview?.dangerPathCount ?? 0;
   const warningPathCount = overview?.warningPathCount ?? 0;
   const selectedNodeImports = selectedNode?.incomingImports ?? [];
+  const handleGraphWheel = (event: React.WheelEvent<HTMLDivElement>) => {
+    if (event.ctrlKey || event.metaKey) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
+
+    scrollElementByWheel(
+      findScrollContainer(event.currentTarget, event.deltaX, event.deltaY),
+      event.deltaX,
+      event.deltaY,
+    );
+  };
   const selectedNodePathList = selectedNode ? (
     <div>
       <Typography.Title level={5}>
@@ -1355,7 +1430,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
 
           <Row gutter={[16, 16]} align="top">
             <Col xs={24} xl={16}>
-              <div ref={graphContainerRef}>
+              <div ref={graphContainerRef} onWheelCapture={handleGraphWheel}>
                 <Card bodyStyle={{ padding: 0 }}>
                   <ReactEChartsCore
                     ref={chartRef}

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -31,15 +31,14 @@ type ChunkGroupGraphOption = ComposeOption<
   GraphSeriesOption | TooltipComponentOption
 >;
 
+type GraphPosition = {
+  x: number;
+  y: number;
+};
+
 type GraphLayout = {
   height: number;
-  positions: Map<
-    string,
-    {
-      x: number;
-      y: number;
-    }
-  >;
+  positions: Map<string, GraphPosition>;
 };
 
 type ChunkGroupGraphPanelProps = {
@@ -677,6 +676,9 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
   const [hoveredPathId, setHoveredPathId] = useState<string | null>(null);
   const [graphZoom, setGraphZoom] = useState(1);
+  const [draggedNodePositions, setDraggedNodePositions] = useState<
+    Map<string, GraphPosition>
+  >(() => new Map());
   const [expandedPathIds, setExpandedPathIds] = useState<Set<string>>(
     () => new Set(),
   );
@@ -770,6 +772,57 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
     });
   };
 
+  const storeDraggedNodePosition = (params: any) => {
+    if (params?.dataType !== 'node') {
+      return;
+    }
+
+    const nodeId = params?.data?.id;
+    if (
+      typeof nodeId !== 'string' ||
+      nodeId.startsWith(GRAPH_BOUNDARY_NODE_ID_PREFIX)
+    ) {
+      return;
+    }
+
+    const chart = chartRef.current?.getEchartsInstance?.();
+    const graphData = chart?.getModel?.()?.getSeriesByIndex?.(0)?.getData?.();
+    const dataIndex =
+      typeof params.dataIndex === 'number' ? params.dataIndex : undefined;
+    const layoutPosition =
+      typeof dataIndex === 'number'
+        ? graphData?.getItemLayout?.(dataIndex)
+        : undefined;
+
+    if (
+      !Array.isArray(layoutPosition) ||
+      typeof layoutPosition[0] !== 'number' ||
+      typeof layoutPosition[1] !== 'number' ||
+      !Number.isFinite(layoutPosition[0]) ||
+      !Number.isFinite(layoutPosition[1])
+    ) {
+      return;
+    }
+
+    setDraggedNodePositions((currentPositions) => {
+      const current = currentPositions.get(nodeId);
+      if (
+        current &&
+        Math.abs(current.x - layoutPosition[0]) < 0.5 &&
+        Math.abs(current.y - layoutPosition[1]) < 0.5
+      ) {
+        return currentPositions;
+      }
+
+      const nextPositions = new Map(currentPositions);
+      nextPositions.set(nodeId, {
+        x: layoutPosition[0],
+        y: layoutPosition[1],
+      });
+      return nextPositions;
+    });
+  };
+
   const configureGraphRoamController = () => {
     const chart = chartRef.current?.getEchartsInstance?.();
     if (!chart) {
@@ -824,6 +877,10 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
   useEffect(() => {
     setExpandedPathIds(new Set());
   }, [selectedNode?.id]);
+
+  useEffect(() => {
+    setDraggedNodePositions(new Map());
+  }, [report]);
 
   useEffect(() => {
     const element = graphContainerRef.current;
@@ -944,7 +1001,11 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
       1,
       ...nodes.map((item) => item.totalEmittedSize),
     );
-    const positionedNodes = [...layout.positions.values()];
+    const nodePositions = new Map(layout.positions);
+    draggedNodePositions.forEach((position, nodeId) => {
+      nodePositions.set(nodeId, position);
+    });
+    const positionedNodes = [...nodePositions.values()];
     const boundaryPadding = isLargeGraph ? 720 : 240;
     const positionedXs = positionedNodes.map((position) => position.x);
     const positionedYs = positionedNodes.map((position) => position.y);
@@ -992,7 +1053,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
     ];
 
     const graphNodes = nodes.map((node) => {
-      const position = layout.positions.get(node.id) ?? { x: 0, y: 0 };
+      const position = nodePositions.get(node.id) ?? { x: 0, y: 0 };
       const baseColor = getBaseNodeColor(node);
       const isMatched = matchedNodeIds.has(node.id);
       const isOnHighlight = highlightNodeIds.has(node.id);
@@ -1204,7 +1265,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
           bottom: 8,
           layout: 'none',
           roam: 'move',
-          draggable: false,
+          draggable: true,
           nodeScaleRatio: 0 as any,
           zoom: graphZoomRef.current ?? defaultGraphZoom,
           scaleLimit: {
@@ -1239,6 +1300,7 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
     edgeMap,
     edges,
     defaultGraphZoom,
+    draggedNodePositions,
     graphHeight,
     graphWidth,
     highlightEdgeIds,
@@ -1599,6 +1661,14 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
                       >
                         Reset zoom
                       </Button>
+                      {draggedNodePositions.size ? (
+                        <Button
+                          size="small"
+                          onClick={() => setDraggedNodePositions(new Map())}
+                        >
+                          Reset layout
+                        </Button>
+                      ) : null}
                     </Space>
                   </div>
                   <ReactEChartsCore
@@ -1613,6 +1683,8 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
                     }}
                     onEvents={{
                       graphRoam: syncGraphZoomFromChart,
+                      mouseup: storeDraggedNodePosition,
+                      dragend: storeDraggedNodePosition,
                       click: (params: any) => {
                         if (params.dataType === 'node') {
                           setSelectedNodeId(params.data.id);

--- a/packages/components/src/pages/BundleSize/components/chunk-group.tsx
+++ b/packages/components/src/pages/BundleSize/components/chunk-group.tsx
@@ -24,6 +24,10 @@ import {
   Typography,
 } from 'antd';
 import { formatSize } from 'src/utils';
+import {
+  getPathParentImportSnippetLabels,
+  normalizeGraphLabel,
+} from './chunk-group-helpers';
 
 echarts.use([GraphChart, TooltipComponent, CanvasRenderer]);
 
@@ -43,11 +47,6 @@ type GraphLayout = {
 
 type ChunkGroupGraphPanelProps = {
   report?: SDK.ChunkGroupGraphData;
-};
-
-type GraphImportSnippetLabel = {
-  file: string;
-  code: string;
 };
 
 const ENTRY_COLOR = '#1f6feb';
@@ -197,115 +196,6 @@ const limitVector = (position: GraphPosition, maxDistance: number) => {
     x: position.x * scale,
     y: position.y * scale,
   };
-};
-
-const truncateLabel = (value: string, maxLength = 26) =>
-  value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
-
-const truncateMiddleLabel = (value: string, maxLength: number) => {
-  if (value.length <= maxLength) {
-    return value;
-  }
-
-  const tailLength = Math.floor((maxLength - 1) / 2);
-  const headLength = maxLength - tailLength - 1;
-  return `${value.slice(0, headLength)}…${value.slice(-tailLength)}`;
-};
-
-const normalizeGraphLabelText = (value: string) =>
-  value.replace(/[{}]/g, '').replace(/\s+/g, ' ').trim();
-
-const normalizeGraphLabel = (value: string, maxLength: number) =>
-  truncateLabel(normalizeGraphLabelText(value), maxLength);
-
-const normalizeFileGraphLabel = (value: string, maxLength: number) =>
-  truncateMiddleLabel(normalizeGraphLabelText(value), maxLength);
-
-const stripSnippetLineNumber = (value: string) =>
-  value.replace(/^\d+\s*\|\s*/, '').trim();
-
-const buildImportSnippetCode = (item: SDK.ChunkGroupGraphImportData) => {
-  const snippetLines =
-    item.snippet
-      ?.split('\n')
-      .map((line) => stripSnippetLineNumber(line.trim()))
-      .filter(Boolean) ?? [];
-  const importLineIndex = snippetLines.findIndex((line) =>
-    line.includes('import('),
-  );
-
-  if (importLineIndex >= 0) {
-    const requestLineIndex = item.request
-      ? snippetLines.findIndex((line, index) => {
-          return index >= importLineIndex && line.includes(item.request!);
-        })
-      : -1;
-    const endIndex =
-      requestLineIndex >= 0
-        ? Math.min(snippetLines.length, requestLineIndex + 2)
-        : importLineIndex + 1;
-
-    return snippetLines.slice(importLineIndex, endIndex).join(' ');
-  }
-
-  return item.request ? `import(${JSON.stringify(item.request)})` : '';
-};
-
-const getSourceFileLabel = (item: SDK.ChunkGroupGraphImportData) => {
-  const source = item.sourceModule || item.loc?.replace(/:\d+:\d+$/, '') || '';
-  const fileName = source.split(/[\\/]/).filter(Boolean).pop() || source;
-  const line = item.loc?.match(/:(\d+):\d+$/)?.[1];
-
-  if (!fileName) {
-    return line ? `line ${line}` : 'unknown source';
-  }
-
-  return line ? `${fileName}:${line}` : fileName;
-};
-
-const getImportSnippetLabel = (
-  item: SDK.ChunkGroupGraphImportData,
-): GraphImportSnippetLabel | undefined => {
-  const code = buildImportSnippetCode(item);
-
-  if (!code) {
-    return undefined;
-  }
-
-  return {
-    file: normalizeFileGraphLabel(getSourceFileLabel(item), 42),
-    code: normalizeGraphLabel(code, 72),
-  };
-};
-
-const formatEdgeImportSnippetLabel = (
-  edge: SDK.ChunkGroupGraphEdgeData,
-): GraphImportSnippetLabel | undefined => {
-  const snippets = edge.imports.map(getImportSnippetLabel).filter(Boolean);
-  if (!snippets.length) {
-    return undefined;
-  }
-
-  const first = snippets[0]!;
-  if (edge.imports.length <= 1) {
-    return first;
-  }
-
-  return {
-    file: `${first.file} +${edge.imports.length - 1}`,
-    code: first.code,
-  };
-};
-
-const getEdgeImportSnippetGraphLabel = (
-  edge: SDK.ChunkGroupGraphEdgeData,
-): GraphImportSnippetLabel | undefined => {
-  const label = formatEdgeImportSnippetLabel(edge);
-  if (!label) {
-    return undefined;
-  }
-
-  return label;
 };
 
 const getZRenderEventPoint = (event: any) => ({
@@ -1067,23 +957,11 @@ const ChunkGroupGraphPanelBase: React.FC<ChunkGroupGraphPanelProps> = ({
     ? (hoveredPath ?? selectedNodePaths[0])
     : undefined;
   const activePathImportSnippets = useMemo(() => {
-    const snippets = new Map<string, GraphImportSnippetLabel>();
     if (!activeSnippetPath) {
-      return snippets;
+      return new Map();
     }
 
-    for (const edgeId of activeSnippetPath.edgeIds) {
-      const edge = edgeMap.get(edgeId);
-      if (!edge) {
-        continue;
-      }
-      const snippet = getEdgeImportSnippetGraphLabel(edge);
-      if (snippet) {
-        snippets.set(edge.to, snippet);
-      }
-    }
-
-    return snippets;
+    return getPathParentImportSnippetLabels(activeSnippetPath, edgeMap);
   }, [activeSnippetPath, edgeMap]);
 
   const highlightNodeIds = useMemo(() => {

--- a/packages/components/src/pages/BundleSize/components/index.tsx
+++ b/packages/components/src/pages/BundleSize/components/index.tsx
@@ -38,6 +38,7 @@ import {
 } from '../../../utils';
 import { AssetDetail } from './asset';
 import { BundleCards } from './cards';
+import { ChunkGroupGraphPanel } from './chunk-group';
 import styles from './index.module.scss';
 import './index.sass';
 import { SearchModal } from './search-modal';
@@ -71,6 +72,7 @@ export const WebpackModulesOverallBase: React.FC<
   const [inputModuleUnit, setModuleUnit] = useState('');
   const [inputChunkUnit, setChunkUnit] = useState('');
   const [assetPath, setAssetPath] = useState<string | null>(null);
+  const [activeTabKey, setActiveTabKey] = useState('tree');
   const { showCode, codeDrawerComponent } = useCodeDrawer(
     'Do not have the codes of assets. If you use the lite or brief mode, there will have codes.',
   );
@@ -205,6 +207,8 @@ export const WebpackModulesOverallBase: React.FC<
         <Card styles={{ body: { paddingTop: 0 } }}>
           <Tabs
             size="middle"
+            activeKey={activeTabKey}
+            onChange={setActiveTabKey}
             items={[
               {
                 key: 'tree',
@@ -591,8 +595,18 @@ export const WebpackModulesOverallBase: React.FC<
                   </ServerAPIProvider>
                 ),
               },
+              {
+                key: 'chunk-group',
+                label: 'Chunk Group Graph',
+                children: (
+                  activeTabKey === 'chunk-group' ? (
+                    <ServerAPIProvider api={SDK.ServerAPI.API.GetChunkGroupGraph}>
+                      {(report) => <ChunkGroupGraphPanel report={report} />}
+                    </ServerAPIProvider>
+                  ) : null
+                ),
+              },
             ]}
-            defaultActiveKey="tree"
           />
         </Card>
       </div>

--- a/packages/components/src/utils/data/remote.ts
+++ b/packages/components/src/utils/data/remote.ts
@@ -16,10 +16,12 @@ export class RemoteDataLoader extends BaseDataLoader {
   public async loadData(key: string): Promise<unknown> {
     return this.limit(key, async () => {
       const [scope, ...rest] = this.getKeys(key);
-      const data = this.getData(
-        scope as keyof Manifest.RsdoctorManifestData,
-        'cloudData',
-      );
+      const data =
+        this.getData(
+          scope as keyof Manifest.RsdoctorManifestData,
+          'cloudData',
+        ) ??
+        this.getData(scope as keyof Manifest.RsdoctorManifestData, 'data');
 
       if (!data) return;
 

--- a/packages/components/src/utils/request.ts
+++ b/packages/components/src/utils/request.ts
@@ -40,11 +40,56 @@ export async function fetchJSONByUrl(url: string) {
     }
   }
 
-  return json as Manifest.RsdoctorManifestWithShardingFiles;
+  return normalizeManifestShardingUrls(
+    json as Manifest.RsdoctorManifestWithShardingFiles,
+    url,
+  );
 }
 
 export function fetchJSONByUrls(urls: string[]) {
   return Promise.all(urls.map((url) => fetchJSONByUrl(url)));
+}
+
+function normalizeManifestShardingUrls(
+  manifest: Manifest.RsdoctorManifestWithShardingFiles,
+  manifestUrl: string,
+) {
+  const resolvedManifestUrl = new URL(manifestUrl, window.location.href);
+  const isShardingPathList = (value: unknown): value is string[] =>
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((item) => typeof item === 'string');
+
+  const normalizeData = (
+    data: Manifest.RsdoctorManifestWithShardingFiles['data'],
+  ) => {
+    return Object.fromEntries(
+      Object.entries(data).map(([key, value]) => {
+        if (!isShardingPathList(value)) {
+          return [key, value];
+        }
+
+        return [
+          key,
+          value.map((item) => {
+            if (Url.isUrl(item)) {
+              return item;
+            }
+
+            return new URL(item, resolvedManifestUrl).toString();
+          }),
+        ];
+      }),
+    ) as Manifest.RsdoctorManifestWithShardingFiles['data'];
+  };
+
+  return {
+    ...manifest,
+    data: normalizeData(manifest.data),
+    cloudData: manifest.cloudData
+      ? normalizeData(manifest.cloudData)
+      : undefined,
+  };
 }
 
 export async function parseManifest(

--- a/packages/components/tests/chunk-group-helpers.test.ts
+++ b/packages/components/tests/chunk-group-helpers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from '@rstest/core';
+import { SDK } from '@rsdoctor/types';
+import { getPathParentImportSnippetLabels } from '../src/pages/BundleSize/components/chunk-group-helpers';
+
+const createEdge = (
+  from: string,
+  to: string,
+  request: string,
+  sourceModule: string,
+): SDK.ChunkGroupGraphEdgeData => ({
+  id: `${from}->${to}`,
+  from,
+  to,
+  fromName: from,
+  toName: to,
+  imports: [
+    {
+      request,
+      sourceModule,
+      loc: `${sourceModule}:1:0`,
+      snippet: `1 | import(${JSON.stringify(request)})`,
+    },
+  ],
+});
+
+describe('getPathParentImportSnippetLabels', () => {
+  it('attaches each import snippet to the parent node that performs the import', () => {
+    const mainToFoo = createEdge('main', 'foo', './foo', 'entry.js');
+    const fooToBar = createEdge('foo', 'bar', './bar', 'foo.js');
+    const snippets = getPathParentImportSnippetLabels(
+      {
+        edgeIds: [mainToFoo.id, fooToBar.id],
+      },
+      new Map([
+        [mainToFoo.id, mainToFoo],
+        [fooToBar.id, fooToBar],
+      ]),
+    );
+
+    expect(snippets.get('main')).toMatchObject({
+      file: 'entry.js:1',
+      code: 'import("./foo")',
+    });
+    expect(snippets.get('foo')).toMatchObject({
+      file: 'foo.js:1',
+      code: 'import("./bar")',
+    });
+    expect(snippets.has('bar')).toBe(false);
+  });
+});

--- a/packages/core/src/build-utils/build/chunks/chunkGroupReport.ts
+++ b/packages/core/src/build-utils/build/chunks/chunkGroupReport.ts
@@ -1,0 +1,1123 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { SDK } from '@rsdoctor/types';
+
+const JS_LIKE_EXTENSIONS = new Set([
+  '.js',
+  '.jsx',
+  '.ts',
+  '.tsx',
+  '.mjs',
+  '.cjs',
+  '.mts',
+  '.cts',
+]);
+const CHUNK_GROUP_PATH_LIMIT = 50;
+const PATH_TOP_MODULE_LIMIT = 20;
+
+type AnyChunk = any;
+type AnyChunkGroup = any;
+type AnyCompilation = any;
+type AnyModule = any;
+
+const safeInvoke = <T>(getter: () => T): T | undefined => {
+  try {
+    return getter();
+  } catch {
+    return undefined;
+  }
+};
+
+const toArray = <T>(value: Iterable<T> | ArrayLike<T> | null | undefined) => {
+  if (!value) {
+    return [] as T[];
+  }
+  return Array.from(value);
+};
+
+const getChunkGroupName = (chunkGroup: AnyChunkGroup, fallbackId: number) =>
+  String(chunkGroup?.name ?? chunkGroup?.id ?? `chunk-group-${fallbackId}`);
+
+const isInitialChunkGroup = (chunkGroup: AnyChunkGroup) => {
+  const result = safeInvoke(() => chunkGroup?.isInitial?.());
+  if (typeof result === 'boolean') {
+    return result;
+  }
+  return Boolean(chunkGroup?.initial);
+};
+
+const getModuleName = (compilation: AnyCompilation, module: AnyModule) => {
+  const requestShortener = compilation?.requestShortener;
+  return (
+    safeInvoke(() => module?.readableIdentifier?.(requestShortener)) ??
+    safeInvoke(() => module?.nameForCondition?.()) ??
+    module?.resource ??
+    safeInvoke(() => module?.identifier?.()) ??
+    'unknown-module'
+  );
+};
+
+const getModuleResource = (compilerContext: string, module: AnyModule) => {
+  const candidates = [
+    module?.resource,
+    safeInvoke(() => module?.nameForCondition?.()),
+    module?.rootModule?.resource,
+  ].filter((item): item is string => typeof item === 'string' && item.length > 0);
+
+  if (!candidates.length) {
+    return null;
+  }
+
+  return path.isAbsolute(candidates[0])
+    ? candidates[0]
+    : path.resolve(compilerContext, candidates[0]);
+};
+
+const normalizeResource = (
+  compilerContext: string,
+  resource: string | null | undefined,
+) => {
+  if (!resource) {
+    return null;
+  }
+  return path.isAbsolute(resource)
+    ? resource
+    : path.resolve(compilerContext, resource);
+};
+
+const getModuleKey = (
+  compilation: AnyCompilation,
+  compilerContext: string,
+  module: AnyModule,
+) =>
+  String(
+    safeInvoke(() => module?.identifier?.()) ??
+      getModuleResource(compilerContext, module) ??
+      getModuleName(compilation, module),
+  );
+
+const isExternalModule = (compilation: AnyCompilation, module: AnyModule) =>
+  getModuleName(compilation, module).startsWith('external ');
+
+const isJavaScriptLikeResource = (resource: string | null) =>
+  Boolean(resource && JS_LIKE_EXTENSIONS.has(path.extname(resource)));
+
+const getAssetSize = (compilation: AnyCompilation, file: string) => {
+  const directAsset = compilation?.assets?.[file];
+  if (directAsset && typeof directAsset.size === 'function') {
+    return directAsset.size();
+  }
+
+  const asset = safeInvoke(() => compilation?.getAsset?.(file));
+  if (asset?.source && typeof asset.source.size === 'function') {
+    return asset.source.size();
+  }
+
+  return 0;
+};
+
+const getModuleSizeRobust = (chunkGraph: AnyCompilation['chunkGraph'], module: AnyModule) => {
+  let size = 0;
+
+  try {
+    size = chunkGraph?.getModuleSize?.(module) ?? 0;
+  } catch {}
+
+  if (!size) {
+    try {
+      size = module?.size?.() ?? 0;
+    } catch {}
+  }
+
+  if (!size) {
+    try {
+      const sourceTypes = module?.getSourceTypes?.();
+      if (sourceTypes) {
+        for (const sourceType of sourceTypes) {
+          size += module.size(sourceType);
+        }
+      }
+    } catch {}
+  }
+
+  return size || 0;
+};
+
+const getOutgoingModules = (moduleGraph: AnyCompilation['moduleGraph'], module: AnyModule) => {
+  const targets = new Set<AnyModule>();
+  const connections = safeInvoke(() => moduleGraph?.getOutgoingConnections?.(module));
+
+  for (const connection of toArray<any>(connections)) {
+    if (!connection?.module || connection?.weak) {
+      continue;
+    }
+
+    const dependency = connection.dependency;
+    if (dependency) {
+      const parentBlock = safeInvoke(() => moduleGraph?.getParentBlock?.(dependency));
+      if (
+        parentBlock &&
+        parentBlock !== module &&
+        parentBlock?.constructor?.name?.includes('AsyncDependenciesBlock')
+      ) {
+        continue;
+      }
+    }
+
+    targets.add(connection.module);
+  }
+
+  return targets;
+};
+
+const getGroupModules = (
+  chunkGroup: AnyChunkGroup,
+  chunkModulesMap: Map<AnyChunk, Set<AnyModule>>,
+) => {
+  const modules = new Set<AnyModule>();
+
+  for (const chunk of toArray<AnyChunk>(chunkGroup?.chunks)) {
+    for (const module of chunkModulesMap.get(chunk) ?? []) {
+      modules.add(module);
+    }
+  }
+
+  return modules;
+};
+
+const getRootModules = (
+  chunkGroup: AnyChunkGroup,
+  actualModules: Set<AnyModule>,
+  chunkGraph: AnyCompilation['chunkGraph'],
+  moduleGraph: AnyCompilation['moduleGraph'],
+) => {
+  const roots = new Set<AnyModule>();
+
+  if (isInitialChunkGroup(chunkGroup)) {
+    for (const chunk of toArray<AnyChunk>(chunkGroup?.chunks)) {
+      const entryModules = safeInvoke(() =>
+        chunkGraph?.getChunkEntryModulesIterable?.(chunk),
+      );
+      for (const module of toArray<AnyModule>(entryModules)) {
+        roots.add(module);
+      }
+    }
+    return roots;
+  }
+
+  for (const origin of toArray<any>(chunkGroup?.origins)) {
+    if (origin?.dependency) {
+      const targetModule = safeInvoke(() => moduleGraph?.getModule?.(origin.dependency));
+      if (targetModule) {
+        roots.add(targetModule);
+        continue;
+      }
+    }
+
+    if (!origin?.module) {
+      continue;
+    }
+
+    const blocks = toArray<any>(safeInvoke(() => origin.module.blocks));
+    for (const block of blocks) {
+      for (const dependency of toArray<any>(block?.dependencies)) {
+        const targetModule = safeInvoke(() => moduleGraph?.getModule?.(dependency));
+        if (targetModule && actualModules.has(targetModule)) {
+          roots.add(targetModule);
+        }
+      }
+    }
+  }
+
+  if (!roots.size) {
+    for (const chunk of toArray<AnyChunk>(chunkGroup?.chunks)) {
+      const entryModules = safeInvoke(() =>
+        chunkGraph?.getChunkEntryModulesIterable?.(chunk),
+      );
+      for (const module of toArray<AnyModule>(entryModules)) {
+        roots.add(module);
+      }
+    }
+  }
+
+  return roots;
+};
+
+const buildSnippet = (
+  linesCache: Map<string, string[] | null>,
+  absolutePath: string,
+  loc: any,
+) => {
+  if (!loc?.start?.line) {
+    return '';
+  }
+
+  let lines = linesCache.get(absolutePath);
+  if (!linesCache.has(absolutePath)) {
+    try {
+      lines = fs.readFileSync(absolutePath, 'utf8').split('\n');
+    } catch {
+      lines = null;
+    }
+    linesCache.set(absolutePath, lines);
+  }
+
+  if (!lines) {
+    return '';
+  }
+
+  const startLine = Math.max(0, loc.start.line - 1);
+  const endLine = loc?.end?.line
+    ? Math.min(lines.length, loc.end.line)
+    : startLine + 1;
+
+  return lines
+    .slice(startLine, Math.min(endLine, startLine + 3))
+    .map((line, index) => `${startLine + index + 1} | ${line}`)
+    .join('\n');
+};
+
+type InternalChunkGroupNode = Omit<
+  SDK.ChunkGroupGraphNodeData,
+  | 'removableJSModuleCount'
+  | 'removableJSSize'
+  | 'inheritedRemovableJSModuleCount'
+  | 'inheritedRemovableJSSize'
+  | 'inheritedRemovableJSModules'
+  | 'removableJSModules'
+> & {
+  localRemovableById: Map<string, SDK.ChunkGroupGraphModuleData>;
+};
+
+const buildAdjacencyMaps = (edges: SDK.ChunkGroupGraphEdgeData[]) => {
+  const forward = new Map<string, string[]>();
+  const reverse = new Map<string, string[]>();
+
+  for (const edge of edges) {
+    if (!forward.has(edge.from)) {
+      forward.set(edge.from, []);
+    }
+    forward.get(edge.from)!.push(edge.to);
+
+    if (!reverse.has(edge.to)) {
+      reverse.set(edge.to, []);
+    }
+    reverse.get(edge.to)!.push(edge.from);
+  }
+
+  return {
+    forward,
+    reverse,
+  };
+};
+
+const intersectModuleMaps = (
+  maps: Array<Map<string, SDK.ChunkGroupGraphModuleData>>,
+) => {
+  if (!maps.length) {
+    return new Map<string, SDK.ChunkGroupGraphModuleData>();
+  }
+
+  const [first, ...rest] = maps;
+  const result = new Map(first);
+
+  for (const key of [...result.keys()]) {
+    if (!rest.every((map) => map.has(key))) {
+      result.delete(key);
+    }
+  }
+
+  return result;
+};
+
+const sumModuleSizes = (
+  modules: Iterable<SDK.ChunkGroupGraphModuleData>,
+) => {
+  let total = 0;
+  for (const module of modules) {
+    total += module.size;
+  }
+  return total;
+};
+
+const getPathEdgeIds = (nodeIds: string[]) => {
+  const edgeIds: string[] = [];
+  for (let index = 0; index < nodeIds.length - 1; index++) {
+    edgeIds.push(`${nodeIds[index]}->${nodeIds[index + 1]}`);
+  }
+  return edgeIds;
+};
+
+const getPathSeverity = (
+  unnecessarySize: number,
+  totalJSSize: number,
+): SDK.ChunkGroupGraphPathSeverity => {
+  const ratio = totalJSSize > 0 ? unnecessarySize / totalJSSize : 0;
+  if (ratio > 1 / 3) {
+    return 'danger';
+  }
+  if (unnecessarySize > 0) {
+    return 'warning';
+  }
+  return 'normal';
+};
+
+const getSeverityRank = (severity: SDK.ChunkGroupGraphPathSeverity) => {
+  if (severity === 'danger') {
+    return 2;
+  }
+  if (severity === 'warning') {
+    return 1;
+  }
+  return 0;
+};
+
+const findPathsToTarget = (
+  targetId: string,
+  entryIds: string[],
+  forwardAdjacency: Map<string, string[]>,
+  fallbackNodeId?: string,
+  maxPaths = CHUNK_GROUP_PATH_LIMIT,
+) => {
+  const paths: string[][] = [];
+  let truncated = false;
+  const entries = entryIds.length
+    ? entryIds
+    : fallbackNodeId
+      ? [fallbackNodeId]
+      : [];
+
+  const dfs = (
+    current: string,
+    visited: Set<string>,
+    currentPath: string[],
+  ) => {
+    if (paths.length >= maxPaths) {
+      truncated = true;
+      return;
+    }
+
+    if (current === targetId) {
+      paths.push([...currentPath]);
+      return;
+    }
+
+    for (const next of forwardAdjacency.get(current) ?? []) {
+      if (visited.has(next)) {
+        continue;
+      }
+      visited.add(next);
+      currentPath.push(next);
+      dfs(next, visited, currentPath);
+      currentPath.pop();
+      visited.delete(next);
+
+      if (paths.length >= maxPaths) {
+        truncated = true;
+        return;
+      }
+    }
+  };
+
+  for (const entryId of entries) {
+    dfs(entryId, new Set([entryId]), [entryId]);
+    if (paths.length >= maxPaths) {
+      truncated = true;
+      break;
+    }
+  }
+
+  if (!paths.length && entries.includes(targetId)) {
+    paths.push([targetId]);
+  }
+
+  return {
+    paths,
+    truncated,
+  };
+};
+
+const buildNodeSearchText = (
+  node: Pick<
+    SDK.ChunkGroupGraphNodeData,
+    | 'name'
+    | 'chunks'
+    | 'localRemovableJSModules'
+    | 'removableJSModules'
+    | 'inheritedRemovableJSModules'
+  >,
+  incomingImports: SDK.ChunkGroupGraphIncomingImportData[],
+) => {
+  const parts = new Set<string>();
+  const addPart = (value: string | null | undefined) => {
+    if (!value) {
+      return;
+    }
+    const normalized = value.trim();
+    if (normalized) {
+      parts.add(normalized);
+    }
+  };
+
+  addPart(node.name);
+  node.chunks.forEach((chunk) => {
+    addPart(chunk.name);
+    chunk.files.forEach((file) => addPart(file));
+  });
+  [
+    ...node.localRemovableJSModules,
+    ...node.removableJSModules,
+    ...node.inheritedRemovableJSModules,
+  ].forEach((module) => {
+    addPart(module.resource);
+    addPart(module.name);
+  });
+  incomingImports.forEach((item) => {
+    addPart(item.fromName);
+    addPart(item.request);
+    addPart(item.sourceModule);
+    addPart(item.loc);
+  });
+
+  return [...parts].join('\n');
+};
+
+export function buildChunkGroupGraphReport(
+  compilation: AnyCompilation,
+  compilerContext: string,
+): SDK.ChunkGroupGraphData | undefined {
+  const chunkGraph = compilation?.chunkGraph;
+  const moduleGraph = compilation?.moduleGraph;
+  const chunkGroups = toArray<AnyChunkGroup>(compilation?.chunkGroups);
+
+  if (!chunkGraph || !moduleGraph || !chunkGroups.length) {
+    return undefined;
+  }
+
+  const chunkModulesMap = new Map<AnyChunk, Set<AnyModule>>();
+  for (const chunk of toArray<AnyChunk>(compilation?.chunks)) {
+    const modules = new Set<AnyModule>();
+    const chunkModules = safeInvoke(() => chunkGraph?.getChunkModulesIterable?.(chunk));
+    for (const module of toArray<AnyModule>(chunkModules)) {
+      modules.add(module);
+    }
+    chunkModulesMap.set(chunk, modules);
+  }
+
+  const chunkToGroups = new Map<AnyChunk, Set<AnyChunkGroup>>();
+  for (const chunkGroup of chunkGroups) {
+    for (const chunk of toArray<AnyChunk>(chunkGroup?.chunks)) {
+      if (!chunkToGroups.has(chunk)) {
+        chunkToGroups.set(chunk, new Set());
+      }
+      chunkToGroups.get(chunk)!.add(chunkGroup);
+    }
+  }
+
+  const resourceToGroups = new Map<string, Set<AnyChunkGroup>>();
+  const registerResourceGroups = (
+    resource: string | null | undefined,
+    groups: Set<AnyChunkGroup>,
+  ) => {
+    const normalizedResource = normalizeResource(compilerContext, resource);
+    if (!normalizedResource) {
+      return;
+    }
+    if (!resourceToGroups.has(normalizedResource)) {
+      resourceToGroups.set(normalizedResource, new Set());
+    }
+    for (const group of groups) {
+      resourceToGroups.get(normalizedResource)!.add(group);
+    }
+  };
+
+  for (const chunk of toArray<AnyChunk>(compilation?.chunks)) {
+    const groups = chunkToGroups.get(chunk) ?? new Set<AnyChunkGroup>();
+    for (const module of chunkModulesMap.get(chunk) ?? []) {
+      registerResourceGroups(
+        module?.resource ?? safeInvoke(() => module?.nameForCondition?.()),
+        groups,
+      );
+      registerResourceGroups(module?.rootModule?.resource, groups);
+
+      for (const innerModule of toArray<any>(safeInvoke(() => module?.modules))) {
+        registerResourceGroups(
+          innerModule?.resource ??
+            safeInvoke(() => innerModule?.nameForCondition?.()),
+          groups,
+        );
+      }
+    }
+  }
+
+  const chunkGroupIdMap = new Map<AnyChunkGroup, string>();
+  const localNodes: InternalChunkGroupNode[] = [];
+
+  chunkGroups.forEach((chunkGroup: AnyChunkGroup, index) => {
+    const nodeId = `cg_${index}`;
+    chunkGroupIdMap.set(chunkGroup, nodeId);
+
+    const actualModules = getGroupModules(chunkGroup, chunkModulesMap);
+    const roots = getRootModules(chunkGroup, actualModules, chunkGraph, moduleGraph);
+    const visited = new Set<AnyModule>();
+    const queue = [...roots];
+
+    while (queue.length) {
+      const current = queue.shift();
+      if (!current || visited.has(current)) {
+        continue;
+      }
+      visited.add(current);
+
+      for (const target of getOutgoingModules(moduleGraph, current)) {
+        if (!visited.has(target)) {
+          queue.push(target);
+        }
+      }
+    }
+
+    const reachableModules = new Set<AnyModule>();
+    for (const module of actualModules) {
+      if (visited.has(module)) {
+        reachableModules.add(module);
+      }
+    }
+
+    for (const module of actualModules) {
+      if (reachableModules.has(module)) {
+        continue;
+      }
+
+      const incomingConnections = safeInvoke(() =>
+        moduleGraph?.getIncomingConnections?.(module),
+      );
+      for (const connection of toArray<any>(incomingConnections)) {
+        if (
+          !connection?.originModule ||
+          connection.originModule === module ||
+          connection.weak
+        ) {
+          continue;
+        }
+
+        const originName = getModuleName(compilation, connection.originModule);
+        if (visited.has(connection.originModule) || originName.includes(' + ')) {
+          reachableModules.add(module);
+          break;
+        }
+      }
+    }
+
+    let totalEmittedSize = 0;
+    let groupTotalJSSize = 0;
+
+    const chunks = toArray<AnyChunk>(chunkGroup?.chunks)
+      .map((chunk: AnyChunk) => {
+        const chunkId = String(chunk?.id ?? chunk?.ukey ?? chunk?.name ?? 'unknown');
+        let emittedSize = 0;
+        const files = toArray<string>(chunk?.files).filter(
+          (file): file is string =>
+            typeof file === 'string' && file.endsWith('.js'),
+        );
+
+        for (const file of files) {
+          emittedSize += getAssetSize(compilation, file);
+        }
+
+        let totalJSSize = 0;
+        const chunkModules = chunkModulesMap.get(chunk) ?? new Set<AnyModule>();
+        for (const module of chunkModules) {
+          totalJSSize += getModuleSizeRobust(chunkGraph, module);
+        }
+
+        totalEmittedSize += emittedSize;
+        groupTotalJSSize += totalJSSize;
+
+        return {
+          id: chunkId,
+          name: String(chunk?.name ?? chunk?.id ?? chunkId),
+          emittedSize,
+          totalJSSize,
+          moduleCount: chunkModules.size,
+          files,
+        };
+      })
+      .sort((a, b) => b.emittedSize - a.emittedSize);
+
+    const localRemovableJSModules: SDK.ChunkGroupGraphModuleData[] = [];
+    let nonJSResidualCount = 0;
+
+    for (const module of actualModules) {
+      if (reachableModules.has(module) || isExternalModule(compilation, module)) {
+        continue;
+      }
+
+      const resource = getModuleResource(compilerContext, module);
+      const size = getModuleSizeRobust(chunkGraph, module);
+
+      if (isJavaScriptLikeResource(resource)) {
+        localRemovableJSModules.push({
+          id: getModuleKey(compilation, compilerContext, module),
+          name: getModuleName(compilation, module),
+          resource: resource ? path.relative(compilerContext, resource) : null,
+          size,
+        });
+      } else {
+        nonJSResidualCount++;
+      }
+    }
+
+    const sortedLocalRemovableJSModules = localRemovableJSModules.sort(
+      (a, b) => b.size - a.size,
+    );
+
+    localNodes.push({
+      id: nodeId,
+      name: getChunkGroupName(chunkGroup, index),
+      isInitial: isInitialChunkGroup(chunkGroup),
+      totalEmittedSize,
+      groupTotalJSSize,
+      actualModuleCount: actualModules.size,
+      rootModuleCount: roots.size,
+      reachableModuleCount: reachableModules.size,
+      localRemovableJSModuleCount: sortedLocalRemovableJSModules.length,
+      localRemovableJSSize: sumModuleSizes(sortedLocalRemovableJSModules),
+      nonJSResidualCount,
+      chunks,
+      localRemovableJSModules: sortedLocalRemovableJSModules,
+      localRemovableById: new Map(
+        sortedLocalRemovableJSModules.map((module) => [module.id, module]),
+      ),
+    });
+  });
+
+  const sourceFileCache = new Map<string, string[] | null>();
+  const edgeMap = new Map<string, SDK.ChunkGroupGraphEdgeData>();
+
+  for (const chunkGroup of chunkGroups) {
+    if (isInitialChunkGroup(chunkGroup)) {
+      continue;
+    }
+
+    const targetId = chunkGroupIdMap.get(chunkGroup);
+    if (!targetId) {
+      continue;
+    }
+
+    for (const origin of toArray<any>(chunkGroup?.origins)) {
+      if (!origin?.module) {
+        continue;
+      }
+
+      const moduleResource = getModuleResource(compilerContext, origin.module);
+      const relativeModulePath = moduleResource
+        ? path.relative(compilerContext, moduleResource)
+        : null;
+      const snippet = moduleResource
+        ? buildSnippet(sourceFileCache, moduleResource, origin.loc)
+        : '';
+      const loc = origin?.loc?.start
+        ? `${relativeModulePath ?? '?'}:${origin.loc.start.line}:${origin.loc.start.column}`
+        : relativeModulePath ?? '';
+
+      const sourceGroups = new Set<AnyChunkGroup>();
+      const originResources = [
+        origin.module?.resource,
+        safeInvoke(() => origin.module?.nameForCondition?.()),
+        origin.module?.rootModule?.resource,
+      ].filter((item): item is string => typeof item === 'string' && item.length > 0);
+
+      for (const resource of originResources) {
+        const normalizedResource = normalizeResource(compilerContext, resource);
+        if (!normalizedResource) {
+          continue;
+        }
+        for (const group of resourceToGroups.get(normalizedResource) ?? []) {
+          sourceGroups.add(group);
+        }
+      }
+
+      for (const sourceGroup of sourceGroups) {
+        const sourceId = chunkGroupIdMap.get(sourceGroup);
+        if (!sourceId || sourceId === targetId) {
+          continue;
+        }
+
+        const edgeId = `${sourceId}->${targetId}`;
+        if (!edgeMap.has(edgeId)) {
+          edgeMap.set(edgeId, {
+            id: edgeId,
+            from: sourceId,
+            to: targetId,
+            fromName: '',
+            toName: '',
+            imports: [],
+          });
+        }
+
+        const edge = edgeMap.get(edgeId)!;
+        const request = String(origin?.request ?? '');
+        const isDuplicate = edge.imports.some(
+          (item) =>
+            item.loc === loc &&
+            item.request === request &&
+            item.sourceModule === relativeModulePath,
+        );
+
+        if (!isDuplicate) {
+          edge.imports.push({
+            ...(loc ? { loc } : {}),
+            ...(request ? { request } : {}),
+            ...(snippet ? { snippet } : {}),
+            ...(relativeModulePath ? { sourceModule: relativeModulePath } : {}),
+          });
+        }
+      }
+    }
+  }
+
+  const edges = [...edgeMap.values()];
+  const { forward, reverse } = buildAdjacencyMaps(edges);
+  const indegree = new Map<string, number>(
+    localNodes.map((node) => [node.id, reverse.get(node.id)?.length ?? 0]),
+  );
+  const zeroIndegreeQueue = localNodes
+    .filter((node) => (indegree.get(node.id) ?? 0) === 0)
+    .sort((a, b) => {
+      if (a.isInitial !== b.isInitial) {
+        return a.isInitial ? -1 : 1;
+      }
+      return a.name.localeCompare(b.name);
+    })
+    .map((node) => node.id);
+  const topologicalOrder: string[] = [];
+
+  while (zeroIndegreeQueue.length) {
+    const currentId = zeroIndegreeQueue.shift()!;
+    topologicalOrder.push(currentId);
+
+    for (const nextId of forward.get(currentId) ?? []) {
+      const nextIndegree = (indegree.get(nextId) ?? 0) - 1;
+      indegree.set(nextId, nextIndegree);
+      if (nextIndegree === 0) {
+        zeroIndegreeQueue.push(nextId);
+      }
+    }
+  }
+
+  for (const node of localNodes) {
+    if (!topologicalOrder.includes(node.id)) {
+      topologicalOrder.push(node.id);
+    }
+  }
+
+  const nodeMap = new Map(localNodes.map((node) => [node.id, node]));
+  const guaranteedInclusiveRemovableByNode = new Map<
+    string,
+    Map<string, SDK.ChunkGroupGraphModuleData>
+  >();
+  const incrementalRemovableByNode = new Map<
+    string,
+    Map<string, SDK.ChunkGroupGraphModuleData>
+  >();
+  const inheritedRemovableByNode = new Map<
+    string,
+    Map<string, SDK.ChunkGroupGraphModuleData>
+  >();
+
+  for (const nodeId of topologicalOrder) {
+    const node = nodeMap.get(nodeId);
+    if (!node) {
+      continue;
+    }
+
+    const parentSets = (reverse.get(nodeId) ?? [])
+      .map((parentId) => guaranteedInclusiveRemovableByNode.get(parentId))
+      .filter(
+        (
+          modules,
+        ): modules is Map<string, SDK.ChunkGroupGraphModuleData> =>
+          Boolean(modules),
+      );
+    const guaranteedBefore = intersectModuleMaps(parentSets);
+    const incrementalRemovable = new Map<string, SDK.ChunkGroupGraphModuleData>();
+    const inheritedRemovable = new Map<string, SDK.ChunkGroupGraphModuleData>();
+
+    for (const [moduleId, module] of node.localRemovableById) {
+      if (guaranteedBefore.has(moduleId)) {
+        inheritedRemovable.set(moduleId, module);
+      } else {
+        incrementalRemovable.set(moduleId, module);
+      }
+    }
+
+    const guaranteedInclusive = new Map(guaranteedBefore);
+    for (const [moduleId, module] of node.localRemovableById) {
+      guaranteedInclusive.set(moduleId, module);
+    }
+
+    guaranteedInclusiveRemovableByNode.set(nodeId, guaranteedInclusive);
+    incrementalRemovableByNode.set(nodeId, incrementalRemovable);
+    inheritedRemovableByNode.set(nodeId, inheritedRemovable);
+  }
+
+  const baseNodes = localNodes.map((node) => {
+    const incrementalRemovable = [
+      ...(incrementalRemovableByNode.get(node.id)?.values() ?? []),
+    ].sort((a, b) => b.size - a.size);
+    const inheritedRemovable = [
+      ...(inheritedRemovableByNode.get(node.id)?.values() ?? []),
+    ].sort((a, b) => b.size - a.size);
+
+    return {
+      id: node.id,
+      name: node.name,
+      isInitial: node.isInitial,
+      totalEmittedSize: node.totalEmittedSize,
+      groupTotalJSSize: node.groupTotalJSSize,
+      actualModuleCount: node.actualModuleCount,
+      rootModuleCount: node.rootModuleCount,
+      reachableModuleCount: node.reachableModuleCount,
+      localRemovableJSModuleCount: node.localRemovableJSModuleCount,
+      localRemovableJSSize: node.localRemovableJSSize,
+      removableJSModuleCount: incrementalRemovable.length,
+      removableJSSize: sumModuleSizes(incrementalRemovable),
+      inheritedRemovableJSModuleCount: inheritedRemovable.length,
+      inheritedRemovableJSSize: sumModuleSizes(inheritedRemovable),
+      nonJSResidualCount: node.nonJSResidualCount,
+      chunks: node.chunks,
+      localRemovableJSModules: node.localRemovableJSModules,
+      inheritedRemovableJSModules: inheritedRemovable,
+      removableJSModules: incrementalRemovable,
+    };
+  });
+
+  const entryNodeIds = baseNodes
+    .filter((node) => node.isInitial)
+    .map((node) => node.id);
+  const fallbackNodeId = baseNodes[0]?.id;
+  const baseNodeMap = new Map(baseNodes.map((node) => [node.id, node]));
+  const enrichedEdges: SDK.ChunkGroupGraphEdgeData[] = edges.map((edge) => ({
+    ...edge,
+    fromName: baseNodeMap.get(edge.from)?.name ?? edge.from,
+    toName: baseNodeMap.get(edge.to)?.name ?? edge.to,
+  }));
+  const incomingEdgesByNode = new Map<string, SDK.ChunkGroupGraphEdgeData[]>();
+  const outgoingEdgesByNode = new Map<string, SDK.ChunkGroupGraphEdgeData[]>();
+
+  for (const edge of enrichedEdges) {
+    if (!incomingEdgesByNode.has(edge.to)) {
+      incomingEdgesByNode.set(edge.to, []);
+    }
+    incomingEdgesByNode.get(edge.to)!.push(edge);
+
+    if (!outgoingEdgesByNode.has(edge.from)) {
+      outgoingEdgesByNode.set(edge.from, []);
+    }
+    outgoingEdgesByNode.get(edge.from)!.push(edge);
+  }
+
+  const nodes: SDK.ChunkGroupGraphNodeData[] = baseNodes.map((node) => {
+    const incomingEdges = incomingEdgesByNode.get(node.id) ?? [];
+    const outgoingEdges = outgoingEdgesByNode.get(node.id) ?? [];
+    const incomingImports = incomingEdges
+      .flatMap((edge) =>
+        edge.imports.map((item) => ({
+          ...item,
+          edgeId: edge.id,
+          from: edge.from,
+          fromName: edge.fromName,
+          to: edge.to,
+          toName: edge.toName,
+        })),
+      )
+      .sort((a, b) => {
+        if (a.fromName !== b.fromName) {
+          return a.fromName.localeCompare(b.fromName);
+        }
+        return (a.request ?? '').localeCompare(b.request ?? '');
+      });
+
+    const { paths: nodePaths, truncated } = findPathsToTarget(
+      node.id,
+      entryNodeIds,
+      forward,
+      fallbackNodeId,
+      CHUNK_GROUP_PATH_LIMIT,
+    );
+
+    const paths = nodePaths
+      .map((nodeIds, index) => {
+        const uniqueChunks = new Map<string, SDK.ChunkGroupGraphChunkData>();
+        const unnecessaryModules = new Map<
+          string,
+          SDK.ChunkGroupGraphModuleData
+        >();
+        const nodeNames = nodeIds.map(
+          (nodeId) => baseNodeMap.get(nodeId)?.name ?? nodeId,
+        );
+
+        nodeIds.forEach((nodeId) => {
+          const pathNode = baseNodeMap.get(nodeId);
+          if (!pathNode) {
+            return;
+          }
+
+          pathNode.chunks.forEach((chunk) => {
+            if (!uniqueChunks.has(chunk.id)) {
+              uniqueChunks.set(chunk.id, chunk);
+            }
+          });
+
+          pathNode.localRemovableJSModules.forEach((module) => {
+            if (!unnecessaryModules.has(module.id)) {
+              unnecessaryModules.set(module.id, module);
+            }
+          });
+        });
+
+        const chunks = [...uniqueChunks.values()].sort(
+          (a, b) => b.emittedSize - a.emittedSize,
+        );
+        const allUnnecessaryModules = [...unnecessaryModules.values()].sort(
+          (a, b) => b.size - a.size,
+        );
+        const totalEmittedSize = chunks.reduce(
+          (total, chunk) => total + chunk.emittedSize,
+          0,
+        );
+        const totalJSSize = chunks.reduce(
+          (total, chunk) => total + chunk.totalJSSize,
+          0,
+        );
+        const unnecessarySize = sumModuleSizes(allUnnecessaryModules);
+        const ratio = totalJSSize > 0 ? unnecessarySize / totalJSSize : 0;
+
+        return {
+          id: nodeIds.join('->') || `path_${index}`,
+          label: nodeNames.join(' → '),
+          nodeIds,
+          nodeNames,
+          edgeIds: getPathEdgeIds(nodeIds),
+          chunkIds: chunks.map((chunk) => chunk.id),
+          chunks,
+          totalEmittedSize,
+          totalJSSize,
+          unnecessarySize,
+          unnecessaryModuleCount: allUnnecessaryModules.length,
+          ratio,
+          severity: getPathSeverity(unnecessarySize, totalJSSize),
+          topUnnecessaryModules: allUnnecessaryModules.slice(
+            0,
+            PATH_TOP_MODULE_LIMIT,
+          ),
+        } satisfies SDK.ChunkGroupGraphPathData;
+      })
+      .sort((a, b) => {
+        if (a.unnecessarySize !== b.unnecessarySize) {
+          return b.unnecessarySize - a.unnecessarySize;
+        }
+        if (a.ratio !== b.ratio) {
+          return b.ratio - a.ratio;
+        }
+        return b.totalJSSize - a.totalJSSize;
+      });
+
+    const maxPathUnnecessarySize = Math.max(
+      0,
+      ...paths.map((path) => path.unnecessarySize),
+    );
+    const maxPathRatio = Math.max(0, ...paths.map((path) => path.ratio));
+    const worstPathSeverity = paths.reduce<SDK.ChunkGroupGraphPathSeverity>(
+      (current, path) =>
+        getSeverityRank(path.severity) > getSeverityRank(current)
+          ? path.severity
+          : current,
+      'normal',
+    );
+
+    return {
+      ...node,
+      incomingEdgeIds: incomingEdges.map((edge) => edge.id),
+      outgoingEdgeIds: outgoingEdges.map((edge) => edge.id),
+      incomingImports,
+      paths,
+      pathCount: paths.length,
+      pathsTruncated: truncated,
+      worstPathSeverity,
+      maxPathUnnecessarySize,
+      maxPathRatio,
+      searchText: buildNodeSearchText(node, incomingImports),
+    };
+  });
+
+  const priorityNodeIds = [...nodes]
+    .sort((a, b) => {
+      if (a.maxPathUnnecessarySize !== b.maxPathUnnecessarySize) {
+        return b.maxPathUnnecessarySize - a.maxPathUnnecessarySize;
+      }
+      if (a.removableJSSize !== b.removableJSSize) {
+        return b.removableJSSize - a.removableJSSize;
+      }
+      if (getSeverityRank(a.worstPathSeverity) !== getSeverityRank(b.worstPathSeverity)) {
+        return getSeverityRank(b.worstPathSeverity) - getSeverityRank(a.worstPathSeverity);
+      }
+      if (a.maxPathRatio !== b.maxPathRatio) {
+        return b.maxPathRatio - a.maxPathRatio;
+      }
+      if (a.totalEmittedSize !== b.totalEmittedSize) {
+        return b.totalEmittedSize - a.totalEmittedSize;
+      }
+      return a.name.localeCompare(b.name);
+    })
+    .map((node) => node.id);
+
+  const overview: SDK.ChunkGroupGraphOverviewData = {
+    totalGroupCount: nodes.length,
+    entryGroupCount: nodes.filter((node) => node.isInitial).length,
+    asyncGroupCount: nodes.filter((node) => !node.isInitial).length,
+    totalEdgeCount: enrichedEdges.length,
+    removableGroupCount: nodes.filter((node) => node.removableJSSize > 0).length,
+    warningGroupCount: nodes.filter(
+      (node) => node.worstPathSeverity === 'warning',
+    ).length,
+    dangerGroupCount: nodes.filter(
+      (node) => node.worstPathSeverity === 'danger',
+    ).length,
+    totalRemovableSize: nodes.reduce(
+      (total, node) => total + node.removableJSSize,
+      0,
+    ),
+    totalLocalRemovableSize: nodes.reduce(
+      (total, node) => total + node.localRemovableJSSize,
+      0,
+    ),
+    totalInheritedRemovableSize: nodes.reduce(
+      (total, node) => total + node.inheritedRemovableJSSize,
+      0,
+    ),
+    totalPathCount: nodes.reduce((total, node) => total + node.pathCount, 0),
+    warningPathCount: nodes.reduce(
+      (total, node) =>
+        total +
+        node.paths.filter((path) => path.severity === 'warning').length,
+      0,
+    ),
+    dangerPathCount: nodes.reduce(
+      (total, node) =>
+        total +
+        node.paths.filter((path) => path.severity === 'danger').length,
+      0,
+    ),
+    truncatedPathGroupCount: nodes.filter((node) => node.pathsTruncated).length,
+  };
+
+  return {
+    nodes,
+    edges: enrichedEdges,
+    overview,
+    entryNodeIds,
+    priorityNodeIds,
+    pathLimit: CHUNK_GROUP_PATH_LIMIT,
+  };
+}

--- a/packages/core/src/build-utils/build/chunks/chunkGroupReport.ts
+++ b/packages/core/src/build-utils/build/chunks/chunkGroupReport.ts
@@ -38,6 +38,36 @@ const toArray = <T>(value: Iterable<T> | ArrayLike<T> | null | undefined) => {
 const getChunkGroupName = (chunkGroup: AnyChunkGroup, fallbackId: number) =>
   String(chunkGroup?.name ?? chunkGroup?.id ?? `chunk-group-${fallbackId}`);
 
+const getChunkId = (chunk: AnyChunk) =>
+  String(chunk?.id ?? chunk?.ukey ?? chunk?.name ?? '');
+
+const getChunkGroupChunkSignature = (chunkGroup: AnyChunkGroup) =>
+  toArray<AnyChunk>(chunkGroup?.chunks)
+    .map(getChunkId)
+    .filter(Boolean)
+    .sort()
+    .join('|');
+
+const isSameChunkGroup = (
+  left: AnyChunkGroup | null | undefined,
+  right: AnyChunkGroup | null | undefined,
+) => {
+  if (!left || !right) {
+    return false;
+  }
+  if (left === right) {
+    return true;
+  }
+
+  if (left.name && right.name && String(left.name) === String(right.name)) {
+    return true;
+  }
+
+  const leftSignature = getChunkGroupChunkSignature(left);
+  const rightSignature = getChunkGroupChunkSignature(right);
+  return Boolean(leftSignature && leftSignature === rightSignature);
+};
+
 const isInitialChunkGroup = (chunkGroup: AnyChunkGroup) => {
   const result = safeInvoke(() => chunkGroup?.isInitial?.());
   if (typeof result === 'boolean') {
@@ -143,9 +173,38 @@ const getModuleSizeRobust = (chunkGraph: AnyCompilation['chunkGraph'], module: A
   return size || 0;
 };
 
+const collectAsyncBlockDependencies = (module: AnyModule) => {
+  const dependencies = new Set<any>();
+  const queue = [...toArray<any>(safeInvoke(() => module?.blocks))];
+
+  while (queue.length) {
+    const block = queue.shift();
+    if (!block) {
+      continue;
+    }
+
+    for (const dependency of toArray<any>(safeInvoke(() => block?.dependencies))) {
+      dependencies.add(dependency);
+    }
+
+    queue.push(...toArray<any>(safeInvoke(() => block?.blocks)));
+  }
+
+  return dependencies;
+};
+
+const hasAsyncBlockParent = (
+  moduleGraph: AnyCompilation['moduleGraph'],
+  dependency: any,
+) => {
+  const parentBlock = safeInvoke(() => moduleGraph?.getParentBlock?.(dependency));
+  return Boolean(parentBlock?.constructor?.name?.includes('AsyncDependenciesBlock'));
+};
+
 const getOutgoingModules = (moduleGraph: AnyCompilation['moduleGraph'], module: AnyModule) => {
   const targets = new Set<AnyModule>();
   const connections = safeInvoke(() => moduleGraph?.getOutgoingConnections?.(module));
+  let asyncBlockDependencies: Set<any> | undefined;
 
   for (const connection of toArray<any>(connections)) {
     if (!connection?.module || connection?.weak) {
@@ -154,12 +213,12 @@ const getOutgoingModules = (moduleGraph: AnyCompilation['moduleGraph'], module: 
 
     const dependency = connection.dependency;
     if (dependency) {
-      const parentBlock = safeInvoke(() => moduleGraph?.getParentBlock?.(dependency));
-      if (
-        parentBlock &&
-        parentBlock !== module &&
-        parentBlock?.constructor?.name?.includes('AsyncDependenciesBlock')
-      ) {
+      if (hasAsyncBlockParent(moduleGraph, dependency)) {
+        continue;
+      }
+
+      asyncBlockDependencies ??= collectAsyncBlockDependencies(module);
+      if (asyncBlockDependencies.has(dependency)) {
         continue;
       }
     }
@@ -192,6 +251,13 @@ const getRootModules = (
   moduleGraph: AnyCompilation['moduleGraph'],
 ) => {
   const roots = new Set<AnyModule>();
+  const canReadBlockChunkGroup = typeof chunkGraph?.getBlockChunkGroup === 'function';
+  const addDependencyRoot = (dependency: any, requireActualModule: boolean) => {
+    const targetModule = safeInvoke(() => moduleGraph?.getModule?.(dependency));
+    if (targetModule && (!requireActualModule || actualModules.has(targetModule))) {
+      roots.add(targetModule);
+    }
+  };
 
   if (isInitialChunkGroup(chunkGroup)) {
     for (const chunk of toArray<AnyChunk>(chunkGroup?.chunks)) {
@@ -207,9 +273,9 @@ const getRootModules = (
 
   for (const origin of toArray<any>(chunkGroup?.origins)) {
     if (origin?.dependency) {
-      const targetModule = safeInvoke(() => moduleGraph?.getModule?.(origin.dependency));
-      if (targetModule) {
-        roots.add(targetModule);
+      const rootCountBeforeDependency = roots.size;
+      addDependencyRoot(origin.dependency, false);
+      if (roots.size > rootCountBeforeDependency) {
         continue;
       }
     }
@@ -220,11 +286,25 @@ const getRootModules = (
 
     const blocks = toArray<any>(safeInvoke(() => origin.module.blocks));
     for (const block of blocks) {
-      for (const dependency of toArray<any>(block?.dependencies)) {
-        const targetModule = safeInvoke(() => moduleGraph?.getModule?.(dependency));
-        if (targetModule && actualModules.has(targetModule)) {
-          roots.add(targetModule);
+      let hasPreciseBlockMapping = false;
+
+      if (canReadBlockChunkGroup) {
+        const blockChunkGroup = safeInvoke(() =>
+          chunkGraph?.getBlockChunkGroup?.(block),
+        );
+        if (blockChunkGroup === null) {
+          continue;
         }
+        if (blockChunkGroup) {
+          if (!isSameChunkGroup(blockChunkGroup, chunkGroup)) {
+            continue;
+          }
+          hasPreciseBlockMapping = true;
+        }
+      }
+
+      for (const dependency of toArray<any>(block?.dependencies)) {
+        addDependencyRoot(dependency, !hasPreciseBlockMapping);
       }
     }
   }

--- a/packages/core/src/build-utils/build/chunks/chunkGroupReport.ts
+++ b/packages/core/src/build-utils/build/chunks/chunkGroupReport.ts
@@ -94,7 +94,9 @@ const getModuleResource = (compilerContext: string, module: AnyModule) => {
     module?.resource,
     safeInvoke(() => module?.nameForCondition?.()),
     module?.rootModule?.resource,
-  ].filter((item): item is string => typeof item === 'string' && item.length > 0);
+  ].filter(
+    (item): item is string => typeof item === 'string' && item.length > 0,
+  );
 
   if (!candidates.length) {
     return null;
@@ -148,7 +150,10 @@ const getAssetSize = (compilation: AnyCompilation, file: string) => {
   return 0;
 };
 
-const getModuleSizeRobust = (chunkGraph: AnyCompilation['chunkGraph'], module: AnyModule) => {
+const getModuleSizeRobust = (
+  chunkGraph: AnyCompilation['chunkGraph'],
+  module: AnyModule,
+) => {
   let size = 0;
 
   try {
@@ -185,7 +190,9 @@ const collectAsyncBlockDependencies = (module: AnyModule) => {
       continue;
     }
 
-    for (const dependency of toArray<any>(safeInvoke(() => block?.dependencies))) {
+    for (const dependency of toArray<any>(
+      safeInvoke(() => block?.dependencies),
+    )) {
       dependencies.add(dependency);
     }
 
@@ -199,13 +206,22 @@ const hasAsyncBlockParent = (
   moduleGraph: AnyCompilation['moduleGraph'],
   dependency: any,
 ) => {
-  const parentBlock = safeInvoke(() => moduleGraph?.getParentBlock?.(dependency));
-  return Boolean(parentBlock?.constructor?.name?.includes('AsyncDependenciesBlock'));
+  const parentBlock = safeInvoke(() =>
+    moduleGraph?.getParentBlock?.(dependency),
+  );
+  return Boolean(
+    parentBlock?.constructor?.name?.includes('AsyncDependenciesBlock'),
+  );
 };
 
-const getOutgoingModules = (moduleGraph: AnyCompilation['moduleGraph'], module: AnyModule) => {
+const getOutgoingModules = (
+  moduleGraph: AnyCompilation['moduleGraph'],
+  module: AnyModule,
+) => {
   const targets = new Set<AnyModule>();
-  const connections = safeInvoke(() => moduleGraph?.getOutgoingConnections?.(module));
+  const connections = safeInvoke(() =>
+    moduleGraph?.getOutgoingConnections?.(module),
+  );
   let asyncBlockDependencies: Set<any> | undefined;
 
   for (const connection of toArray<any>(connections)) {
@@ -253,10 +269,14 @@ const getRootModules = (
   moduleGraph: AnyCompilation['moduleGraph'],
 ) => {
   const roots = new Set<AnyModule>();
-  const canReadBlockChunkGroup = typeof chunkGraph?.getBlockChunkGroup === 'function';
+  const canReadBlockChunkGroup =
+    typeof chunkGraph?.getBlockChunkGroup === 'function';
   const addDependencyRoot = (dependency: any, requireActualModule: boolean) => {
     const targetModule = safeInvoke(() => moduleGraph?.getModule?.(dependency));
-    if (targetModule && (!requireActualModule || actualModules.has(targetModule))) {
+    if (
+      targetModule &&
+      (!requireActualModule || actualModules.has(targetModule))
+    ) {
       roots.add(targetModule);
     }
   };
@@ -329,8 +349,9 @@ const buildSnippet = (
   linesCache: Map<string, string[] | null>,
   absolutePath: string,
   loc: any,
+  request?: string,
 ) => {
-  if (!loc?.start?.line) {
+  if (!loc?.start?.line && !request) {
     return '';
   }
 
@@ -348,15 +369,66 @@ const buildSnippet = (
     return '';
   }
 
-  const startLine = Math.max(0, loc.start.line - 1);
+  const buildSnippetFromLines = (startLine: number, endLine: number) =>
+    lines
+      .slice(startLine, endLine)
+      .map((line, index) => `${startLine + index + 1} | ${line}`)
+      .join('\n');
+
+  const findImportSnippetByRequest = () => {
+    if (!request) {
+      return '';
+    }
+
+    const requestLineIndexes = lines
+      .map((line, index) => ({ line, index }))
+      .filter(({ line }) => line.includes(request));
+
+    for (const { index } of requestLineIndexes) {
+      let importStartLine = -1;
+      for (let cursor = index; cursor >= Math.max(0, index - 8); cursor--) {
+        if (/\bimport\s*\(/.test(lines[cursor])) {
+          importStartLine = cursor;
+          break;
+        }
+      }
+
+      if (importStartLine < 0) {
+        continue;
+      }
+
+      const candidate = lines.slice(importStartLine, index + 1).join('\n');
+      if (/\btypeof\s+import\s*\(/.test(candidate)) {
+        continue;
+      }
+
+      return buildSnippetFromLines(
+        importStartLine,
+        Math.min(lines.length, importStartLine + 5, index + 3),
+      );
+    }
+
+    return '';
+  };
+
+  const startLine = loc?.start?.line ? Math.max(0, loc.start.line - 1) : 0;
   const endLine = loc?.end?.line
     ? Math.min(lines.length, loc.end.line)
     : startLine + 1;
 
-  return lines
-    .slice(startLine, Math.min(endLine, startLine + 3))
-    .map((line, index) => `${startLine + index + 1} | ${line}`)
-    .join('\n');
+  const locSnippet = loc?.start?.line
+    ? buildSnippetFromLines(startLine, Math.min(endLine, startLine + 3))
+    : '';
+
+  if (
+    !request ||
+    (locSnippet.includes('import(') &&
+      !/\btypeof\s+import\s*\(/.test(locSnippet))
+  ) {
+    return locSnippet;
+  }
+
+  return findImportSnippetByRequest() || locSnippet;
 };
 
 type InternalChunkGroupNode = Omit<
@@ -424,9 +496,7 @@ const intersectModuleMaps = (
   return result;
 };
 
-const sumModuleSizes = (
-  modules: Iterable<SDK.ChunkGroupGraphModuleData>,
-) => {
+const sumModuleSizes = (modules: Iterable<SDK.ChunkGroupGraphModuleData>) => {
   let total = 0;
   for (const module of modules) {
     total += module.size;
@@ -595,7 +665,9 @@ export function buildChunkGroupGraphReport(
   const chunkModulesMap = new Map<AnyChunk, Set<AnyModule>>();
   for (const chunk of toArray<AnyChunk>(compilation?.chunks)) {
     const modules = new Set<AnyModule>();
-    const chunkModules = safeInvoke(() => chunkGraph?.getChunkModulesIterable?.(chunk));
+    const chunkModules = safeInvoke(() =>
+      chunkGraph?.getChunkModulesIterable?.(chunk),
+    );
     for (const module of toArray<AnyModule>(chunkModules)) {
       modules.add(module);
     }
@@ -638,7 +710,9 @@ export function buildChunkGroupGraphReport(
       );
       registerResourceGroups(module?.rootModule?.resource, groups);
 
-      for (const innerModule of toArray<any>(safeInvoke(() => module?.modules))) {
+      for (const innerModule of toArray<any>(
+        safeInvoke(() => module?.modules),
+      )) {
         registerResourceGroups(
           innerModule?.resource ??
             safeInvoke(() => innerModule?.nameForCondition?.()),
@@ -656,7 +730,12 @@ export function buildChunkGroupGraphReport(
     chunkGroupIdMap.set(chunkGroup, nodeId);
 
     const actualModules = getGroupModules(chunkGroup, chunkModulesMap);
-    const roots = getRootModules(chunkGroup, actualModules, chunkGraph, moduleGraph);
+    const roots = getRootModules(
+      chunkGroup,
+      actualModules,
+      chunkGraph,
+      moduleGraph,
+    );
     const visited = new Set<AnyModule>();
     const queue = [...roots];
 
@@ -699,7 +778,10 @@ export function buildChunkGroupGraphReport(
         }
 
         const originName = getModuleName(compilation, connection.originModule);
-        if (visited.has(connection.originModule) || originName.includes(' + ')) {
+        if (
+          visited.has(connection.originModule) ||
+          originName.includes(' + ')
+        ) {
           reachableModules.add(module);
           break;
         }
@@ -711,7 +793,9 @@ export function buildChunkGroupGraphReport(
 
     const chunks = toArray<AnyChunk>(chunkGroup?.chunks)
       .map((chunk: AnyChunk) => {
-        const chunkId = String(chunk?.id ?? chunk?.ukey ?? chunk?.name ?? 'unknown');
+        const chunkId = String(
+          chunk?.id ?? chunk?.ukey ?? chunk?.name ?? 'unknown',
+        );
         let emittedSize = 0;
         const files = toArray<string>(chunk?.files).filter(
           (file): file is string =>
@@ -743,10 +827,7 @@ export function buildChunkGroupGraphReport(
       })
       .sort((a, b) => b.emittedSize - a.emittedSize);
 
-    const localActualJSById = new Map<
-      string,
-      SDK.ChunkGroupGraphModuleData
-    >();
+    const localActualJSById = new Map<string, SDK.ChunkGroupGraphModuleData>();
     const localReachableJSById = new Map<
       string,
       SDK.ChunkGroupGraphModuleData
@@ -829,19 +910,22 @@ export function buildChunkGroupGraphReport(
       const relativeModulePath = moduleResource
         ? path.relative(compilerContext, moduleResource)
         : null;
+      const request = String(origin?.request ?? '');
       const snippet = moduleResource
-        ? buildSnippet(sourceFileCache, moduleResource, origin.loc)
+        ? buildSnippet(sourceFileCache, moduleResource, origin.loc, request)
         : '';
       const loc = origin?.loc?.start
         ? `${relativeModulePath ?? '?'}:${origin.loc.start.line}:${origin.loc.start.column}`
-        : relativeModulePath ?? '';
+        : (relativeModulePath ?? '');
 
       const sourceGroups = new Set<AnyChunkGroup>();
       const originResources = [
         origin.module?.resource,
         safeInvoke(() => origin.module?.nameForCondition?.()),
         origin.module?.rootModule?.resource,
-      ].filter((item): item is string => typeof item === 'string' && item.length > 0);
+      ].filter(
+        (item): item is string => typeof item === 'string' && item.length > 0,
+      );
 
       for (const resource of originResources) {
         const normalizedResource = normalizeResource(compilerContext, resource);
@@ -872,7 +956,6 @@ export function buildChunkGroupGraphReport(
         }
 
         const edge = edgeMap.get(edgeId)!;
-        const request = String(origin?.request ?? '');
         const isDuplicate = edge.imports.some(
           (item) =>
             item.loc === loc &&
@@ -953,13 +1036,14 @@ export function buildChunkGroupGraphReport(
     const parentSets = (reverse.get(nodeId) ?? [])
       .map((parentId) => guaranteedInclusiveLoadedByNode.get(parentId))
       .filter(
-        (
-          modules,
-        ): modules is Map<string, SDK.ChunkGroupGraphModuleData> =>
+        (modules): modules is Map<string, SDK.ChunkGroupGraphModuleData> =>
           Boolean(modules),
       );
     const guaranteedBefore = intersectModuleMaps(parentSets);
-    const incrementalRemovable = new Map<string, SDK.ChunkGroupGraphModuleData>();
+    const incrementalRemovable = new Map<
+      string,
+      SDK.ChunkGroupGraphModuleData
+    >();
     const inheritedRemovable = new Map<string, SDK.ChunkGroupGraphModuleData>();
 
     for (const [moduleId, module] of node.localRemovableById) {
@@ -1069,10 +1153,7 @@ export function buildChunkGroupGraphReport(
     const paths = nodePaths
       .map((nodeIds, index) => {
         const uniqueChunks = new Map<string, SDK.ChunkGroupGraphChunkData>();
-        const loadedModules = new Map<
-          string,
-          SDK.ChunkGroupGraphModuleData
-        >();
+        const loadedModules = new Map<string, SDK.ChunkGroupGraphModuleData>();
         const requiredModules = new Map<
           string,
           SDK.ChunkGroupGraphModuleData
@@ -1188,8 +1269,14 @@ export function buildChunkGroupGraphReport(
       if (a.removableJSSize !== b.removableJSSize) {
         return b.removableJSSize - a.removableJSSize;
       }
-      if (getSeverityRank(a.worstPathSeverity) !== getSeverityRank(b.worstPathSeverity)) {
-        return getSeverityRank(b.worstPathSeverity) - getSeverityRank(a.worstPathSeverity);
+      if (
+        getSeverityRank(a.worstPathSeverity) !==
+        getSeverityRank(b.worstPathSeverity)
+      ) {
+        return (
+          getSeverityRank(b.worstPathSeverity) -
+          getSeverityRank(a.worstPathSeverity)
+        );
       }
       if (a.maxPathRatio !== b.maxPathRatio) {
         return b.maxPathRatio - a.maxPathRatio;
@@ -1206,7 +1293,8 @@ export function buildChunkGroupGraphReport(
     entryGroupCount: nodes.filter((node) => node.isInitial).length,
     asyncGroupCount: nodes.filter((node) => !node.isInitial).length,
     totalEdgeCount: enrichedEdges.length,
-    removableGroupCount: nodes.filter((node) => node.removableJSSize > 0).length,
+    removableGroupCount: nodes.filter((node) => node.removableJSSize > 0)
+      .length,
     warningGroupCount: nodes.filter(
       (node) => node.worstPathSeverity === 'warning',
     ).length,
@@ -1228,14 +1316,12 @@ export function buildChunkGroupGraphReport(
     totalPathCount: nodes.reduce((total, node) => total + node.pathCount, 0),
     warningPathCount: nodes.reduce(
       (total, node) =>
-        total +
-        node.paths.filter((path) => path.severity === 'warning').length,
+        total + node.paths.filter((path) => path.severity === 'warning').length,
       0,
     ),
     dangerPathCount: nodes.reduce(
       (total, node) =>
-        total +
-        node.paths.filter((path) => path.severity === 'danger').length,
+        total + node.paths.filter((path) => path.severity === 'danger').length,
       0,
     ),
     truncatedPathGroupCount: nodes.filter((node) => node.pathsTruncated).length,

--- a/packages/core/src/build-utils/build/chunks/chunkGroupReport.ts
+++ b/packages/core/src/build-utils/build/chunks/chunkGroupReport.ts
@@ -285,7 +285,19 @@ type InternalChunkGroupNode = Omit<
   | 'inheritedRemovableJSSize'
   | 'inheritedRemovableJSModules'
   | 'removableJSModules'
+  | 'incomingEdgeIds'
+  | 'outgoingEdgeIds'
+  | 'incomingImports'
+  | 'paths'
+  | 'pathCount'
+  | 'pathsTruncated'
+  | 'worstPathSeverity'
+  | 'maxPathUnnecessarySize'
+  | 'maxPathRatio'
+  | 'searchText'
 > & {
+  localActualJSById: Map<string, SDK.ChunkGroupGraphModuleData>;
+  localReachableJSById: Map<string, SDK.ChunkGroupGraphModuleData>;
   localRemovableById: Map<string, SDK.ChunkGroupGraphModuleData>;
 };
 
@@ -644,11 +656,19 @@ export function buildChunkGroupGraphReport(
       })
       .sort((a, b) => b.emittedSize - a.emittedSize);
 
+    const localActualJSById = new Map<
+      string,
+      SDK.ChunkGroupGraphModuleData
+    >();
+    const localReachableJSById = new Map<
+      string,
+      SDK.ChunkGroupGraphModuleData
+    >();
     const localRemovableJSModules: SDK.ChunkGroupGraphModuleData[] = [];
     let nonJSResidualCount = 0;
 
     for (const module of actualModules) {
-      if (reachableModules.has(module) || isExternalModule(compilation, module)) {
+      if (isExternalModule(compilation, module)) {
         continue;
       }
 
@@ -656,13 +676,20 @@ export function buildChunkGroupGraphReport(
       const size = getModuleSizeRobust(chunkGraph, module);
 
       if (isJavaScriptLikeResource(resource)) {
-        localRemovableJSModules.push({
+        const moduleData = {
           id: getModuleKey(compilation, compilerContext, module),
           name: getModuleName(compilation, module),
           resource: resource ? path.relative(compilerContext, resource) : null,
           size,
-        });
-      } else {
+        };
+
+        localActualJSById.set(moduleData.id, moduleData);
+        if (reachableModules.has(module)) {
+          localReachableJSById.set(moduleData.id, moduleData);
+        } else {
+          localRemovableJSModules.push(moduleData);
+        }
+      } else if (!reachableModules.has(module)) {
         nonJSResidualCount++;
       }
     }
@@ -685,6 +712,8 @@ export function buildChunkGroupGraphReport(
       nonJSResidualCount,
       chunks,
       localRemovableJSModules: sortedLocalRemovableJSModules,
+      localActualJSById,
+      localReachableJSById,
       localRemovableById: new Map(
         sortedLocalRemovableJSModules.map((module) => [module.id, module]),
       ),
@@ -812,7 +841,7 @@ export function buildChunkGroupGraphReport(
   }
 
   const nodeMap = new Map(localNodes.map((node) => [node.id, node]));
-  const guaranteedInclusiveRemovableByNode = new Map<
+  const guaranteedInclusiveLoadedByNode = new Map<
     string,
     Map<string, SDK.ChunkGroupGraphModuleData>
   >();
@@ -832,7 +861,7 @@ export function buildChunkGroupGraphReport(
     }
 
     const parentSets = (reverse.get(nodeId) ?? [])
-      .map((parentId) => guaranteedInclusiveRemovableByNode.get(parentId))
+      .map((parentId) => guaranteedInclusiveLoadedByNode.get(parentId))
       .filter(
         (
           modules,
@@ -852,11 +881,11 @@ export function buildChunkGroupGraphReport(
     }
 
     const guaranteedInclusive = new Map(guaranteedBefore);
-    for (const [moduleId, module] of node.localRemovableById) {
+    for (const [moduleId, module] of node.localActualJSById) {
       guaranteedInclusive.set(moduleId, module);
     }
 
-    guaranteedInclusiveRemovableByNode.set(nodeId, guaranteedInclusive);
+    guaranteedInclusiveLoadedByNode.set(nodeId, guaranteedInclusive);
     incrementalRemovableByNode.set(nodeId, incrementalRemovable);
     inheritedRemovableByNode.set(nodeId, inheritedRemovable);
   }
@@ -949,7 +978,11 @@ export function buildChunkGroupGraphReport(
     const paths = nodePaths
       .map((nodeIds, index) => {
         const uniqueChunks = new Map<string, SDK.ChunkGroupGraphChunkData>();
-        const unnecessaryModules = new Map<
+        const loadedModules = new Map<
+          string,
+          SDK.ChunkGroupGraphModuleData
+        >();
+        const requiredModules = new Map<
           string,
           SDK.ChunkGroupGraphModuleData
         >();
@@ -969,15 +1002,20 @@ export function buildChunkGroupGraphReport(
             }
           });
 
-          pathNode.localRemovableJSModules.forEach((module) => {
-            if (!unnecessaryModules.has(module.id)) {
-              unnecessaryModules.set(module.id, module);
-            }
+          const internalPathNode = nodeMap.get(nodeId);
+          internalPathNode?.localActualJSById.forEach((module, moduleId) => {
+            loadedModules.set(moduleId, module);
+          });
+          internalPathNode?.localReachableJSById.forEach((module, moduleId) => {
+            requiredModules.set(moduleId, module);
           });
         });
 
         const chunks = [...uniqueChunks.values()].sort(
           (a, b) => b.emittedSize - a.emittedSize,
+        );
+        const unnecessaryModules = [...loadedModules.values()].filter(
+          (module) => !requiredModules.has(module.id),
         );
         const allUnnecessaryModules = [...unnecessaryModules.values()].sort(
           (a, b) => b.size - a.size,

--- a/packages/core/src/build-utils/build/chunks/chunkGroupReport.ts
+++ b/packages/core/src/build-utils/build/chunks/chunkGroupReport.ts
@@ -13,6 +13,8 @@ const JS_LIKE_EXTENSIONS = new Set([
   '.cts',
 ]);
 const CHUNK_GROUP_PATH_LIMIT = 50;
+const CHUNK_GROUP_PATH_MAX_DEPTH = 64;
+const CHUNK_GROUP_PATH_TRAVERSAL_LIMIT = 200_000;
 const PATH_TOP_MODULE_LIMIT = 20;
 
 type AnyChunk = any;
@@ -464,68 +466,72 @@ const getSeverityRank = (severity: SDK.ChunkGroupGraphPathSeverity) => {
   return 0;
 };
 
-const findPathsToTarget = (
-  targetId: string,
+const buildRepresentativePaths = (
   entryIds: string[],
   forwardAdjacency: Map<string, string[]>,
   fallbackNodeId?: string,
   maxPaths = CHUNK_GROUP_PATH_LIMIT,
 ) => {
-  const paths: string[][] = [];
-  let truncated = false;
+  const pathsByNode = new Map<string, string[][]>();
+  const truncatedNodeIds = new Set<string>();
   const entries = entryIds.length
     ? entryIds
     : fallbackNodeId
       ? [fallbackNodeId]
       : [];
+  const queue: string[][] = [];
+  let visitedPathCount = 0;
 
-  const dfs = (
-    current: string,
-    visited: Set<string>,
-    currentPath: string[],
-  ) => {
-    if (paths.length >= maxPaths) {
-      truncated = true;
-      return;
+  const addPath = (nodeId: string, pathIds: string[]) => {
+    const nodePaths = pathsByNode.get(nodeId) ?? [];
+    if (nodePaths.length >= maxPaths) {
+      truncatedNodeIds.add(nodeId);
+      return false;
     }
 
-    if (current === targetId) {
-      paths.push([...currentPath]);
-      return;
-    }
-
-    for (const next of forwardAdjacency.get(current) ?? []) {
-      if (visited.has(next)) {
-        continue;
-      }
-      visited.add(next);
-      currentPath.push(next);
-      dfs(next, visited, currentPath);
-      currentPath.pop();
-      visited.delete(next);
-
-      if (paths.length >= maxPaths) {
-        truncated = true;
-        return;
-      }
-    }
+    nodePaths.push(pathIds);
+    pathsByNode.set(nodeId, nodePaths);
+    return true;
   };
 
   for (const entryId of entries) {
-    dfs(entryId, new Set([entryId]), [entryId]);
-    if (paths.length >= maxPaths) {
-      truncated = true;
-      break;
+    const pathIds = [entryId];
+    if (addPath(entryId, pathIds)) {
+      queue.push(pathIds);
     }
   }
 
-  if (!paths.length && entries.includes(targetId)) {
-    paths.push([targetId]);
+  while (queue.length) {
+    if (visitedPathCount++ > CHUNK_GROUP_PATH_TRAVERSAL_LIMIT) {
+      for (const pathIds of queue) {
+        truncatedNodeIds.add(pathIds[pathIds.length - 1]);
+      }
+      break;
+    }
+
+    const currentPath = queue.shift()!;
+    const current = currentPath[currentPath.length - 1];
+
+    for (const next of forwardAdjacency.get(current) ?? []) {
+      if (currentPath.includes(next)) {
+        continue;
+      }
+
+      if (currentPath.length >= CHUNK_GROUP_PATH_MAX_DEPTH) {
+        truncatedNodeIds.add(next);
+        continue;
+      }
+
+      const nextPath = [...currentPath, next];
+      if (addPath(next, nextPath)) {
+        queue.push(nextPath);
+      }
+    }
   }
 
   return {
-    paths,
-    truncated,
+    pathsByNode,
+    truncatedNodeIds,
   };
 };
 
@@ -709,7 +715,8 @@ export function buildChunkGroupGraphReport(
         let emittedSize = 0;
         const files = toArray<string>(chunk?.files).filter(
           (file): file is string =>
-            typeof file === 'string' && file.endsWith('.js'),
+            typeof file === 'string' &&
+            JS_LIKE_EXTENSIONS.has(path.extname(file).toLowerCase()),
         );
 
         for (const file of files) {
@@ -900,10 +907,12 @@ export function buildChunkGroupGraphReport(
     })
     .map((node) => node.id);
   const topologicalOrder: string[] = [];
+  const topologicalOrderSet = new Set<string>();
 
   while (zeroIndegreeQueue.length) {
     const currentId = zeroIndegreeQueue.shift()!;
     topologicalOrder.push(currentId);
+    topologicalOrderSet.add(currentId);
 
     for (const nextId of forward.get(currentId) ?? []) {
       const nextIndegree = (indegree.get(nextId) ?? 0) - 1;
@@ -915,8 +924,9 @@ export function buildChunkGroupGraphReport(
   }
 
   for (const node of localNodes) {
-    if (!topologicalOrder.includes(node.id)) {
+    if (!topologicalOrderSet.has(node.id)) {
       topologicalOrder.push(node.id);
+      topologicalOrderSet.add(node.id);
     }
   }
 
@@ -1005,6 +1015,12 @@ export function buildChunkGroupGraphReport(
     .filter((node) => node.isInitial)
     .map((node) => node.id);
   const fallbackNodeId = baseNodes[0]?.id;
+  const { pathsByNode, truncatedNodeIds } = buildRepresentativePaths(
+    entryNodeIds,
+    forward,
+    fallbackNodeId,
+    CHUNK_GROUP_PATH_LIMIT,
+  );
   const baseNodeMap = new Map(baseNodes.map((node) => [node.id, node]));
   const enrichedEdges: SDK.ChunkGroupGraphEdgeData[] = edges.map((edge) => ({
     ...edge,
@@ -1047,13 +1063,8 @@ export function buildChunkGroupGraphReport(
         return (a.request ?? '').localeCompare(b.request ?? '');
       });
 
-    const { paths: nodePaths, truncated } = findPathsToTarget(
-      node.id,
-      entryNodeIds,
-      forward,
-      fallbackNodeId,
-      CHUNK_GROUP_PATH_LIMIT,
-    );
+    const nodePaths = pathsByNode.get(node.id) ?? [];
+    const truncated = truncatedNodeIds.has(node.id);
 
     const paths = nodePaths
       .map((nodeIds, index) => {

--- a/packages/core/src/build-utils/build/chunks/index.ts
+++ b/packages/core/src/build-utils/build/chunks/index.ts
@@ -1,3 +1,4 @@
 export * from './assetsModules';
+export * from './chunkGroupReport';
 export * from './chunkTransform';
 export * from './rspack/transform';

--- a/packages/core/src/inner-plugins/plugins/ensureModulesChunkGraph.ts
+++ b/packages/core/src/inner-plugins/plugins/ensureModulesChunkGraph.ts
@@ -236,6 +236,19 @@ async function doneHandler(
   logger.debug('reportChunkGraph start');
   await _this.sdk.reportChunkGraph(_this.chunkGraph!);
   logger.debug('reportChunkGraph done');
+
+  if (_this.options.features.bundle) {
+    const chunkGroupGraph = ChunksBuildUtils.buildChunkGroupGraphReport(
+      stats.compilation,
+      compiler.context || process.cwd(),
+    );
+    if (chunkGroupGraph) {
+      _this.sdk.reportOtherReports({
+        chunkGroupGraph,
+      });
+    }
+  }
+
   // Warn if deprecated treemap option is enabled
   if (_this.options.supports.generateTileGraph) {
     logger.warn(

--- a/packages/core/tests/build/utils/chunk-group-report.test.ts
+++ b/packages/core/tests/build/utils/chunk-group-report.test.ts
@@ -366,4 +366,248 @@ describe('buildChunkGroupGraphReport', () => {
     expect(report?.overview.dangerPathCount).toBe(2);
     expect(report?.overview.warningPathCount).toBe(0);
   });
+
+  it('deduplicates shared split chunks when calculating a nested load path', () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'rsdoctor-chunk-group-splitchunks-'),
+    );
+    tempDirs.push(tempDir);
+
+    const mainFile = path.join(tempDir, 'main.js');
+    const fooFile = path.join(tempDir, 'foo.js');
+    const barFile = path.join(tempDir, 'bar.js');
+    const libFile = path.join(tempDir, 'lib.js');
+    const sharedMainFooFile = path.join(tempDir, 'shared-main-foo.js');
+    const sharedFooBarFile = path.join(tempDir, 'shared-foo-bar.js');
+
+    fs.writeFileSync(mainFile, "import('./foo')\n");
+    fs.writeFileSync(fooFile, "import('./bar')\n");
+    fs.writeFileSync(barFile, "export const bar = true\n");
+    fs.writeFileSync(libFile, "export const lib = true\n");
+    fs.writeFileSync(sharedMainFooFile, "export const sharedMainFoo = true\n");
+    fs.writeFileSync(sharedFooBarFile, "export const sharedFooBar = true\n");
+
+    const mainModule = {
+      resource: mainFile,
+      identifier: () => mainFile,
+      nameForCondition: () => mainFile,
+      readableIdentifier: () => mainFile,
+      blocks: [{ dependencies: ['dep_foo'] }],
+    };
+    const fooModule = {
+      resource: fooFile,
+      identifier: () => fooFile,
+      nameForCondition: () => fooFile,
+      readableIdentifier: () => fooFile,
+      blocks: [{ dependencies: ['dep_bar'] }],
+    };
+    const barModule = {
+      resource: barFile,
+      identifier: () => barFile,
+      nameForCondition: () => barFile,
+      readableIdentifier: () => barFile,
+    };
+    const libModule = {
+      resource: libFile,
+      identifier: () => libFile,
+      nameForCondition: () => libFile,
+      readableIdentifier: () => libFile,
+    };
+    const sharedMainFooModule = {
+      resource: sharedMainFooFile,
+      identifier: () => sharedMainFooFile,
+      nameForCondition: () => sharedMainFooFile,
+      readableIdentifier: () => sharedMainFooFile,
+    };
+    const sharedFooBarModule = {
+      resource: sharedFooBarFile,
+      identifier: () => sharedFooBarFile,
+      nameForCondition: () => sharedFooBarFile,
+      readableIdentifier: () => sharedFooBarFile,
+    };
+
+    const mainChunk = {
+      id: 'main-chunk',
+      name: 'main',
+      files: ['main.js'],
+    };
+    const fooChunk = {
+      id: 'foo-chunk',
+      name: 'foo',
+      files: ['foo.js'],
+    };
+    const barChunk = {
+      id: 'bar-chunk',
+      name: 'bar',
+      files: ['bar.js'],
+    };
+    const libChunk = {
+      id: 'lib-chunk',
+      name: 'lib',
+      files: ['lib.js'],
+    };
+    const sharedChunk = {
+      id: 'shared-chunk',
+      name: 'shared-main-foo-and-foo-bar',
+      files: ['shared.js'],
+    };
+
+    const mainGroup = {
+      name: 'main',
+      isInitial: () => true,
+      chunks: [mainChunk, libChunk, sharedChunk],
+      origins: [],
+    };
+    const fooGroup = {
+      name: 'foo',
+      isInitial: () => false,
+      chunks: [fooChunk, libChunk, sharedChunk],
+      origins: [
+        {
+          request: './foo',
+          dependency: 'dep_foo',
+          module: mainModule,
+          loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 15 },
+          },
+        },
+      ],
+    };
+    const barGroup = {
+      name: 'bar',
+      isInitial: () => false,
+      chunks: [barChunk, libChunk, sharedChunk],
+      origins: [
+        {
+          request: './bar',
+          dependency: 'dep_bar',
+          module: fooModule,
+          loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 15 },
+          },
+        },
+      ],
+    };
+
+    const chunkModules = new Map<any, any[]>([
+      [mainChunk, [mainModule]],
+      [fooChunk, [fooModule]],
+      [barChunk, [barModule]],
+      [libChunk, [libModule]],
+      [sharedChunk, [sharedMainFooModule, sharedFooBarModule]],
+    ]);
+
+    const chunkEntries = new Map<any, any[]>([
+      [mainChunk, [mainModule]],
+      [fooChunk, [fooModule]],
+      [barChunk, [barModule]],
+      [libChunk, []],
+      [sharedChunk, []],
+    ]);
+
+    const moduleSizes = new Map<any, number>([
+      [mainModule, 10],
+      [fooModule, 20],
+      [barModule, 30],
+      [libModule, 40],
+      [sharedMainFooModule, 50],
+      [sharedFooBarModule, 70],
+    ]);
+
+    const syncDependencies = new Map<any, any[]>([
+      [mainModule, [libModule, sharedMainFooModule]],
+      [fooModule, [libModule, sharedMainFooModule, sharedFooBarModule]],
+      [barModule, [libModule, sharedFooBarModule]],
+    ]);
+
+    const compilation = {
+      requestShortener: undefined,
+      chunks: [mainChunk, fooChunk, barChunk, libChunk, sharedChunk],
+      chunkGroups: [mainGroup, fooGroup, barGroup],
+      assets: {
+        'main.js': { size: () => 100 },
+        'foo.js': { size: () => 200 },
+        'bar.js': { size: () => 300 },
+        'lib.js': { size: () => 400 },
+        'shared.js': { size: () => 500 },
+      },
+      chunkGraph: {
+        getChunkModulesIterable(chunk: any) {
+          return chunkModules.get(chunk) ?? [];
+        },
+        getChunkEntryModulesIterable(chunk: any) {
+          return chunkEntries.get(chunk) ?? [];
+        },
+        getModuleSize(module: any) {
+          return moduleSizes.get(module) ?? 0;
+        },
+      },
+      moduleGraph: {
+        getModule(dep: string) {
+          if (dep === 'dep_foo') {
+            return fooModule;
+          }
+          if (dep === 'dep_bar') {
+            return barModule;
+          }
+          return undefined;
+        },
+        getOutgoingConnections(module: any) {
+          return (syncDependencies.get(module) ?? []).map((target) => ({
+            module: target,
+          }));
+        },
+        getIncomingConnections() {
+          return [];
+        },
+        getParentBlock() {
+          return null;
+        },
+      },
+    };
+
+    const report = buildChunkGroupGraphReport(compilation, tempDir);
+
+    expect(report).toBeTruthy();
+
+    const mainNode = report?.nodes.find((node) => node.name === 'main');
+    const fooNode = report?.nodes.find((node) => node.name === 'foo');
+    const barNode = report?.nodes.find((node) => node.name === 'bar');
+    const barPath = barNode?.paths[0];
+
+    expect(
+      mainNode?.localRemovableJSModules.map((module) => module.resource),
+    ).toEqual(['shared-foo-bar.js']);
+    expect(fooNode?.localRemovableJSSize).toBe(0);
+    expect(
+      barNode?.localRemovableJSModules.map((module) => module.resource),
+    ).toEqual(['shared-main-foo.js']);
+    expect(barNode?.removableJSSize).toBe(50);
+
+    expect(barPath?.label).toBe('main → foo → bar');
+    expect([...(barPath?.chunkIds ?? [])].sort()).toEqual(
+      [
+        'bar-chunk',
+        'foo-chunk',
+        'lib-chunk',
+        'main-chunk',
+        'shared-chunk',
+      ].sort(),
+    );
+    expect(barPath?.totalEmittedSize).toBe(100 + 200 + 300 + 400 + 500);
+    expect(barPath?.totalJSSize).toBe(10 + 20 + 30 + 40 + 50 + 70);
+    expect(barPath?.unnecessarySize).toBe(70 + 50);
+    expect(barPath?.severity).toBe('danger');
+    expect(
+      barPath?.topUnnecessaryModules.map((module) => [
+        module.resource,
+        module.size,
+      ]),
+    ).toEqual([
+      ['shared-foo-bar.js', 70],
+      ['shared-main-foo.js', 50],
+    ]);
+  });
 });

--- a/packages/core/tests/build/utils/chunk-group-report.test.ts
+++ b/packages/core/tests/build/utils/chunk-group-report.test.ts
@@ -584,7 +584,8 @@ describe('buildChunkGroupGraphReport', () => {
     expect(
       barNode?.localRemovableJSModules.map((module) => module.resource),
     ).toEqual(['shared-main-foo.js']);
-    expect(barNode?.removableJSSize).toBe(50);
+    expect(barNode?.removableJSSize).toBe(0);
+    expect(barNode?.inheritedRemovableJSSize).toBe(50);
 
     expect(barPath?.label).toBe('main → foo → bar');
     expect([...(barPath?.chunkIds ?? [])].sort()).toEqual(
@@ -598,16 +599,8 @@ describe('buildChunkGroupGraphReport', () => {
     );
     expect(barPath?.totalEmittedSize).toBe(100 + 200 + 300 + 400 + 500);
     expect(barPath?.totalJSSize).toBe(10 + 20 + 30 + 40 + 50 + 70);
-    expect(barPath?.unnecessarySize).toBe(70 + 50);
-    expect(barPath?.severity).toBe('danger');
-    expect(
-      barPath?.topUnnecessaryModules.map((module) => [
-        module.resource,
-        module.size,
-      ]),
-    ).toEqual([
-      ['shared-foo-bar.js', 70],
-      ['shared-main-foo.js', 50],
-    ]);
+    expect(barPath?.unnecessarySize).toBe(0);
+    expect(barPath?.severity).toBe('normal');
+    expect(barPath?.topUnnecessaryModules).toEqual([]);
   });
 });

--- a/packages/core/tests/build/utils/chunk-group-report.test.ts
+++ b/packages/core/tests/build/utils/chunk-group-report.test.ts
@@ -23,7 +23,7 @@ describe('buildChunkGroupGraphReport', () => {
     const asyncFile = path.join(tempDir, 'async.js');
     const unusedFile = path.join(tempDir, 'unused.js');
 
-    fs.writeFileSync(entryFile, "import('./async')\nconsole.log('entry')\n");
+    fs.writeFileSync(entryFile, "console.log('entry')\nimport('./async')\n");
     fs.writeFileSync(asyncFile, "export const value = 'async'\n");
     fs.writeFileSync(unusedFile, "export const value = 'unused'\n");
 
@@ -193,8 +193,8 @@ describe('buildChunkGroupGraphReport', () => {
 
     fs.writeFileSync(entryFile, "import('./parent')\n");
     fs.writeFileSync(parentFile, "import('./child')\n");
-    fs.writeFileSync(childFile, "export const child = true\n");
-    fs.writeFileSync(sharedUnusedFile, "export const unused = true\n");
+    fs.writeFileSync(childFile, 'export const child = true\n');
+    fs.writeFileSync(sharedUnusedFile, 'export const unused = true\n');
 
     const entryModule = {
       resource: entryFile,
@@ -343,7 +343,9 @@ describe('buildChunkGroupGraphReport', () => {
 
     expect(report).toBeTruthy();
 
-    const parentNode = report?.nodes.find((node) => node.name === 'parent-group');
+    const parentNode = report?.nodes.find(
+      (node) => node.name === 'parent-group',
+    );
     const childNode = report?.nodes.find((node) => node.name === 'child-group');
 
     expect(parentNode).toBeTruthy();
@@ -382,10 +384,10 @@ describe('buildChunkGroupGraphReport', () => {
 
     fs.writeFileSync(mainFile, "import('./foo')\n");
     fs.writeFileSync(fooFile, "import('./bar')\n");
-    fs.writeFileSync(barFile, "export const bar = true\n");
-    fs.writeFileSync(libFile, "export const lib = true\n");
-    fs.writeFileSync(sharedMainFooFile, "export const sharedMainFoo = true\n");
-    fs.writeFileSync(sharedFooBarFile, "export const sharedFooBar = true\n");
+    fs.writeFileSync(barFile, 'export const bar = true\n');
+    fs.writeFileSync(libFile, 'export const lib = true\n');
+    fs.writeFileSync(sharedMainFooFile, 'export const sharedMainFoo = true\n');
+    fs.writeFileSync(sharedFooBarFile, 'export const sharedFooBar = true\n');
 
     const fooBlock = { dependencies: ['dep_foo'] };
     const barBlock = { dependencies: ['dep_bar'] };

--- a/packages/core/tests/build/utils/chunk-group-report.test.ts
+++ b/packages/core/tests/build/utils/chunk-group-report.test.ts
@@ -1,0 +1,369 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from '@rstest/core';
+import { buildChunkGroupGraphReport } from '@/build-utils/build/chunks/chunkGroupReport';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('buildChunkGroupGraphReport', () => {
+  it('collects removable modules and dynamic import origin details', () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'rsdoctor-chunk-group-'),
+    );
+    tempDirs.push(tempDir);
+
+    const entryFile = path.join(tempDir, 'entry.js');
+    const asyncFile = path.join(tempDir, 'async.js');
+    const unusedFile = path.join(tempDir, 'unused.js');
+
+    fs.writeFileSync(entryFile, "import('./async')\nconsole.log('entry')\n");
+    fs.writeFileSync(asyncFile, "export const value = 'async'\n");
+    fs.writeFileSync(unusedFile, "export const value = 'unused'\n");
+
+    const entryModule = {
+      resource: entryFile,
+      identifier: () => entryFile,
+      nameForCondition: () => entryFile,
+      readableIdentifier: () => entryFile,
+      blocks: [{ dependencies: ['dep_async'] }],
+    };
+    const asyncModule = {
+      resource: asyncFile,
+      identifier: () => asyncFile,
+      nameForCondition: () => asyncFile,
+      readableIdentifier: () => asyncFile,
+    };
+    const unusedModule = {
+      resource: unusedFile,
+      identifier: () => unusedFile,
+      nameForCondition: () => unusedFile,
+      readableIdentifier: () => unusedFile,
+    };
+
+    const entryChunk = {
+      id: 'entry-chunk',
+      name: 'main',
+      files: ['main.js'],
+    };
+    const asyncChunk = {
+      id: 'async-chunk',
+      name: 'async',
+      files: ['async.js'],
+    };
+
+    const chunkModules = new Map<any, any[]>([
+      [entryChunk, [entryModule]],
+      [asyncChunk, [asyncModule, unusedModule]],
+    ]);
+
+    const chunkEntries = new Map<any, any[]>([
+      [entryChunk, [entryModule]],
+      [asyncChunk, [asyncModule]],
+    ]);
+
+    const moduleSizes = new Map<any, number>([
+      [entryModule, 40],
+      [asyncModule, 30],
+      [unusedModule, 25],
+    ]);
+
+    const asyncGroup = {
+      name: 'async-group',
+      isInitial: () => false,
+      chunks: [asyncChunk],
+      origins: [
+        {
+          request: './async',
+          module: entryModule,
+          loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 17 },
+          },
+        },
+      ],
+    };
+
+    const compilation = {
+      requestShortener: undefined,
+      chunks: [entryChunk, asyncChunk],
+      chunkGroups: [
+        {
+          name: 'entry-group',
+          isInitial: () => true,
+          chunks: [entryChunk],
+          origins: [],
+        },
+        asyncGroup,
+      ],
+      assets: {
+        'main.js': { size: () => 120 },
+        'async.js': { size: () => 64 },
+      },
+      chunkGraph: {
+        getChunkModulesIterable(chunk: any) {
+          return chunkModules.get(chunk) ?? [];
+        },
+        getChunkEntryModulesIterable(chunk: any) {
+          return chunkEntries.get(chunk) ?? [];
+        },
+        getModuleSize(module: any) {
+          return moduleSizes.get(module) ?? 0;
+        },
+      },
+      moduleGraph: {
+        getModule(dep: string) {
+          if (dep === 'dep_async') {
+            return asyncModule;
+          }
+          return undefined;
+        },
+        getOutgoingConnections(module: any) {
+          if (module === asyncModule) {
+            return [];
+          }
+          return [];
+        },
+        getIncomingConnections() {
+          return [];
+        },
+        getParentBlock() {
+          return null;
+        },
+      },
+    };
+
+    const report = buildChunkGroupGraphReport(compilation, tempDir);
+
+    expect(report).toBeTruthy();
+    expect(report?.nodes).toHaveLength(2);
+    expect(report?.edges).toHaveLength(1);
+    expect(report?.overview.totalGroupCount).toBe(2);
+    expect(report?.overview.entryGroupCount).toBe(1);
+    expect(report?.overview.asyncGroupCount).toBe(1);
+    expect(report?.entryNodeIds).toEqual(['cg_0']);
+    expect(report?.priorityNodeIds[0]).toBe('cg_1');
+
+    const asyncNode = report?.nodes.find((node) => node.name === 'async-group');
+    expect(asyncNode).toBeTruthy();
+    expect(asyncNode?.localRemovableJSModuleCount).toBe(1);
+    expect(asyncNode?.localRemovableJSSize).toBe(25);
+    expect(asyncNode?.removableJSModuleCount).toBe(1);
+    expect(asyncNode?.removableJSSize).toBe(25);
+    expect(asyncNode?.inheritedRemovableJSModuleCount).toBe(0);
+    expect(asyncNode?.inheritedRemovableJSSize).toBe(0);
+    expect(asyncNode?.removableJSModules[0].resource).toBe('unused.js');
+    expect(asyncNode?.localRemovableJSModules[0].resource).toBe('unused.js');
+    expect(asyncNode?.incomingImports).toHaveLength(1);
+    expect(asyncNode?.incomingImports[0].fromName).toBe('entry-group');
+    expect(asyncNode?.pathCount).toBe(1);
+    expect(asyncNode?.pathsTruncated).toBe(false);
+    expect(asyncNode?.paths[0].label).toBe('entry-group → async-group');
+    expect(asyncNode?.paths[0].unnecessarySize).toBe(25);
+    expect(asyncNode?.paths[0].topUnnecessaryModules[0].resource).toBe(
+      'unused.js',
+    );
+    expect(asyncNode?.worstPathSeverity).toBe('warning');
+
+    const edge = report?.edges[0];
+    expect(edge?.fromName).toBe('entry-group');
+    expect(edge?.toName).toBe('async-group');
+    expect(edge?.imports).toHaveLength(1);
+    expect(edge?.imports[0].request).toBe('./async');
+    expect(edge?.imports[0].loc).toContain('entry.js:1:0');
+    expect(edge?.imports[0].snippet).toContain("import('./async')");
+  });
+
+  it('deduplicates removable size that is already guaranteed to load on every parent path', () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'rsdoctor-chunk-group-inherited-'),
+    );
+    tempDirs.push(tempDir);
+
+    const entryFile = path.join(tempDir, 'entry.js');
+    const parentFile = path.join(tempDir, 'parent.js');
+    const childFile = path.join(tempDir, 'child.js');
+    const sharedUnusedFile = path.join(tempDir, 'shared-unused.js');
+
+    fs.writeFileSync(entryFile, "import('./parent')\n");
+    fs.writeFileSync(parentFile, "import('./child')\n");
+    fs.writeFileSync(childFile, "export const child = true\n");
+    fs.writeFileSync(sharedUnusedFile, "export const unused = true\n");
+
+    const entryModule = {
+      resource: entryFile,
+      identifier: () => entryFile,
+      nameForCondition: () => entryFile,
+      readableIdentifier: () => entryFile,
+      blocks: [{ dependencies: ['dep_parent'] }],
+    };
+    const parentModule = {
+      resource: parentFile,
+      identifier: () => parentFile,
+      nameForCondition: () => parentFile,
+      readableIdentifier: () => parentFile,
+      blocks: [{ dependencies: ['dep_child'] }],
+    };
+    const childModule = {
+      resource: childFile,
+      identifier: () => childFile,
+      nameForCondition: () => childFile,
+      readableIdentifier: () => childFile,
+    };
+    const sharedUnusedModule = {
+      resource: sharedUnusedFile,
+      identifier: () => sharedUnusedFile,
+      nameForCondition: () => sharedUnusedFile,
+      readableIdentifier: () => sharedUnusedFile,
+    };
+
+    const entryChunk = {
+      id: 'entry-chunk',
+      name: 'entry',
+      files: ['entry.js'],
+    };
+    const parentChunk = {
+      id: 'parent-chunk',
+      name: 'parent',
+      files: ['parent.js'],
+    };
+    const childChunk = {
+      id: 'child-chunk',
+      name: 'child',
+      files: ['child.js'],
+    };
+
+    const chunkModules = new Map<any, any[]>([
+      [entryChunk, [entryModule]],
+      [parentChunk, [parentModule, sharedUnusedModule]],
+      [childChunk, [childModule, sharedUnusedModule]],
+    ]);
+
+    const chunkEntries = new Map<any, any[]>([
+      [entryChunk, [entryModule]],
+      [parentChunk, [parentModule]],
+      [childChunk, [childModule]],
+    ]);
+
+    const moduleSizes = new Map<any, number>([
+      [entryModule, 10],
+      [parentModule, 20],
+      [childModule, 15],
+      [sharedUnusedModule, 1024 * 1024],
+    ]);
+
+    const compilation = {
+      requestShortener: undefined,
+      chunks: [entryChunk, parentChunk, childChunk],
+      chunkGroups: [
+        {
+          name: 'entry-group',
+          isInitial: () => true,
+          chunks: [entryChunk],
+          origins: [],
+        },
+        {
+          name: 'parent-group',
+          isInitial: () => false,
+          chunks: [parentChunk],
+          origins: [
+            {
+              request: './parent',
+              dependency: 'dep_parent',
+              module: entryModule,
+              loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 18 },
+              },
+            },
+          ],
+        },
+        {
+          name: 'child-group',
+          isInitial: () => false,
+          chunks: [childChunk],
+          origins: [
+            {
+              request: './child',
+              dependency: 'dep_child',
+              module: parentModule,
+              loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 17 },
+              },
+            },
+          ],
+        },
+      ],
+      assets: {
+        'entry.js': { size: () => 40 },
+        'parent.js': { size: () => 50 },
+        'child.js': { size: () => 60 },
+      },
+      chunkGraph: {
+        getChunkModulesIterable(chunk: any) {
+          return chunkModules.get(chunk) ?? [];
+        },
+        getChunkEntryModulesIterable(chunk: any) {
+          return chunkEntries.get(chunk) ?? [];
+        },
+        getModuleSize(module: any) {
+          return moduleSizes.get(module) ?? 0;
+        },
+      },
+      moduleGraph: {
+        getModule(dep: string) {
+          if (dep === 'dep_parent') {
+            return parentModule;
+          }
+          if (dep === 'dep_child') {
+            return childModule;
+          }
+          return undefined;
+        },
+        getOutgoingConnections() {
+          return [];
+        },
+        getIncomingConnections() {
+          return [];
+        },
+        getParentBlock() {
+          return null;
+        },
+      },
+    };
+
+    const report = buildChunkGroupGraphReport(compilation, tempDir);
+
+    expect(report).toBeTruthy();
+
+    const parentNode = report?.nodes.find((node) => node.name === 'parent-group');
+    const childNode = report?.nodes.find((node) => node.name === 'child-group');
+
+    expect(parentNode).toBeTruthy();
+    expect(parentNode?.localRemovableJSSize).toBe(1024 * 1024);
+    expect(parentNode?.removableJSSize).toBe(1024 * 1024);
+
+    expect(childNode).toBeTruthy();
+    expect(childNode?.localRemovableJSSize).toBe(1024 * 1024);
+    expect(childNode?.removableJSSize).toBe(0);
+    expect(childNode?.removableJSModuleCount).toBe(0);
+    expect(childNode?.inheritedRemovableJSSize).toBe(1024 * 1024);
+    expect(childNode?.inheritedRemovableJSModuleCount).toBe(1);
+    expect(childNode?.inheritedRemovableJSModules[0].resource).toBe(
+      'shared-unused.js',
+    );
+    expect(childNode?.paths).toHaveLength(1);
+    expect(childNode?.paths[0].unnecessarySize).toBe(1024 * 1024);
+    expect(childNode?.paths[0].severity).toBe('danger');
+    expect(report?.priorityNodeIds.slice(0, 2)).toEqual(['cg_1', 'cg_2']);
+    expect(report?.overview.dangerPathCount).toBe(2);
+    expect(report?.overview.warningPathCount).toBe(0);
+  });
+});

--- a/packages/core/tests/build/utils/chunk-group-report.test.ts
+++ b/packages/core/tests/build/utils/chunk-group-report.test.ts
@@ -387,19 +387,22 @@ describe('buildChunkGroupGraphReport', () => {
     fs.writeFileSync(sharedMainFooFile, "export const sharedMainFoo = true\n");
     fs.writeFileSync(sharedFooBarFile, "export const sharedFooBar = true\n");
 
+    const fooBlock = { dependencies: ['dep_foo'] };
+    const barBlock = { dependencies: ['dep_bar'] };
+
     const mainModule = {
       resource: mainFile,
       identifier: () => mainFile,
       nameForCondition: () => mainFile,
       readableIdentifier: () => mainFile,
-      blocks: [{ dependencies: ['dep_foo'] }],
+      blocks: [fooBlock],
     };
     const fooModule = {
       resource: fooFile,
       identifier: () => fooFile,
       nameForCondition: () => fooFile,
       readableIdentifier: () => fooFile,
-      blocks: [{ dependencies: ['dep_bar'] }],
+      blocks: [barBlock],
     };
     const barModule = {
       resource: barFile,
@@ -465,7 +468,6 @@ describe('buildChunkGroupGraphReport', () => {
       origins: [
         {
           request: './foo',
-          dependency: 'dep_foo',
           module: mainModule,
           loc: {
             start: { line: 1, column: 0 },
@@ -481,7 +483,6 @@ describe('buildChunkGroupGraphReport', () => {
       origins: [
         {
           request: './bar',
-          dependency: 'dep_bar',
           module: fooModule,
           loc: {
             start: { line: 1, column: 0 },
@@ -517,9 +518,28 @@ describe('buildChunkGroupGraphReport', () => {
     ]);
 
     const syncDependencies = new Map<any, any[]>([
-      [mainModule, [libModule, sharedMainFooModule]],
-      [fooModule, [libModule, sharedMainFooModule, sharedFooBarModule]],
-      [barModule, [libModule, sharedFooBarModule]],
+      [
+        mainModule,
+        [
+          { module: libModule, dependency: 'dep_main_lib' },
+          { module: sharedMainFooModule, dependency: 'dep_main_shared' },
+        ],
+      ],
+      [
+        fooModule,
+        [
+          { module: libModule, dependency: 'dep_foo_lib' },
+          { module: sharedMainFooModule, dependency: 'dep_foo_main_shared' },
+          { module: sharedFooBarModule, dependency: 'dep_foo_bar_shared' },
+        ],
+      ],
+      [
+        barModule,
+        [
+          { module: libModule, dependency: 'dep_bar_lib' },
+          { module: sharedFooBarModule, dependency: 'dep_bar_shared' },
+        ],
+      ],
     ]);
 
     const compilation = {
@@ -543,6 +563,15 @@ describe('buildChunkGroupGraphReport', () => {
         getModuleSize(module: any) {
           return moduleSizes.get(module) ?? 0;
         },
+        getBlockChunkGroup(block: any) {
+          if (block === fooBlock) {
+            return fooGroup;
+          }
+          if (block === barBlock) {
+            return barGroup;
+          }
+          return null;
+        },
       },
       moduleGraph: {
         getModule(dep: string) {
@@ -555,9 +584,14 @@ describe('buildChunkGroupGraphReport', () => {
           return undefined;
         },
         getOutgoingConnections(module: any) {
-          return (syncDependencies.get(module) ?? []).map((target) => ({
-            module: target,
-          }));
+          const connections = [...(syncDependencies.get(module) ?? [])];
+          if (module === mainModule) {
+            connections.unshift({ module: fooModule, dependency: 'dep_foo' });
+          }
+          if (module === fooModule) {
+            connections.unshift({ module: barModule, dependency: 'dep_bar' });
+          }
+          return connections;
         },
         getIncomingConnections() {
           return [];

--- a/packages/sdk/src/sdk/sdk/core.ts
+++ b/packages/sdk/src/sdk/sdk/core.ts
@@ -175,7 +175,7 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
       client: {
         enableRoutes: this.getClientRoutes(),
       },
-      data: transformDataUrls(dataUrls),
+      data: transformDataUrls(dataUrls, outputDir),
     };
   }
 

--- a/packages/sdk/src/sdk/sdk/index.ts
+++ b/packages/sdk/src/sdk/sdk/index.ts
@@ -58,6 +58,8 @@ export class RsdoctorSDK<
 
   private _packageGraph!: SDK.PackageGraphInstance;
 
+  private _otherReports: SDK.OtherReports = {};
+
   constructor(options: T) {
     super(options);
     this.server = options.config?.noServer
@@ -139,6 +141,7 @@ export class RsdoctorSDK<
     this._plugin = {};
     this._moduleGraph = new ModuleGraph();
     this._chunkGraph = new ChunkGraph();
+    this._otherReports = {};
   }
 
   clearSourceMapCache(): void {
@@ -306,6 +309,14 @@ export class RsdoctorSDK<
     this._chunkGraph.addAsset(...data.getAssets());
     this._chunkGraph.addChunk(...data.getChunks());
     this._chunkGraph.addEntryPoint(...data.getEntryPoints());
+    this.onDataReport();
+  }
+
+  reportOtherReports(part: Partial<SDK.OtherReports>): void {
+    this._otherReports = {
+      ...this._otherReports,
+      ...part,
+    };
     this.onDataReport();
   }
 
@@ -506,7 +517,7 @@ export class RsdoctorSDK<
         return ctx._moduleGraph.toTreeShakingData();
       },
       get otherReports() {
-        return { treemapReportHtml: '' };
+        return { ...ctx._otherReports };
       },
     };
   }
@@ -550,7 +561,7 @@ export class RsdoctorSDK<
       chunkGraph: this._chunkGraph,
       packageGraph: this._packageGraph,
       loader: this._loader.slice(),
-      otherReports: { treemapReportHtml: '' },
+      otherReports: { ...this._otherReports },
     };
   }
 

--- a/packages/sdk/src/sdk/server/apis/graph.ts
+++ b/packages/sdk/src/sdk/server/apis/graph.ts
@@ -106,4 +106,11 @@ export class GraphAPI extends BaseAPI {
   > {
     return this.dataLoader.loadAPI(SDK.ServerAPI.API.GetEntryPoints);
   }
+
+  @Router.post(SDK.ServerAPI.API.GetChunkGroupGraph)
+  public async getChunkGroupGraph(): Promise<
+    SDK.ServerAPI.InferResponseType<SDK.ServerAPI.API.GetChunkGroupGraph>
+  > {
+    return this.dataLoader.loadAPI(SDK.ServerAPI.API.GetChunkGroupGraph);
+  }
 }

--- a/packages/sdk/src/sdk/utils/upload.ts
+++ b/packages/sdk/src/sdk/utils/upload.ts
@@ -1,11 +1,21 @@
+import path from 'node:path';
 import { DataWithUrl } from '../sdk/types';
 
 export const transformDataUrls = (
   d: DataWithUrl[],
+  baseDir?: string,
 ): Record<string, string[] | string> => {
   return d.reduce((t: { [key: string]: string[] | string }, item) => {
     t[item.name] = Array.isArray(item.files)
-      ? item.files.map((e) => e.path).concat(t[item.name] || [])
+      ? item.files
+          .map((e) => {
+            if (!baseDir) {
+              return e.path;
+            }
+
+            return path.relative(baseDir, e.path).split(path.sep).join('/');
+          })
+          .concat(t[item.name] || [])
       : item.files;
     return t;
   }, {});

--- a/packages/types/src/sdk/chunk-group.ts
+++ b/packages/types/src/sdk/chunk-group.ts
@@ -1,0 +1,117 @@
+export interface ChunkGroupGraphChunkData {
+  id: string;
+  name: string;
+  emittedSize: number;
+  totalJSSize: number;
+  moduleCount: number;
+  files: string[];
+}
+
+export interface ChunkGroupGraphModuleData {
+  id: string;
+  name: string;
+  resource: string | null;
+  size: number;
+}
+
+export type ChunkGroupGraphPathSeverity = 'normal' | 'warning' | 'danger';
+
+export interface ChunkGroupGraphImportData {
+  loc?: string;
+  request?: string;
+  snippet?: string;
+  sourceModule?: string | null;
+}
+
+export interface ChunkGroupGraphIncomingImportData
+  extends ChunkGroupGraphImportData {
+  edgeId: string;
+  from: string;
+  fromName: string;
+  to: string;
+  toName: string;
+}
+
+export interface ChunkGroupGraphPathData {
+  id: string;
+  label: string;
+  nodeIds: string[];
+  nodeNames: string[];
+  edgeIds: string[];
+  chunkIds: string[];
+  chunks: ChunkGroupGraphChunkData[];
+  totalEmittedSize: number;
+  totalJSSize: number;
+  unnecessarySize: number;
+  unnecessaryModuleCount: number;
+  ratio: number;
+  severity: ChunkGroupGraphPathSeverity;
+  topUnnecessaryModules: ChunkGroupGraphModuleData[];
+}
+
+export interface ChunkGroupGraphNodeData {
+  id: string;
+  name: string;
+  isInitial: boolean;
+  totalEmittedSize: number;
+  groupTotalJSSize: number;
+  actualModuleCount: number;
+  rootModuleCount: number;
+  reachableModuleCount: number;
+  localRemovableJSModuleCount: number;
+  localRemovableJSSize: number;
+  removableJSModuleCount: number;
+  removableJSSize: number;
+  inheritedRemovableJSModuleCount: number;
+  inheritedRemovableJSSize: number;
+  nonJSResidualCount: number;
+  chunks: ChunkGroupGraphChunkData[];
+  localRemovableJSModules: ChunkGroupGraphModuleData[];
+  inheritedRemovableJSModules: ChunkGroupGraphModuleData[];
+  removableJSModules: ChunkGroupGraphModuleData[];
+  incomingEdgeIds: string[];
+  outgoingEdgeIds: string[];
+  incomingImports: ChunkGroupGraphIncomingImportData[];
+  paths: ChunkGroupGraphPathData[];
+  pathCount: number;
+  pathsTruncated: boolean;
+  worstPathSeverity: ChunkGroupGraphPathSeverity;
+  maxPathUnnecessarySize: number;
+  maxPathRatio: number;
+  searchText: string;
+}
+
+export interface ChunkGroupGraphEdgeData {
+  id: string;
+  from: string;
+  to: string;
+  fromName: string;
+  toName: string;
+  imports: ChunkGroupGraphImportData[];
+}
+
+export interface ChunkGroupGraphOverviewData {
+  totalGroupCount: number;
+  entryGroupCount: number;
+  asyncGroupCount: number;
+  totalEdgeCount: number;
+  removableGroupCount: number;
+  warningGroupCount: number;
+  dangerGroupCount: number;
+  totalRemovableSize: number;
+  totalLocalRemovableSize: number;
+  totalInheritedRemovableSize: number;
+  totalPathCount: number;
+  warningPathCount: number;
+  dangerPathCount: number;
+  truncatedPathGroupCount: number;
+}
+
+export interface ChunkGroupGraphData {
+  nodes: ChunkGroupGraphNodeData[];
+  edges: ChunkGroupGraphEdgeData[];
+  overview: ChunkGroupGraphOverviewData;
+  entryNodeIds: string[];
+  priorityNodeIds: string[];
+  pathLimit: number;
+}

--- a/packages/types/src/sdk/index.ts
+++ b/packages/types/src/sdk/index.ts
@@ -3,6 +3,7 @@ export * from './resolver';
 export * from './plugin';
 export * from './module';
 export * from './chunk';
+export * from './chunk-group';
 export * from './result';
 export * from './summary';
 export * from './package';

--- a/packages/types/src/sdk/instance.ts
+++ b/packages/types/src/sdk/instance.ts
@@ -18,6 +18,7 @@ import { BriefModeOptions } from '../config';
 import { EmoCheckData } from '../emo';
 import { SummaryData } from './summary';
 import { ConfigData } from './config';
+import { OtherReports } from './package';
 
 export type WriteStoreOptionsType = {};
 
@@ -47,6 +48,7 @@ export interface RsdoctorBuilderSDKInstance extends RsdoctorSDKInstance {
   /** Report module chart data */
   reportModuleGraph(data: ModuleGraphInstance): void;
   reportChunkGraph(data: ChunkGraphInstance): void;
+  reportOtherReports(part: Partial<OtherReports>): void;
   /** report the data of summary */
   reportSummaryData(part: Partial<SummaryData>): void;
   /** Report sourceMap data */

--- a/packages/types/src/sdk/package.ts
+++ b/packages/types/src/sdk/package.ts
@@ -148,4 +148,6 @@ export interface PackageGraphData {
   dependencies: PackageDependencyData[];
 }
 
-export interface OtherReports {}
+export interface OtherReports {
+  chunkGroupGraph?: import('./chunk-group').ChunkGroupGraphData;
+}

--- a/packages/types/src/sdk/server/apis/graph.ts
+++ b/packages/types/src/sdk/server/apis/graph.ts
@@ -5,6 +5,7 @@ import {
   ChunkGraphData,
   EntryPointData,
 } from '../../chunk';
+import { ChunkGroupGraphData } from '../../chunk-group';
 import { ModuleData, ModuleGraphData, SideEffectCodeData } from '../../module';
 import { API } from './index';
 
@@ -21,6 +22,7 @@ export interface GraphAPIResponse {
   } & Pick<ModuleGraphData, 'dependencies'>;
   [API.GetModulesByModuleIds]: ModuleData[];
   [API.GetEntryPoints]: EntryPointData[];
+  [API.GetChunkGroupGraph]: ChunkGroupGraphData | undefined;
 }
 
 export interface GraphAPIRequestBody {

--- a/packages/types/src/sdk/server/apis/index.ts
+++ b/packages/types/src/sdk/server/apis/index.ts
@@ -61,6 +61,7 @@ export enum API {
   GetModuleDetails = '/api/graph/module/details',
   GetModulesByModuleIds = '/api/graph/modules/ids',
   GetEntryPoints = '/api/graph/entrypoints',
+  GetChunkGroupGraph = '/api/graph/chunk-group',
   GetModuleCodeByModuleId = '/api/graph/module/code',
   GetModuleCodeByModuleIds = '/api/graph/module/codes',
   GetAllModuleGraph = '/api/graph/module/all',
@@ -147,6 +148,7 @@ export interface ResponseTypes
     relativePath: string;
   }[];
   [API.GetAllChunkGraph]: SDK.ChunkData[];
+  [API.GetChunkGroupGraph]: SDK.ChunkGroupGraphData | undefined;
   [API.GetModuleByName]: { id: number; path: string }[];
   [API.GetModuleIssuerPath]: StatsModule['issuerPath'];
   [API.GetPackageInfo]: SDK.PackageData[];

--- a/packages/utils/src/common/data/index.ts
+++ b/packages/utils/src/common/data/index.ts
@@ -284,6 +284,11 @@ export class APIDataLoader {
           return Graph.getEntryPoints(entrypoints) as R;
         });
 
+      case SDK.ServerAPI.API.GetChunkGroupGraph:
+        return this.loader.loadData('otherReports').then((reports) => {
+          return reports?.chunkGroupGraph as R;
+        });
+
       case SDK.ServerAPI.API.GetModuleCodeByModuleId:
         return this.loader.loadData('moduleCodeMap').then((moduleCodeMap) => {
           const { moduleId } =


### PR DESCRIPTION
## Summary
- add a richer chunk group report payload to `/api/graph/chunk-group`, including overview stats, ranked group ids, path summaries, import origins, and search text for downstream rendering and analysis
- implement chunk group path analysis and inherited removable-size deduction in the core report builder, with regression coverage for path and removable-module semantics
- render the new payload in the bundle size UI with a searchable chunk group graph, sortable opportunity list, and collapsible load paths

## Testing
- `pnpm --filter @rsdoctor/types build`
- `pnpm --filter @rsdoctor/core build`
- `pnpm exec rstest run packages/core/tests/build/utils/chunk-group-report.test.ts`
- `pnpm --filter @rsdoctor/components build`
- `pnpm --filter @rsdoctor/client build` *(currently fails in this workspace because `@rsdoctor/components` package resolution is broken during client bundling, e.g. `@rsdoctor/components/utils` and `../storage.mjs`)*
