### PR TITLE
optimize: rsdoctor agent-cli

### DIFF
--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -1,5 +1,6 @@
 import { cac } from 'cac';
 
+import packageJson from '../package.json';
 import { createRsdoctorCliToolExecutor } from './executor';
 import { describeSubcommands, getToolCatalog, runAiCli } from './commands';
 
@@ -142,6 +143,8 @@ async function runRegisteredCommands(
   if (
     argv[0] !== '--help' &&
     argv[0] !== '-h' &&
+    argv[0] !== '--version' &&
+    argv[0] !== '-v' &&
     argv[0] !== 'list' &&
     argv[0] !== 'query'
   ) {
@@ -158,6 +161,11 @@ async function runRegisteredCommands(
       options.write(
         `rsdoctor-agent\n\nUsage:\n  $ rsdoctor-agent <command> [options]\n\nCommands:\n${commandHelp}\n`,
       );
+      return 0;
+    }
+
+    if (argv[0] === '--version' || argv[0] === '-v') {
+      options.write(`${packageJson.version}\n`);
       return 0;
     }
 

--- a/packages/agent-cli/src/commands/handlers/assets.ts
+++ b/packages/agent-cli/src/commands/handlers/assets.ts
@@ -4,7 +4,7 @@ import {
   getChunks,
   getAssets as getAssetsFromData,
 } from '../datasource';
-import { requireArg } from '../utils';
+import { omitModulesFields, requireArg } from '../utils';
 
 interface Asset {
   path: string;
@@ -229,21 +229,6 @@ const getAssetsDiffResult = (baseline: ChunkGraph, current: ChunkGraph) => ({
     ),
   },
 });
-
-const omitModulesFields = <T>(value: T): T => {
-  if (!value || typeof value !== 'object') {
-    return value;
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => omitModulesFields(item)) as T;
-  }
-
-  return Object.fromEntries(
-    Object.entries(value)
-      .filter(([key]) => key !== 'modules')
-      .map(([key, item]) => [key, omitModulesFields(item)]),
-  ) as T;
-};
 
 export async function listAssets(): Promise<{
   ok: boolean;

--- a/packages/agent-cli/src/commands/handlers/assets.ts
+++ b/packages/agent-cli/src/commands/handlers/assets.ts
@@ -230,6 +230,21 @@ const getAssetsDiffResult = (baseline: ChunkGraph, current: ChunkGraph) => ({
   },
 });
 
+const omitModulesFields = <T>(value: T): T => {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => omitModulesFields(item)) as T;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => key !== 'modules')
+      .map(([key, item]) => [key, omitModulesFields(item)]),
+  ) as T;
+};
+
 export async function listAssets(): Promise<{
   ok: boolean;
   data: unknown;
@@ -286,7 +301,10 @@ export async function getMediaAssets(): Promise<{
   const chunks = chunksResult.items || [];
   return {
     ok: true,
-    data: { guidance: 'Media asset optimization guidance.', chunks },
+    data: {
+      guidance: 'Media asset optimization guidance.',
+      chunks: omitModulesFields(chunks),
+    },
     description: 'Media asset optimization guidance.',
   };
 }

--- a/packages/agent-cli/src/commands/handlers/build.ts
+++ b/packages/agent-cli/src/commands/handlers/build.ts
@@ -5,7 +5,7 @@ import {
   getDataFilePath,
   getEntrypoints as getEntrypointsFromData,
 } from '../datasource';
-import { parsePositiveInt } from '../utils';
+import { omitModulesFields, parsePositiveInt } from '../utils';
 import { getMediaAssets } from './assets';
 import { getLargeChunksData } from './chunks';
 import { detectDuplicatePackages, detectSimilarPackages } from './packages';
@@ -23,21 +23,6 @@ function withoutDescription<T>(result: { ok: boolean; data: T }): {
     ok: result.ok,
     data: result.data,
   };
-}
-
-function omitModulesFields<T>(value: T): T {
-  if (!value || typeof value !== 'object') {
-    return value;
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => omitModulesFields(item)) as T;
-  }
-
-  return Object.fromEntries(
-    Object.entries(value)
-      .filter(([key]) => key !== 'modules')
-      .map(([key, item]) => [key, omitModulesFields(item)]),
-  ) as T;
 }
 
 export async function getSummary(): Promise<{

--- a/packages/agent-cli/src/commands/handlers/build.ts
+++ b/packages/agent-cli/src/commands/handlers/build.ts
@@ -25,6 +25,21 @@ function withoutDescription<T>(result: { ok: boolean; data: T }): {
   };
 }
 
+function omitModulesFields<T>(value: T): T {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => omitModulesFields(item)) as T;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => key !== 'modules')
+      .map(([key, item]) => [key, omitModulesFields(item)]),
+  ) as T;
+}
+
 export async function getSummary(): Promise<{
   ok: boolean;
   data: unknown;
@@ -81,10 +96,13 @@ async function executeStep1(): Promise<{
   const chunksArray = chunks as Chunk[];
 
   return {
-    duplicatePackages: withoutDescription(duplicatePackages),
-    similarPackages: withoutDescription(similarPackages),
-    mediaAssets: withoutDescription(mediaAssets),
-    largeChunks: { ok: true, data: getLargeChunksData(chunksArray) },
+    duplicatePackages: omitModulesFields(withoutDescription(duplicatePackages)),
+    similarPackages: omitModulesFields(withoutDescription(similarPackages)),
+    mediaAssets: omitModulesFields(withoutDescription(mediaAssets)),
+    largeChunks: omitModulesFields({
+      ok: true,
+      data: getLargeChunksData(chunksArray),
+    }),
   };
 }
 

--- a/packages/agent-cli/src/commands/handlers/chunks.ts
+++ b/packages/agent-cli/src/commands/handlers/chunks.ts
@@ -5,6 +5,21 @@ interface Chunk {
   size: number;
 }
 
+const omitModulesFields = <T>(value: T): T => {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => omitModulesFields(item)) as T;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => key !== 'modules')
+      .map(([key, item]) => [key, omitModulesFields(item)]),
+  ) as T;
+};
+
 export function getLargeChunksData(chunks: Chunk[]): {
   median: number;
   operator: number;
@@ -35,7 +50,7 @@ export async function listChunks(
 
   return {
     ok: true,
-    data: chunks,
+    data: omitModulesFields(chunks),
     description: 'List all chunks (id, name, size, modules).',
   };
 }
@@ -71,7 +86,7 @@ export async function findLargeChunks(): Promise<{
   }
   return {
     ok: true,
-    data: getLargeChunksData(chunks),
+    data: omitModulesFields(getLargeChunksData(chunks)),
     description:
       'Find oversized chunks (>30% over median size and >= 1MB) to prioritize splitChunks suggestions.',
   };

--- a/packages/agent-cli/src/commands/handlers/chunks.ts
+++ b/packages/agent-cli/src/commands/handlers/chunks.ts
@@ -1,24 +1,14 @@
 import { getChunks, getChunkById as getChunkByIdFromData } from '../datasource';
-import { getMedianChunkSize, parseNumber, parsePositiveInt } from '../utils';
+import {
+  getMedianChunkSize,
+  omitModulesFields,
+  parseNumber,
+  parsePositiveInt,
+} from '../utils';
 
 interface Chunk {
   size: number;
 }
-
-const omitModulesFields = <T>(value: T): T => {
-  if (!value || typeof value !== 'object') {
-    return value;
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => omitModulesFields(item)) as T;
-  }
-
-  return Object.fromEntries(
-    Object.entries(value)
-      .filter(([key]) => key !== 'modules')
-      .map(([key, item]) => [key, omitModulesFields(item)]),
-  ) as T;
-};
 
 export function getLargeChunksData(chunks: Chunk[]): {
   median: number;

--- a/packages/agent-cli/src/commands/handlers/chunks.ts
+++ b/packages/agent-cli/src/commands/handlers/chunks.ts
@@ -51,7 +51,7 @@ export async function listChunks(
   return {
     ok: true,
     data: omitModulesFields(chunks),
-    description: 'List all chunks (id, name, size, modules).',
+    description: 'List all chunks (id, name, size).',
   };
 }
 

--- a/packages/agent-cli/src/commands/handlers/tree-shaking.ts
+++ b/packages/agent-cli/src/commands/handlers/tree-shaking.ts
@@ -90,7 +90,7 @@ export async function getTreeShakingSummary(): Promise<{
       'Comprehensive tree-shaking health summary. ' +
       'Aggregates all three rule violations (E1007 side-effects-only imports, ' +
       'E1008 bare require() calls, E1009 ESM-resolved-to-CJS). ' +
-      'For detailed per-module bailout reasons, use the dedicated tree-shaking side-effects command. ' +
+      'For detailed per-module bailout reasons, use tree-shaking bailout-reasons or tree-shaking retained-modules. ' +
       'Rspack enables tree-shaking in production mode via usedExports, sideEffects, ' +
       'providedExports, and innerGraph — violations in this report indicate where those ' +
       'optimizations are being blocked. ' +

--- a/packages/agent-cli/src/commands/router.ts
+++ b/packages/agent-cli/src/commands/router.ts
@@ -129,7 +129,7 @@ function createOptimizeCommand(
 const SUBCOMMANDS: Record<string, Record<string, SubcommandDef>> = {
   chunks: {
     list: {
-      description: 'List all chunks (id, name, size, modules).',
+      description: 'List all chunks (id, name, size).',
       toolName: 'chunks_list',
       toolDescription:
         'List chunks with ids, names, sizes, and module counts for bundle composition analysis.',

--- a/packages/agent-cli/src/commands/utils.ts
+++ b/packages/agent-cli/src/commands/utils.ts
@@ -126,6 +126,21 @@ export function parseModulesInput(
   return parseCommaList(value);
 }
 
+export function omitModulesFields<T>(value: T): T {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => omitModulesFields(item)) as T;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => key !== 'modules')
+      .map(([key, item]) => [key, omitModulesFields(item)]),
+  ) as T;
+}
+
 export function paginateItems<T>(
   items: T[],
   pageNumber: number,

--- a/packages/agent-cli/tests/cli.test.ts
+++ b/packages/agent-cli/tests/cli.test.ts
@@ -4,6 +4,9 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { runCli } from '../src/cli';
+import packageJson from '../package.json';
+
+const expectedVersionOutput = `${packageJson.version}\n`;
 
 describe('agent cli', () => {
   it('lists the available subcommands for an external main agent', async () => {
@@ -56,7 +59,7 @@ describe('agent cli', () => {
 
     expect(exitCode).toBe(0);
     expect(stderr.join('')).toBe('');
-    expect(stdout.join('')).toBe('0.1.0-beta.0\n');
+    expect(stdout.join('')).toBe(expectedVersionOutput);
   });
 
   it('prints the package version with short option', async () => {
@@ -70,7 +73,7 @@ describe('agent cli', () => {
 
     expect(exitCode).toBe(0);
     expect(stderr.join('')).toBe('');
-    expect(stdout.join('')).toBe('0.1.0-beta.0\n');
+    expect(stdout.join('')).toBe(expectedVersionOutput);
   });
 
   it('invokes a named tool through the external agent query path', async () => {

--- a/packages/agent-cli/tests/cli.test.ts
+++ b/packages/agent-cli/tests/cli.test.ts
@@ -320,7 +320,7 @@ describe('agent cli', () => {
           },
         ],
       },
-      description: 'List all chunks (id, name, size, modules).',
+      description: 'List all chunks (id, name, size).',
     });
   });
 

--- a/packages/agent-cli/tests/cli.test.ts
+++ b/packages/agent-cli/tests/cli.test.ts
@@ -45,6 +45,34 @@ describe('agent cli', () => {
     expect(text).toContain('Execute one mapped tool from the catalog.');
   });
 
+  it('prints the package version', async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    const exitCode = await runCli(['--version'], {
+      write: (text) => stdout.push(text),
+      writeError: (text) => stderr.push(text),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr.join('')).toBe('');
+    expect(stdout.join('')).toBe('0.1.0-beta.0\n');
+  });
+
+  it('prints the package version with short option', async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    const exitCode = await runCli(['-v'], {
+      write: (text) => stdout.push(text),
+      writeError: (text) => stderr.push(text),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr.join('')).toBe('');
+    expect(stdout.join('')).toBe('0.1.0-beta.0\n');
+  });
+
   it('invokes a named tool through the external agent query path', async () => {
     const chunks: string[] = [];
     let capturedInput: Record<string, unknown> | undefined;
@@ -285,7 +313,6 @@ describe('agent cli', () => {
             id: 1,
             name: 'main',
             size: 1024,
-            modules: [],
             assets: [],
           },
         ],
@@ -348,7 +375,6 @@ describe('agent cli', () => {
           id: 2,
           name: 'async',
           size: 512,
-          modules: [],
           assets: [],
         },
       ],

--- a/packages/agent-cli/tests/rsdoctor-cli.test.ts
+++ b/packages/agent-cli/tests/rsdoctor-cli.test.ts
@@ -243,7 +243,6 @@ describe('rsdoctor cli tool executor', () => {
               id: 1,
               name: 'main',
               size: 10,
-              modules: [],
               assets: [
                 {
                   name: 'main.js',

--- a/packages/agent-cli/tests/rsdoctor-cli.test.ts
+++ b/packages/agent-cli/tests/rsdoctor-cli.test.ts
@@ -252,7 +252,7 @@ describe('rsdoctor cli tool executor', () => {
             },
           ],
         },
-        description: 'List all chunks (id, name, size, modules).',
+        description: 'List all chunks (id, name, size).',
       });
 
       const filteredSummary = await executor.execute({


### PR DESCRIPTION
## Summary
This pull request introduces several improvements and fixes to the agent CLI, focusing on version reporting and the consistent omission of the `modules` field from chunk-related outputs. The changes also update tests to reflect the new behavior and clarify tree-shaking guidance messaging.

**New Features and Enhancements:**

* **CLI Version Reporting:**
  - Added support for `--version` and `-v` flags to print the package version, along with corresponding tests for both options. 

**Data Output Consistency:**

* **Omit `modules` Field from Chunk Outputs:**
  - Introduced a reusable `omitModulesFields` utility function in multiple files to remove the `modules` property from chunk data structures and all related outputs. This affects handlers for assets, build, and chunks, ensuring that any API or CLI output no longer includes the `modules` field. 

**Documentation and Messaging:**

* **Clarified Tree-Shaking Guidance Message:**
  - Updated the tree-shaking summary message to reference the correct commands for detailed per-module bailout reasons.

## Related Links

<!--- Provide links of related issues or pages -->
