### PR TITLE
release v1.5.10

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/cli",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/client",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "main": "dist/index.html",
   "repository": {
     "type": "git",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/components",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "license": "MIT",
   "types": "dist/index.d.ts",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/core",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -2,7 +2,7 @@ import {
   RsdoctorRspackPluginOptions,
   RsdoctorRspackPluginOptionsNormalized,
 } from '@/types';
-import { Linter, Plugin, SDK } from '@rsdoctor/types';
+import { Config, Linter, Plugin, SDK } from '@rsdoctor/types';
 import { chalk, logger } from '@rsdoctor/utils/logger';
 import assert from 'assert';
 import {
@@ -32,6 +32,9 @@ function getDefaultSupports() {
     banner: undefined,
     gzip: true, // change the gzip to true by default.
   };
+}
+function isJsonOutputEnv(value: unknown): boolean {
+  return value === 'json';
 }
 function normalizeFeatures(features: any, mode: keyof typeof SDK.IMode) {
   if (Array.isArray(features)) {
@@ -71,6 +74,24 @@ function isValidMode(mode: any): mode is keyof typeof SDK.IMode {
 export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
   config: Plugin.RsdoctorWebpackPluginOptions<Rules> = {},
 ): Plugin.RsdoctorPluginOptionsNormalized<Rules> {
+  const userOutput = config.output;
+  const defaultOutput = getDefaultOutput();
+  const outputConfig: Config.IOutput<'brief' | 'normal'> = isJsonOutputEnv(
+    process.env.RSDOCTOR_OUTPUT,
+  )
+    ? {
+        reportDir: userOutput?.reportDir,
+        compressData: userOutput?.compressData,
+        mode: 'brief' as const,
+        options: {
+          type: ['json'] as Array<'json'>,
+        },
+      }
+    : (userOutput ?? defaultOutput);
+  const normalizedConfig = {
+    ...config,
+    output: outputConfig,
+  };
   const {
     linter = {},
     features = {},
@@ -78,13 +99,13 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     disableClientServer: userDisableClientServer = false,
     sdkInstance,
     innerClientPath = '',
-    output = getDefaultOutput(),
+    output = outputConfig,
     supports = getDefaultSupports(),
     port,
     printLog = { serverUrls: true },
     mode = undefined,
     brief = undefined,
-  } = config;
+  } = normalizedConfig;
   // If process.env.RSTEST is set to true, disableClientServer should be false
   // Otherwise, if process.env.CI is set, disableClientServer should be true
   const disableClientServer =

--- a/packages/core/tests/build/utils/config.test.ts
+++ b/packages/core/tests/build/utils/config.test.ts
@@ -7,6 +7,7 @@ const originalConsoleLog = console.log;
 let consoleOutput: string[] = [];
 const originalEnvCI = process.env.CI;
 const originalEnvRSTEST = process.env.RSTEST;
+const originalEnvRSDOCTOROUTPUT = process.env.RSDOCTOR_OUTPUT;
 
 beforeEach(() => {
   consoleOutput = [];
@@ -15,6 +16,7 @@ beforeEach(() => {
   };
   delete process.env.CI;
   delete process.env.RSTEST;
+  delete process.env.RSDOCTOR_OUTPUT;
 });
 
 afterEach(() => {
@@ -28,6 +30,11 @@ afterEach(() => {
     process.env.RSTEST = originalEnvRSTEST;
   } else {
     delete process.env.RSTEST;
+  }
+  if (originalEnvRSDOCTOROUTPUT !== undefined) {
+    process.env.RSDOCTOR_OUTPUT = originalEnvRSDOCTOROUTPUT;
+  } else {
+    delete process.env.RSDOCTOR_OUTPUT;
   }
 });
 
@@ -228,6 +235,29 @@ describe('normalizeUserConfig', () => {
   });
 
   describe('mode priority', () => {
+    it('should use brief json output when RSDOCTOR_OUTPUT is json', () => {
+      process.env.RSDOCTOR_OUTPUT = 'json';
+
+      const result = normalizeUserConfig();
+
+      expect(result.output.mode).toBe('brief');
+      expect(result.output.options).toEqual({
+        type: ['json'],
+        htmlOptions: {
+          reportHtmlName: undefined,
+          writeDataJson: false,
+        },
+        jsonOptions: {
+          fileName: 'rsdoctor-data.json',
+          sections: {
+            moduleGraph: true,
+            chunkGraph: true,
+            rules: true,
+          },
+        },
+      });
+    });
+
     it('should prioritize output.mode over mode', () => {
       const result = normalizeUserConfig({
         mode: 'normal',

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/docs",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "scripts": {
     "dev": "cross-env RSPRESS_PERSIST_CACHE=false rspress dev",
     "build": "cross-env RSPRESS_PERSIST_CACHE=false rspress build && sh build.sh",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/graph",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/rspack-plugin/package.json
+++ b/packages/rspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/rspack-plugin",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/sdk",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/types",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/utils",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/webpack-plugin",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",


### PR DESCRIPTION
## Summary
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat(agent-cli): support agent-cli by @yifancong in https://github.com/web-infra-dev/rsdoctor/pull/1618
### Bug Fixes 🐞
* fix(build): add cjs declaration exports by @yifancong in https://github.com/web-infra-dev/rsdoctor/pull/1635
### Document 📖
* docs: add agent cli guide by @yifancong in https://github.com/web-infra-dev/rsdoctor/pull/1649
### Other Changes
* chore(deps): update all patch dependencies by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1631
* Release: v1.5.9 by @yifancong in https://github.com/web-infra-dev/rsdoctor/pull/1629
* chore(deps): update rstackjs/rstack-ecosystem-ci digest to 6680c15 by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1630
* chore(deps): update actions/setup-node action to v6.4.0 by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1632
* chore(deps): update dependency @changesets/cli to ^2.31.0 by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1633
* chore(deps): fix dependabot alerts by @yifancong in https://github.com/web-infra-dev/rsdoctor/pull/1623
* chore: change to use pnpm catalog by @yifancong in https://github.com/web-infra-dev/rsdoctor/pull/1634
* chore(deps): update all patch dependencies by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1638
* chore(deps): update actions/setup-node digest to 48b55a0 by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1636
* chore(deps): update dependency @lynx-js/react to ^0.120.0 by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1640
* chore(deps): update rstackjs/rstack-ecosystem-ci digest to 9758026 by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1637
* chore(deps): update all patch dependencies by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1643
* chore(deps): update rstackjs/rstack-ecosystem-ci digest to f767cdd by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1642
* chore(deps): update dependency @lynx-js/rspeedy to ^0.14.3 by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1644
* chore(deps): update dependency node-forge to v1.4.0 by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1646
* chore(deps): unify rsbuild rspack and rslint versions via catalog by @yifancong in https://github.com/web-infra-dev/rsdoctor/pull/1648
* optimize: rsdoctor agent-cli by @yifancong in https://github.com/web-infra-dev/rsdoctor/pull/1650
* Release @rsdoctor/agent-cli v0.1.0 by @yifancong in https://github.com/web-infra-dev/rsdoctor/pull/1651


**Full Changelog**: https://github.com/web-infra-dev/rsdoctor/compare/V1.5.9...v1.5.10
## Related Links

<!--- Provide links of related issues or pages -->
