### PR TITLE
chore(deps): update pnpm workspace config

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,27 +51,9 @@
     "prettier": "^3.8.3",
     "rsbuild-plugin-publint": "^0.3.4"
   },
-  "pnpm": {
-    "overrides": {
-      "@remix-run/router": "1.23.2",
-      "call-bind-apply-helpers": "1.0.2",
-      "es-object-atoms": "1.1.1",
-      "get-intrinsic": "1.3.0",
-      "node-forge": "1.4.0",
-      "qs": "6.15.1",
-      "rc-dialog": "9.1.0",
-      "rc-tree": "5.7.2",
-      "react-dom": "18.3.1",
-      "socket.io-parser": "4.2.6",
-      "minimatch": "^9.0.9",
-      "sirv": "3.0.2",
-      "tar": "7.5.15",
-      "tslib": "2.8.1"
-    }
-  },
-  "packageManager": "pnpm@10.17.1",
+  "packageManager": "pnpm@10.33.4",
   "engines": {
-    "node": ">=16.20.2",
-    "pnpm": ">=10.17.1"
+    "node": ">=18.0.0",
+    "pnpm": ">=10.33.4"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,16 @@
 packages:
-  - 'e2e/**'
-  - 'scripts/**'
-  - 'packages/**'
-  - 'examples/**'
+  - e2e/**
+  - scripts/**
+  - packages/**
+  - examples/**
   - '!**/compiled/**'
 
+allowBuilds:
+  '@swc/core': false
+  core-js: false
+  core-js-pure: false
+  esbuild: true
+  nx: false
 
 catalog:
   '@rsbuild/core': 2.0.5
@@ -16,11 +22,11 @@ catalog:
   '@rsbuild/plugin-svgr': 2.0.2
   '@rsbuild/plugin-type-check': ^1.3.4
   '@rslint/core': ^0.5.2
-  '@rstest/core': 0.9.10
   '@rspack/cli': 2.0.2
   '@rspack/core': 2.0.2
   '@rspack/plugin-react-refresh': 2.0.0
   '@rspack/resolver': 0.2.8
+  '@rstest/core': 0.9.10
   '@types/body-parser': 1.19.6
   '@types/connect': 3.4.38
   '@types/estree': 1.0.5
@@ -49,3 +55,32 @@ catalog:
   source-map: ^0.7.6
   tslib: 2.8.1
   typescript: ^5.9.2
+
+minimumReleaseAge: 1440
+
+minimumReleaseAgeExclude:
+  - '@rspack/*'
+  - '@rsbuild/*'
+  - '@rslib/*'
+  - '@rspress/*'
+  - '@rstest/*'
+  - '@rsdoctor/*'
+  - '@rslint/*'
+
+overrides:
+  '@remix-run/router': 1.23.2
+  call-bind-apply-helpers: 1.0.2
+  es-object-atoms: 1.1.1
+  get-intrinsic: 1.3.0
+  minimatch: ^9.0.9
+  node-forge: 1.4.0
+  qs: 6.15.1
+  rc-dialog: 9.1.0
+  rc-tree: 5.7.2
+  react-dom: 18.3.1
+  sirv: 3.0.2
+  socket.io-parser: 4.2.6
+  tar: 7.5.15
+  tslib: 2.8.1
+
+strictDepBuilds: true


### PR DESCRIPTION
## Summary

This PR updates the pnpm workspace configuration for stricter installs: it pins pnpm 10.33.4, moves package overrides into pnpm-workspace.yaml, and enables dependency build controls plus release-age safeguards.

## Related Links

None