### PR TITLE
chore(agent-cli): remove ignoreDeprecations from tsconfig

### DIFF
--- a/packages/agent-cli/tsconfig.json
+++ b/packages/agent-cli/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "experimentalDecorators": true,
     "outDir": "./dist",
-    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
## Summary

- Remove the obsolete `ignoreDeprecations` compiler option from `packages/agent-cli/tsconfig.json`.
- Keep the agent CLI TypeScript config aligned with the rest of the workspace.

## Related Links

None.

## Validation

- `pnpm --filter @rsdoctor/agent-cli run build`
- `pnpm --filter @rsdoctor/agent-cli run test`
