### PR TITLE
chore(deps): add renovate security preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,7 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     'config:recommended',
+    'github>rstackjs/renovate:security',
     'schedule:weekly',
     'helpers:pinGitHubActionDigests',
   ],


### PR DESCRIPTION
## Summary

- Add `github>rstackjs/renovate:security` to the Renovate presets.
- This keeps the minimal release age (`minimumReleaseAge`) behavior aligned with the pnpm settings from the shared Rstack preset.

## Related Links

- https://github.com/rstackjs/renovate#security-preset