### PR TITLE
refactor(sdk): replace socket.io with native ws transport

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -63,7 +63,6 @@
     'rc-dialog',
     'monaco-editor',
     'react-i18next',
-    'socket.io-client',
     'react-router-dom',
     'tsx',
     '@types/estree',

--- a/examples/rsbuild-minimal/rsbuild.config.ts
+++ b/examples/rsbuild-minimal/rsbuild.config.ts
@@ -18,15 +18,15 @@ export default defineConfig({
         {
           disableClientServer: !process.env.ENABLE_CLIENT_SERVER,
           features: ['resolver', 'bundle', 'plugins', 'loader'],
-          output: {
-            mode: 'brief',
-            options: {
-              type: ['json', 'html'],
-            },
-            reportCodeType: {
-              noCode: true,
-            },
-          },
+          // output: {
+          //   mode: 'brief',
+          //   options: {
+          //     type: ['json', 'html'],
+          //   },
+          //   reportCodeType: {
+          //     noCode: true,
+          //   },
+          // },
           linter: {
             level: 'Error',
             extends: [AssetsCountLimit],

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -30,7 +30,6 @@
     "@rstest/core": "catalog:",
     "@types/node": "catalog:",
     "prebundle": "catalog:",
-    "socket.io-client": "catalog:",
     "typescript": "catalog:",
     "zod": "^4.4.3"
   },

--- a/packages/ai/prebundle.config.mjs
+++ b/packages/ai/prebundle.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('prebundle').Config} */
 export default {
-  dependencies: ['socket.io-client'],
+  dependencies: [],
   exclude: ['@rsdoctor/types', '@rsdoctor/utils'],
 
   build: {

--- a/packages/ai/src/server/request.ts
+++ b/packages/ai/src/server/request.ts
@@ -1,25 +1,9 @@
-import { Socket, io } from 'socket.io-client';
-import { logger } from '@rsdoctor/utils/logger';
 import { GlobalConfig } from '@rsdoctor/utils/common';
+import { logger } from '@rsdoctor/utils/logger';
 import fs from 'node:fs';
 
-const map: Record<string, Socket> = {};
-
-// 使用 logger.error 输出日志
-export const createSocket = (url: string): Socket => {
-  logger.error(map[url]);
-  if (map[url]) return map[url];
-  const socket = io(url, {});
-  logger.error('socket created', url);
-  socket.on('connect', () => {
-    logger.error(`Socket Connect ${url}`);
-  });
-  map[url] = socket;
-  return socket;
-};
-
 export function getPortFromArgs(): number {
-  const args = process.argv.slice(2); // Skip the first two elements
+  const args = process.argv.slice(2);
   const portIndex = args.indexOf('--port');
   const compilerIndex = args.indexOf('--compiler');
   if (portIndex !== -1 && args[portIndex + 1]) {
@@ -34,26 +18,27 @@ export function getPortFromArgs(): number {
     }
   }
 
-  // If no port is specified, use the default port.
   return 3000;
 }
 
-export const getWsUrl = async () => {
+export const getServerUrl = async () => {
   const port = getPortFromArgs();
-  logger.error(`Socket will start on port: ${port}`);
-  return `ws://localhost:${port}`;
+  logger.error(`HTTP requests will use port: ${port}`);
+  return `http://localhost:${port}`;
 };
 
 export const sendRequest = async (api: string, params = {}) => {
-  const url = await getWsUrl();
-  const socket = createSocket(url);
-  logger.error('[mcp]socket client is started');
-  const res = await new Promise((resolve) => {
-    socket.emit(api, params, (res: any) => {
-      resolve(res.res);
-    });
+  const response = await fetch(`${await getServerUrl()}${api}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
   });
-  return res;
+
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+
+  return response.json();
 };
 
 export const getMcpPort = (compiler?: string) => {

--- a/packages/ai/src/server/tools.ts
+++ b/packages/ai/src/server/tools.ts
@@ -1,5 +1,5 @@
 import { SDK } from '@rsdoctor/types';
-import { getWsUrl, sendRequest } from './socket.js';
+import { getServerUrl, sendRequest } from './request.js';
 import { toolDescriptions } from '@/prompt/bundle.js';
 
 export enum Tools {
@@ -375,5 +375,5 @@ export const getLoaderTimes = async () => {
 };
 
 export const getPort = async () => {
-  return getWsUrl();
+  return getServerUrl();
 };

--- a/packages/ai/tests/request.test.ts
+++ b/packages/ai/tests/request.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import { SDK } from '@rsdoctor/types';
+import { sendRequest } from '../src/server/request';
+
+describe('http transport', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('sendRequest() posts JSON to the local Rsdoctor server', async () => {
+    const fetchMock = rs.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ value: 'ok' }),
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const res = await sendRequest(SDK.ServerAPI.API.GetChunkGraphAI, {
+      limit: 3,
+    });
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsedUrl = new URL(url);
+
+    expect(parsedUrl.hostname).toBe('localhost');
+    expect(parsedUrl.pathname).toBe(SDK.ServerAPI.API.GetChunkGraphAI);
+    expect(init).toMatchObject({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ limit: 3 }),
+    });
+    expect(res).toStrictEqual({ value: 'ok' });
+  });
+});

--- a/packages/ai/tests/socket.test.ts
+++ b/packages/ai/tests/socket.test.ts
@@ -1,8 +1,0 @@
-import { expect, test } from '@rstest/core';
-import { createSocket, sendRequest } from '../src/server/socket';
-import { SDK } from '@rsdoctor/types';
-
-test('createSocket', async () => {
-  const res = await sendRequest(SDK.ServerAPI.API.GetChunkGraph, {});
-  console.log(res);
-});

--- a/packages/client/rsbuild.config.ts
+++ b/packages/client/rsbuild.config.ts
@@ -127,7 +127,7 @@ export default defineConfig(({ env }) => {
             vender: {
               chunks: 'all',
               name: 'vender',
-              test: /node_modules\/(acorn|lodash|i18next|socket.io-*|remark-*)/,
+              test: /node_modules\/(acorn|lodash|i18next|remark-*)/,
               maxSize: 1000000,
               minSize: 200000,
             },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -79,7 +79,6 @@
     "react-i18next": "12.0.0",
     "react-json-view": "1.21.3",
     "react-markdown": "catalog:",
-    "socket.io-client": "catalog:",
     "url-parse": "1.5.10"
   },
   "peerDependencies": {

--- a/packages/components/src/components/Manifest/api.tsx
+++ b/packages/components/src/components/Manifest/api.tsx
@@ -111,10 +111,10 @@ export const ServerAPIProvider = <
   useEffect(() => {
     if (!loader) return;
     // add update event listener
-    loader.onDataUpdate(api, update);
+    loader.onDataUpdate(api, body, update);
     return () => {
       // remove update event when the component unmount.
-      loader.removeOnDataUpdate(api, update);
+      loader.removeOnDataUpdate(api, body, update);
     };
   }, [loader, api, body]);
 

--- a/packages/components/src/utils/data/base.ts
+++ b/packages/components/src/utils/data/base.ts
@@ -76,17 +76,25 @@ export abstract class BaseDataLoader implements Manifest.ManifestDataLoader {
 
   abstract loadAPI<
     T extends SDK.ServerAPI.API,
-    B extends
-      SDK.ServerAPI.InferRequestBodyType<T> = SDK.ServerAPI.InferRequestBodyType<T>,
-    R extends
-      SDK.ServerAPI.InferResponseType<T> = SDK.ServerAPI.InferResponseType<T>,
+    B extends SDK.ServerAPI.InferRequestBodyType<T> =
+      SDK.ServerAPI.InferRequestBodyType<T>,
+    R extends SDK.ServerAPI.InferResponseType<T> =
+      SDK.ServerAPI.InferResponseType<T>,
   >(...args: B extends void ? [api: T] : [api: T, body: B]): Promise<R>;
 
   public abstract onDataUpdate<
     T extends SDK.ServerAPI.API | SDK.ServerAPI.APIExtends,
-  >(api: T, fn: (response: SDK.ServerAPI.SocketResponseType<T>) => void): void;
+  >(
+    api: T,
+    body: SDK.ServerAPI.InferRequestBodyType<T, null> | null,
+    fn: (response: SDK.ServerAPI.SocketResponseType<T>) => void,
+  ): void;
 
   public abstract removeOnDataUpdate<
     T extends SDK.ServerAPI.API | SDK.ServerAPI.APIExtends,
-  >(api: T, fn: (response: SDK.ServerAPI.SocketResponseType<T>) => void): void;
+  >(
+    api: T,
+    body: SDK.ServerAPI.InferRequestBodyType<T, null> | null,
+    fn: (response: SDK.ServerAPI.SocketResponseType<T>) => void,
+  ): void;
 }

--- a/packages/components/src/utils/data/local.test.ts
+++ b/packages/components/src/utils/data/local.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import { SDK } from '@rsdoctor/types';
+import { LocalServerDataLoader } from './local';
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  public readyState = 0;
+
+  public sentMessages: string[] = [];
+
+  private listeners = new Map<
+    string,
+    Set<(event?: { data: string }) => void>
+  >();
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  addEventListener(
+    event: string,
+    listener: (event?: { data: string }) => void,
+  ) {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event)!.add(listener);
+  }
+
+  send(message: string) {
+    this.sentMessages.push(message);
+  }
+
+  trigger(event: string, data?: string) {
+    if (event === 'open') {
+      this.readyState = 1;
+    }
+    this.listeners
+      .get(event)
+      ?.forEach((listener) =>
+        listener(data === undefined ? undefined : { data }),
+      );
+  }
+}
+
+describe('LocalServerDataLoader', () => {
+  const originalFetch = globalThis.fetch;
+  const originalWebSocket = globalThis.WebSocket;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    globalThis.WebSocket = originalWebSocket;
+    MockWebSocket.instances = [];
+    rs.restoreAllMocks();
+  });
+
+  it('disposes subscriptions when request body strings contain delimiters', () => {
+    const loader = new LocalServerDataLoader({
+      data: {},
+    } as any);
+
+    loader.onDataUpdate(
+      SDK.ServerAPI.API.GetModuleByName,
+      { name: 'foo::bar' } as any,
+      rs.fn(),
+    );
+
+    expect(() => loader.dispose()).not.toThrow();
+  });
+
+  it('loads APIs through websocket requests', async () => {
+    globalThis.WebSocket = MockWebSocket as any;
+    const fetchMock = rs.fn();
+    globalThis.fetch = fetchMock as typeof fetch;
+    const loader = new LocalServerDataLoader({
+      data: {},
+      __SOCKET__PORT__: '3083',
+    } as any);
+
+    const task = loader.loadAPI(SDK.ServerAPI.API.GetAllModuleGraph, {} as any);
+    const socket = MockWebSocket.instances[0];
+    socket.trigger('open');
+    const request = JSON.parse(socket.sentMessages[0]);
+
+    socket.trigger(
+      'message',
+      JSON.stringify({
+        type: 'response',
+        id: request.id,
+        payload: [{ id: 1 }],
+      }),
+    );
+
+    await expect(task).resolves.toStrictEqual([{ id: 1 }]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/components/src/utils/data/local.ts
+++ b/packages/components/src/utils/data/local.ts
@@ -2,13 +2,23 @@ import { Manifest as ManifestShared } from '@rsdoctor/utils/common';
 import { Common, Manifest, SDK } from '@rsdoctor/types';
 import { get } from 'es-toolkit/compat';
 import { BaseDataLoader } from './base';
-import { getSocket } from '../socket';
+import { postServerAPI } from '../request';
+import {
+  requestServerAPI,
+  subscribeServerAPI,
+  unsubscribeServerAPI,
+} from '../socket';
+
+type DataUpdateAPI = SDK.ServerAPI.API | SDK.ServerAPI.APIExtends;
+
+type DataUpdateSubscription = {
+  api: DataUpdateAPI;
+  body: SDK.ServerAPI.InferRequestBodyType<DataUpdateAPI, null> | null;
+  listeners: Set<Common.Function>;
+};
 
 export class LocalServerDataLoader extends BaseDataLoader {
-  protected events: Map<
-    SDK.ServerAPI.API | SDK.ServerAPI.APIExtends,
-    Set<Common.Function>
-  > = new Map();
+  protected events: Map<string, DataUpdateSubscription> = new Map();
 
   public isLocal() {
     return true;
@@ -30,21 +40,12 @@ export class LocalServerDataLoader extends BaseDataLoader {
       // sharding files
       if (ManifestShared.isShardingData(res)) {
         if (!this.shardingDataMap.has(key)) {
-          const task = new Promise((resolve) => {
-            getSocket().emit(
-              SDK.ServerAPI.API.LoadDataByKey,
-              { key },
-              (
-                res: SDK.ServerAPI.SocketResponseType<SDK.ServerAPI.API.LoadDataByKey>,
-              ) => {
-                resolve(res.res);
-              },
-            );
+          const task = postServerAPI(SDK.ServerAPI.API.LoadDataByKey, {
+            key,
+          }).catch((err) => {
+            this.log(`loadData error: `, res, key);
+            throw err;
           });
-          // const task = postServerAPI(SDK.ServerAPI.API.LoadDataByKey, { key }).catch((err) => {
-          //   this.log(`loadData error: `, res, key);
-          //   throw err;
-          // });
           // save with every key
           this.shardingDataMap.set(key, task);
         }
@@ -60,10 +61,10 @@ export class LocalServerDataLoader extends BaseDataLoader {
 
   public async loadAPI<
     T extends SDK.ServerAPI.API,
-    B extends
-      SDK.ServerAPI.InferRequestBodyType<T> = SDK.ServerAPI.InferRequestBodyType<T>,
-    R extends
-      SDK.ServerAPI.InferResponseType<T> = SDK.ServerAPI.InferResponseType<T>,
+    B extends SDK.ServerAPI.InferRequestBodyType<T> =
+      SDK.ServerAPI.InferRequestBodyType<T>,
+    R extends SDK.ServerAPI.InferResponseType<T> =
+      SDK.ServerAPI.InferResponseType<T>,
   >(...args: B extends void ? [api: T] : [api: T, body: B]): Promise<R> {
     const [api, body] = args;
     // request limitation key
@@ -71,31 +72,26 @@ export class LocalServerDataLoader extends BaseDataLoader {
     const socketPort = this.get('__SOCKET__PORT__') ?? '';
 
     return this.limit(key, async () => {
-      return new Promise((resolve) => {
-        getSocket(socketPort).emit(
+      try {
+        return (await requestServerAPI(
           api,
-          body,
-          (res: SDK.ServerAPI.SocketResponseType<T>) => {
-            resolve(res.res as R);
-          },
-        );
-      });
-      // const res = await postServerAPI(...args).catch((err) => {
-      //   this.log(`loadAPI error: `, key);
-      //   throw err;
-      // });
-
-      // return res as R;
+          body as SDK.ServerAPI.InferRequestBodyType<T>,
+          socketPort,
+        )) as R;
+      } catch (err) {
+        this.log(`loadAPI error: `, key);
+        throw err;
+      }
     });
   }
 
   public dispose() {
     super.dispose();
-    this.events.forEach((evs, api) => {
-      evs.forEach((ev) => {
-        this.removeOnDataUpdate(api, ev);
+    this.events.forEach(({ api, body, listeners }) => {
+      listeners.forEach((listener) => {
+        this.removeOnDataUpdate(api, body, listener);
       });
-      evs.clear();
+      listeners.clear();
     });
     this.events.clear();
   }
@@ -105,24 +101,39 @@ export class LocalServerDataLoader extends BaseDataLoader {
    */
   public onDataUpdate<T extends SDK.ServerAPI.API | SDK.ServerAPI.APIExtends>(
     api: T,
+    body: SDK.ServerAPI.InferRequestBodyType<T, null> | null,
     fn: (response: SDK.ServerAPI.SocketResponseType<T>) => void,
   ) {
-    if (!this.events.has(api)) {
-      this.events.set(api, new Set());
+    const normalizedBody = body ?? null;
+    const key = `${api}::${JSON.stringify(normalizedBody)}`;
+    if (!this.events.has(key)) {
+      this.events.set(key, {
+        api,
+        body: normalizedBody,
+        listeners: new Set(),
+      });
     }
 
-    if (this.events.get(api)!.has(fn)) {
+    const subscription = this.events.get(key)!;
+    if (subscription.listeners.has(fn)) {
       return;
     }
 
-    this.events.get(api)!.add(fn);
-    getSocket().on(api as string, fn);
+    subscription.listeners.add(fn);
+    const socketPort = this.get('__SOCKET__PORT__') ?? '';
+    subscribeServerAPI(api, normalizedBody, fn, socketPort);
   }
 
   public removeOnDataUpdate<
     T extends SDK.ServerAPI.API | SDK.ServerAPI.APIExtends,
-  >(api: T, fn: (response: SDK.ServerAPI.SocketResponseType<T>) => void) {
-    getSocket().off(api as string, fn);
-    this.events.get(api)!.delete(fn);
+  >(
+    api: T,
+    body: SDK.ServerAPI.InferRequestBodyType<T, null> | null,
+    fn: (response: SDK.ServerAPI.SocketResponseType<T>) => void,
+  ) {
+    const key = `${api}::${JSON.stringify(body ?? null)}`;
+    const socketPort = this.get('__SOCKET__PORT__') ?? '';
+    unsubscribeServerAPI(api, body, fn, socketPort);
+    this.events.get(key)?.listeners.delete(fn);
   }
 }

--- a/packages/components/src/utils/request.test.ts
+++ b/packages/components/src/utils/request.test.ts
@@ -58,4 +58,26 @@ describe('request utils', () => {
     });
     expect(result).toStrictEqual({ ok: true });
   });
+
+  it('postServerAPI() omits request body when body is null', async () => {
+    const fetchMock = rs.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+    process.env.NODE_ENV = 'production';
+
+    const result = await (postServerAPI as any)('/api/demo', null);
+    const [url, init] = fetchMock.mock.calls[0];
+
+    expect(url).toContain('/api/demo?_t=');
+    expect(init).toMatchObject({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    expect(init).not.toHaveProperty('body');
+    expect(result).toStrictEqual({ ok: true });
+  });
 });

--- a/packages/components/src/utils/request.ts
+++ b/packages/components/src/utils/request.ts
@@ -155,14 +155,19 @@ export async function postServerAPI<
 >(...args: B extends void ? [api: T] : [api: T, body: B]): Promise<R> {
   const [api, body] = args;
   const timeout = process.env.NODE_ENV === 'development' ? 10000 : 60000;
+  const requestInit: Fetch.FetchOptions = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    timeout,
+  };
+
+  if (body != null) {
+    requestInit.body = JSON.stringify(body);
+  }
+
   const res = await Fetch.fetchWithTimeout(
     resolveRequestUrl(`${api}?_t=${random()}`),
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: body === undefined ? undefined : JSON.stringify(body),
-      timeout,
-    },
+    requestInit,
   );
   return (await res.json()) as R;
 }

--- a/packages/components/src/utils/socket.test.ts
+++ b/packages/components/src/utils/socket.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import { SDK } from '@rsdoctor/types';
+import {
+  formatURL,
+  publishServerSocketMessage,
+  requestServerAPI,
+  subscribeServerAPI,
+} from './socket';
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  public readyState = 0;
+
+  public sentMessages: string[] = [];
+
+  private listeners = new Map<
+    string,
+    Set<(event?: { data: string }) => void>
+  >();
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  addEventListener(
+    event: string,
+    listener: (event?: { data: string }) => void,
+  ) {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event)!.add(listener);
+  }
+
+  send(message: string) {
+    this.sentMessages.push(message);
+  }
+
+  trigger(event: string, data?: string) {
+    if (event === 'open') {
+      this.readyState = 1;
+    }
+    this.listeners
+      .get(event)
+      ?.forEach((listener) =>
+        listener(data === undefined ? undefined : { data }),
+      );
+  }
+}
+
+describe('websocket transport', () => {
+  const originalLocation = globalThis.location;
+  const originalWebSocket = globalThis.WebSocket;
+
+  afterEach(() => {
+    rs.restoreAllMocks();
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+    globalThis.WebSocket = originalWebSocket;
+    MockWebSocket.instances = [];
+  });
+
+  it('dispatches server push payloads to subscribers by api', () => {
+    const callback = rs.fn();
+    const api = SDK.ServerAPI.APIExtends.GetCompileProgress;
+    const unsubscribe = subscribeServerAPI(api, null, callback);
+
+    publishServerSocketMessage({
+      api,
+      payload: {
+        req: { api, body: undefined },
+        res: { percentage: 50, message: 'building' },
+      },
+    });
+
+    expect(callback).toHaveBeenCalledWith({
+      req: { api, body: undefined },
+      res: { percentage: 50, message: 'building' },
+    });
+
+    unsubscribe();
+  });
+
+  it('formats non-localhost socket urls with websocket protocol', () => {
+    expect(
+      formatURL({
+        port: '3000',
+        protocol: 'https:',
+        hostname: 'example.com',
+      }),
+    ).toBe('wss://example.com/');
+  });
+
+  it('removes subscriptions when the last listener unsubscribes', () => {
+    globalThis.WebSocket = MockWebSocket as any;
+
+    const api = SDK.ServerAPI.API.GetModuleByName;
+    const body = { name: 'foo' };
+    const unsubscribe = subscribeServerAPI(api, body as any, rs.fn(), '3081');
+    const staleSocket = MockWebSocket.instances[0];
+
+    unsubscribe();
+    staleSocket.trigger('close');
+
+    subscribeServerAPI(SDK.ServerAPI.API.GetProjectInfo, null, rs.fn(), '3081');
+    const reconnectedSocket = MockWebSocket.instances[1];
+    reconnectedSocket.trigger('open');
+
+    expect(
+      reconnectedSocket.sentMessages.map((message) => JSON.parse(message)),
+    ).toStrictEqual([
+      {
+        type: 'subscribe',
+        api: SDK.ServerAPI.API.GetProjectInfo,
+        body: null,
+      },
+    ]);
+  });
+
+  it('sends unsubscribe messages when the last listener unsubscribes', () => {
+    globalThis.WebSocket = MockWebSocket as any;
+
+    const api = SDK.ServerAPI.API.GetModuleByName;
+    const body = { name: 'foo' };
+    const unsubscribe = subscribeServerAPI(api, body as any, rs.fn(), '3084');
+    const socket = MockWebSocket.instances[0];
+    socket.trigger('open');
+
+    unsubscribe();
+
+    expect(
+      socket.sentMessages.map((message) => JSON.parse(message)),
+    ).toContainEqual({
+      type: 'unsubscribe',
+      api,
+      body,
+    });
+  });
+
+  it('resolves request responses sent over websocket', async () => {
+    globalThis.WebSocket = MockWebSocket as any;
+
+    const request = requestServerAPI(
+      SDK.ServerAPI.API.GetAllModuleGraph,
+      {},
+      '3082',
+    );
+    const socket = MockWebSocket.instances[0];
+    socket.trigger('open');
+    const [message] = socket.sentMessages.map((item) => JSON.parse(item));
+
+    expect(message).toMatchObject({
+      type: 'request',
+      api: SDK.ServerAPI.API.GetAllModuleGraph,
+      body: {},
+    });
+    expect(message.id).toBeTruthy();
+
+    socket.trigger(
+      'message',
+      JSON.stringify({
+        type: 'response',
+        id: message.id,
+        payload: [{ id: 1 }],
+      }),
+    );
+
+    await expect(request).resolves.toStrictEqual([{ id: 1 }]);
+  });
+
+  it('rejects websocket requests when no socket url is available', async () => {
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: undefined,
+    });
+    globalThis.WebSocket = MockWebSocket as any;
+
+    await expect(
+      requestServerAPI(SDK.ServerAPI.API.GetAllModuleGraph, {}),
+    ).rejects.toThrow('WebSocket URL is not available.');
+  });
+
+  it('rejects websocket requests when WebSocket is unavailable', async () => {
+    globalThis.WebSocket = undefined as any;
+
+    await expect(
+      requestServerAPI(SDK.ServerAPI.API.GetAllModuleGraph, {}, '3085'),
+    ).rejects.toThrow('WebSocket is not available.');
+  });
+});

--- a/packages/components/src/utils/socket.ts
+++ b/packages/components/src/utils/socket.ts
@@ -1,35 +1,295 @@
 /* rslint-disable no-restricted-globals */
-import { io, Socket } from 'socket.io-client';
+import type { Common, SDK } from '@rsdoctor/types';
 
-const map = new Map<string, Socket>();
-const socketProtocol = location.protocol.includes('https') ? 'wss' : 'ws';
-const defaultSocketUrl =
-  process.env.NODE_ENV === 'development'
-    ? `${socketProtocol}://${location.hostname}:${process.env.LOCAL_CLI_PORT}`
-    : `${socketProtocol}://${location.host}`;
+type SocketAPI = SDK.ServerAPI.API | SDK.ServerAPI.APIExtends;
+
+export interface ServerSocketMessage<T extends SocketAPI = SocketAPI> {
+  api: T;
+  payload: SDK.ServerAPI.SocketResponseType<T>;
+}
+
+type ServerSocketResponseMessage<
+  T extends SDK.ServerAPI.API = SDK.ServerAPI.API,
+> = {
+  type: 'response';
+  id: string;
+  payload?: SDK.ServerAPI.InferResponseType<T>;
+  error?: string;
+};
+
+type SocketListener<T extends SocketAPI = SocketAPI> = (
+  payload: SDK.ServerAPI.SocketResponseType<T>,
+) => void;
+
+type Subscription = {
+  api: SocketAPI;
+  body: Common.PlainObject | null | undefined;
+};
+
+type PendingRequest = {
+  message: string;
+  resolve: (payload: unknown) => void;
+  reject: (error: Error) => void;
+};
+
+type SocketClient = {
+  url: string;
+  socket?: WebSocket;
+  listeners: Map<string, Set<SocketListener>>;
+  subscriptions: Map<string, Subscription>;
+  requests: Map<string, PendingRequest>;
+};
+
+const clients = new Map<string, SocketClient>();
+const defaultClientKey = '__default__';
+const openState = 1;
+let requestId = 0;
 
 const ipv4Pattern =
   /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
 
-function ensureSocket(socketUrl: string = defaultSocketUrl) {
-  if (!map.has(socketUrl)) {
-    const socket = io(socketUrl, {});
-    socket.on('connect', () => {
-      console.log(`Socket Connect ${socketUrl}`);
-    });
-    map.set(socketUrl, socket);
-  }
-  return map.get(socketUrl)!;
+function getSocketProtocol(protocol: string) {
+  return protocol.includes('https') ? 'wss' : 'ws';
 }
 
-export function getSocket(socketPort?: string): Socket {
-  const socketUrl = formatURL({
-    port: socketPort,
-    hostname: location.hostname,
-    protocol: location.protocol,
+function getDefaultSocketUrl() {
+  if (typeof location === 'undefined') {
+    return '';
+  }
+
+  const socketProtocol = getSocketProtocol(location.protocol);
+  return process.env.NODE_ENV === 'development'
+    ? `${socketProtocol}://${location.hostname}:${process.env.LOCAL_CLI_PORT}`
+    : `${socketProtocol}://${location.host}`;
+}
+
+function getSocketUrl(socketPort?: string) {
+  if (typeof location === 'undefined') {
+    return socketPort ? `ws://localhost:${socketPort}` : '';
+  }
+
+  return socketPort
+    ? formatURL({
+        port: socketPort,
+        hostname: location.hostname,
+        protocol: location.protocol,
+      })
+    : getDefaultSocketUrl();
+}
+
+function getClient(socketUrl = getDefaultSocketUrl()) {
+  const key = socketUrl || defaultClientKey;
+  if (!clients.has(key)) {
+    clients.set(key, {
+      url: socketUrl,
+      listeners: new Map(),
+      subscriptions: new Map(),
+      requests: new Map(),
+    });
+  }
+  return clients.get(key)!;
+}
+
+function getSubscriptionKey(api: SocketAPI, body: unknown) {
+  return `${api}:${JSON.stringify(body ?? null)}`;
+}
+
+function sendSubscription(client: SocketClient, subscription: Subscription) {
+  if (client.socket?.readyState !== openState) {
+    return;
+  }
+
+  client.socket.send(
+    JSON.stringify({
+      type: 'subscribe',
+      api: subscription.api,
+      body: subscription.body ?? null,
+    }),
+  );
+}
+
+function sendUnsubscribe(client: SocketClient, subscription: Subscription) {
+  if (client.socket?.readyState !== openState) {
+    return;
+  }
+
+  client.socket.send(
+    JSON.stringify({
+      type: 'unsubscribe',
+      api: subscription.api,
+      body: subscription.body ?? null,
+    }),
+  );
+}
+
+function sendRequest(client: SocketClient, id: string) {
+  if (client.socket?.readyState !== openState) {
+    return;
+  }
+
+  const request = client.requests.get(id);
+  if (!request) {
+    return;
+  }
+  client.socket.send(request.message);
+}
+
+function handleResponseMessage(
+  client: SocketClient,
+  message: ServerSocketResponseMessage,
+) {
+  const request = client.requests.get(message.id);
+  if (!request) {
+    return;
+  }
+
+  client.requests.delete(message.id);
+  if (message.error) {
+    request.reject(new Error(message.error));
+    return;
+  }
+  request.resolve(message.payload);
+}
+
+function connectSocket(client: SocketClient) {
+  if (!client.url || typeof WebSocket === 'undefined' || client.socket) {
+    return;
+  }
+
+  const socket = new WebSocket(client.url);
+  socket.addEventListener('open', () => {
+    client.subscriptions.forEach((subscription) => {
+      sendSubscription(client, subscription);
+    });
+    client.requests.forEach((_, id) => {
+      sendRequest(client, id);
+    });
   });
-  const socket = ensureSocket(socketPort ? socketUrl : defaultSocketUrl);
-  return socket;
+  socket.addEventListener('message', (event) => {
+    if (typeof event.data !== 'string') {
+      return;
+    }
+
+    try {
+      const message = JSON.parse(event.data) as
+        | ServerSocketMessage
+        | ServerSocketResponseMessage;
+      if ('type' in message && message.type === 'response') {
+        handleResponseMessage(client, message);
+        return;
+      }
+      publishServerSocketMessage(message as ServerSocketMessage, client.url);
+    } catch {
+      // Ignore malformed payloads and keep the transport alive.
+    }
+  });
+  socket.addEventListener('close', () => {
+    client.socket = undefined;
+    client.requests.forEach((request) => {
+      request.reject(
+        new Error('WebSocket closed before the response arrived.'),
+      );
+    });
+    client.requests.clear();
+  });
+  client.socket = socket;
+}
+
+export function requestServerAPI<
+  T extends SDK.ServerAPI.API,
+  B extends SDK.ServerAPI.InferRequestBodyType<T> =
+    SDK.ServerAPI.InferRequestBodyType<T>,
+  R extends SDK.ServerAPI.InferResponseType<T> =
+    SDK.ServerAPI.InferResponseType<T>,
+>(api: T, body: B | null | undefined, socketPort?: string): Promise<R> {
+  const socketUrl = getSocketUrl(socketPort);
+  if (!socketUrl) {
+    return Promise.reject(new Error('WebSocket URL is not available.'));
+  }
+
+  if (typeof WebSocket === 'undefined') {
+    return Promise.reject(new Error('WebSocket is not available.'));
+  }
+
+  const client = getClient(socketUrl);
+  const id = `${Date.now()}-${++requestId}`;
+
+  return new Promise<R>((resolve, reject) => {
+    client.requests.set(id, {
+      message: JSON.stringify({
+        type: 'request',
+        id,
+        api,
+        body: body ?? null,
+      }),
+      resolve: resolve as (payload: unknown) => void,
+      reject,
+    });
+    connectSocket(client);
+    sendRequest(client, id);
+  });
+}
+
+export function subscribeServerAPI<T extends SocketAPI>(
+  api: T,
+  body: SDK.ServerAPI.InferRequestBodyType<T, null> | null,
+  listener: SocketListener<T>,
+  socketPort?: string,
+) {
+  const client = getClient(getSocketUrl(socketPort));
+  const bodyValue = body ?? null;
+  const key = getSubscriptionKey(api, bodyValue);
+  if (!client.listeners.has(key)) {
+    client.listeners.set(key, new Set());
+  }
+  client.listeners.get(key)!.add(listener as SocketListener);
+
+  const subscription = {
+    api,
+    body: bodyValue,
+  };
+  client.subscriptions.set(key, subscription);
+  connectSocket(client);
+  sendSubscription(client, subscription);
+
+  return () => {
+    unsubscribeServerAPI(api, bodyValue, listener, socketPort);
+  };
+}
+
+export function unsubscribeServerAPI<T extends SocketAPI>(
+  api: T,
+  body: SDK.ServerAPI.InferRequestBodyType<T, null> | null,
+  listener: SocketListener<T>,
+  socketPort?: string,
+) {
+  const client = getClient(getSocketUrl(socketPort));
+  const key = getSubscriptionKey(api, body);
+  const listeners = client.listeners.get(key);
+  listeners?.delete(listener as SocketListener);
+
+  if (listeners?.size === 0) {
+    const subscription = client.subscriptions.get(key);
+    if (subscription) {
+      sendUnsubscribe(client, subscription);
+    }
+    client.listeners.delete(key);
+    client.subscriptions.delete(key);
+  }
+}
+
+export function publishServerSocketMessage(
+  message: ServerSocketMessage,
+  socketUrl?: string,
+) {
+  const targets = socketUrl ? [getClient(socketUrl)] : [...clients.values()];
+
+  targets.forEach((client) => {
+    const key = getSubscriptionKey(message.api, message.payload.req.body);
+    client.listeners.get(key)?.forEach((listener) => {
+      listener(message.payload);
+    });
+  });
 }
 
 export function formatURL({
@@ -41,17 +301,20 @@ export function formatURL({
   protocol: string;
   hostname: string;
 }) {
+  const socketProtocol = getSocketProtocol(protocol);
+  const shouldUsePort =
+    ipv4Pattern.test(hostname) || hostname.includes('localhost');
+
   if (typeof URL !== 'undefined') {
     const url = new URL('http://localhost');
-    url.port = String(port);
     url.hostname = hostname;
-    url.protocol = location.protocol.includes('https') ? 'wss' : 'ws';
-    return ipv4Pattern.test(hostname) || hostname.includes('localhost')
-      ? url.toString()
-      : `${protocol}//${hostname}`;
+    url.protocol = socketProtocol;
+    if (port && shouldUsePort) {
+      url.port = port;
+    }
+    return url.toString();
   }
 
-  // compatible with IE11
-  const colon = protocol.indexOf(':') === -1 ? ':' : '';
-  return `${protocol}${colon}//${hostname}:${port}`;
+  const portText = port && shouldUsePort ? `:${port}` : '';
+  return `${socketProtocol}://${hostname}${portText}`;
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -41,8 +41,8 @@
     "@rsdoctor/utils": "workspace:*",
     "launch-editor": "^2.13.2",
     "safer-buffer": "2.1.2",
-    "socket.io": "4.8.1",
-    "tapable": "2.3.3"
+    "tapable": "2.3.3",
+    "ws": "8.18.3"
   },
   "devDependencies": {
     "@types/body-parser": "catalog:",
@@ -50,6 +50,7 @@
     "@types/cors": "2.8.19",
     "@types/fs-extra": "catalog:",
     "@types/node": "catalog:",
+    "@types/ws": "^8.18.1",
     "body-parser": "2.2.2",
     "cors": "2.8.6",
     "dayjs": "catalog:",

--- a/packages/sdk/src/sdk/server/apis/base.ts
+++ b/packages/sdk/src/sdk/server/apis/base.ts
@@ -7,7 +7,10 @@ export class BaseAPI implements Manifest.ManifestDataLoader {
 
   protected dataLoader: Data.APIDataLoader;
 
-  constructor(sdk: SDK.RsdoctorSDKInstance, server: SDK.RsdoctorServerInstance) {
+  constructor(
+    sdk: SDK.RsdoctorSDKInstance,
+    server: SDK.RsdoctorServerInstance,
+  ) {
     this.ctx = { sdk, server } as SDK.ServerAPI.APIContext;
     this.dataLoader = new Data.APIDataLoader(this);
   }

--- a/packages/sdk/src/sdk/server/apis/bundle-diff.ts
+++ b/packages/sdk/src/sdk/server/apis/bundle-diff.ts
@@ -4,6 +4,7 @@ import { Router } from '../router';
 
 export class BundleDiffAPI extends BaseAPI {
   @Router.get(SDK.ServerAPI.API.GetBundleDiffSummary)
+  @Router.post(SDK.ServerAPI.API.GetBundleDiffSummary)
   public async getBundleDiffSummary(): Promise<
     SDK.ServerAPI.InferResponseType<SDK.ServerAPI.API.GetBundleDiffSummary>
   > {

--- a/packages/sdk/src/sdk/server/apis/index.ts
+++ b/packages/sdk/src/sdk/server/apis/index.ts
@@ -1,4 +1,5 @@
 export * from './alerts';
+export * from './bundle-diff';
 export { DataAPI } from './data';
 export * from './fs';
 export * from './loader';

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -324,13 +324,12 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     }
     this.disposed = true;
 
-    if (this._server) {
-      await this._server.close();
-    }
-
-    // must close socket after server to avoid socket.io close error.
     if (this._socket) {
       this._socket.dispose();
+    }
+
+    if (this._server) {
+      await this._server.close();
     }
 
     if (exitCode !== undefined) {

--- a/packages/sdk/src/sdk/server/socket/index.ts
+++ b/packages/sdk/src/sdk/server/socket/index.ts
@@ -1,73 +1,205 @@
 import { Common, SDK } from '@rsdoctor/types';
 import type { Server } from 'http';
-import {
-  Server as SocketServer,
-  ServerOptions as SocketServerOptions,
-  Socket as SocketType,
-} from 'socket.io';
-import { isDeepStrictEqual } from 'util';
+import WebSocket, { WebSocketServer } from 'ws';
 import { SocketAPILoader } from './api';
 
 interface SocketOptions {
   sdk: SDK.RsdoctorBuilderSDKInstance;
   server: Server;
   port: number;
-  socketOptions?: SocketServerOptions;
 }
 
+type Subscription = {
+  api: SDK.ServerAPI.API;
+  body: Common.PlainObject | null;
+};
+
+type SubscriptionRecord = Subscription & {
+  count: number;
+};
+
+type ClientMessage = {
+  type?: string;
+  id?: string;
+  api?: SDK.ServerAPI.API;
+  body?: Common.PlainObject | null;
+};
+
 export class Socket {
-  protected io!: SocketServer;
+  protected server?: WebSocketServer;
+
+  protected clients = new Set<WebSocket>();
 
   protected loader: SocketAPILoader;
 
-  protected map: Map<SDK.ServerAPI.API, (Common.PlainObject | null)[]> =
-    new Map();
+  protected map: Map<string, SubscriptionRecord> = new Map();
+
+  protected clientSubscriptions: Map<WebSocket, Set<string>> = new Map();
 
   constructor(protected options: SocketOptions) {
     this.loader = new SocketAPILoader({ sdk: options.sdk });
   }
 
   public bootstrap() {
-    this.io = new SocketServer(this.options.server, {
-      cors: {
-        origin: '*',
-      },
-      ...this.options.socketOptions,
-    });
-    this.io.on('connection', (socket) => {
-      // setup event listeners for every socket which connected
-      this.setupSocket(socket);
+    this.server = new WebSocketServer({ server: this.options.server });
+    this.server.on('connection', (client) => {
+      this.attachClient(client);
     });
   }
 
-  protected setupSocket(socket: SocketType) {
-    // setup server api load request
-    Object.values(SDK.ServerAPI.API).forEach((api) => {
-      // server received the request for server api
-      // and the first argument is request body.
-      socket.on(api, async (body, callback) => {
-        // save to map for server side emit event to client.
-        this.saveRequestToMap(api, body);
+  public attachClient(client: WebSocket) {
+    this.clients.add(client);
 
-        // server will send the response for server api
-        callback(await this.getAPIResponse(api, body));
+    if (typeof client.on === 'function') {
+      client.on('message', (message) => {
+        this.handleClientMessage(message.toString(), client);
       });
-    });
+      client.on('close', () => {
+        this.clients.delete(client);
+        this.removeClientSubscriptions(client);
+      });
+    }
+  }
+
+  public async handleClientMessage(raw: string, client?: WebSocket) {
+    let message: ClientMessage;
+    try {
+      message = JSON.parse(raw) as ClientMessage;
+    } catch {
+      return;
+    }
+
+    if (
+      !message.api ||
+      !Object.values(SDK.ServerAPI.API).includes(message.api)
+    ) {
+      return;
+    }
+
+    if (message.type === 'request') {
+      await this.handleAPIRequestMessage(message, client);
+      return;
+    }
+
+    if (message.type === 'subscribe') {
+      this.saveRequestToMap(message.api, message.body ?? null, client);
+      return;
+    }
+
+    if (message.type === 'unsubscribe') {
+      this.removeRequestFromMap(message.api, message.body ?? null, client);
+    }
+  }
+
+  protected async handleAPIRequestMessage(
+    message: ClientMessage,
+    client?: WebSocket,
+  ) {
+    if (!message.id || !client || client.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    try {
+      const response = await this.getAPIResponse(message.api!, message.body!);
+      client.send(
+        JSON.stringify({
+          type: 'response',
+          id: message.id,
+          payload: response.res,
+        }),
+      );
+    } catch (err) {
+      client.send(
+        JSON.stringify({
+          type: 'response',
+          id: message.id,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    }
+  }
+
+  public getSubscriptions(): Subscription[] {
+    return [...this.map.values()].map(({ api, body }) => ({ api, body }));
   }
 
   protected saveRequestToMap<T extends SDK.ServerAPI.API>(
     api: T,
     body: SDK.ServerAPI.InferRequestBodyType<T, null> | null = null,
+    client?: WebSocket,
   ) {
-    if (!this.map.has(api)) {
-      this.map.set(api, []);
+    const key = this.getSubscriptionKey(api, body);
+    if (client) {
+      if (!this.clientSubscriptions.has(client)) {
+        this.clientSubscriptions.set(client, new Set());
+      }
+      const subscriptions = this.clientSubscriptions.get(client)!;
+      if (subscriptions.has(key)) {
+        return;
+      }
+      subscriptions.add(key);
     }
 
-    const list = this.map.get(api)!;
-
-    if (!list.some((e) => e === body || isDeepStrictEqual(e, body))) {
-      list.push(body);
+    const record = this.map.get(key);
+    if (record) {
+      record.count += 1;
+      return;
     }
+
+    this.map.set(key, {
+      api,
+      body,
+      count: 1,
+    });
+  }
+
+  protected removeRequestFromMap<T extends SDK.ServerAPI.API>(
+    api: T,
+    body: SDK.ServerAPI.InferRequestBodyType<T, null> | null = null,
+    client?: WebSocket,
+  ) {
+    const key = this.getSubscriptionKey(api, body);
+    if (client) {
+      const subscriptions = this.clientSubscriptions.get(client);
+      if (!subscriptions?.has(key)) {
+        return;
+      }
+      subscriptions.delete(key);
+      if (subscriptions.size === 0) {
+        this.clientSubscriptions.delete(client);
+      }
+    }
+
+    this.removeSubscriptionKey(key);
+  }
+
+  protected removeClientSubscriptions(client: WebSocket) {
+    const subscriptions = this.clientSubscriptions.get(client);
+    if (!subscriptions) {
+      return;
+    }
+
+    subscriptions.forEach((key) => this.removeSubscriptionKey(key));
+    this.clientSubscriptions.delete(client);
+  }
+
+  protected removeSubscriptionKey(key: string) {
+    const record = this.map.get(key);
+    if (!record) {
+      return;
+    }
+
+    record.count -= 1;
+    if (record.count <= 0) {
+      this.map.delete(key);
+    }
+  }
+
+  protected getSubscriptionKey(
+    api: SDK.ServerAPI.API,
+    body: Common.PlainObject | null,
+  ) {
+    return `${api}:${JSON.stringify(body ?? null)}`;
   }
 
   protected async getAPIResponse<T extends SDK.ServerAPI.API>(
@@ -95,15 +227,13 @@ export class Socket {
     this.timer = setImmediate(async () => {
       const promises: Promise<void>[] = [];
 
-      this.map.forEach((bodies, api) => {
-        bodies.forEach((body) => {
-          promises.push(
-            (async () => {
-              const res = await this.getAPIResponse(api, body!);
-              this.io.emit(api, res);
-            })(),
-          );
-        });
+      this.map.forEach(({ api, body }) => {
+        promises.push(
+          (async () => {
+            const res = await this.getAPIResponse(api, body!);
+            this.sendAPIData(api, res);
+          })(),
+        );
       });
 
       await Promise.all(promises);
@@ -112,13 +242,21 @@ export class Socket {
 
   public sendAPIData<T extends SDK.ServerAPI.API | SDK.ServerAPI.APIExtends>(
     api: T,
-    msg: SDK.ServerAPI.SocketResponseType<T>,
+    payload: SDK.ServerAPI.SocketResponseType<T>,
   ) {
-    this.io.sockets.emit(api, msg);
+    const message = JSON.stringify({ api, payload });
+    this.clients.forEach((client) => {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(message);
+      }
+    });
   }
 
   public dispose() {
-    this.io.disconnectSockets();
-    this.io.close();
+    this.clients.forEach((client) => {
+      client.close();
+    });
+    this.clients.clear();
+    this.server?.close();
   }
 }

--- a/packages/sdk/tests/server/apis/index.test.ts
+++ b/packages/sdk/tests/server/apis/index.test.ts
@@ -19,4 +19,13 @@ describe('ensure all of the apis implementation for server', () => {
 
     expect(list.length).toBeGreaterThanOrEqual(30);
   });
+
+  it('ensure bundle diff APIs are registered', async () => {
+    const { get, post } = Router.routes;
+    const getRoutes = [...get.values()].flat().map((el) => el[1]);
+    const postRoutes = [...post.values()].flat().map((el) => el[1]);
+
+    expect(getRoutes).toContain(SDK.ServerAPI.API.BundleDiffManifest);
+    expect(postRoutes).toContain(SDK.ServerAPI.API.GetBundleDiffSummary);
+  });
 });

--- a/packages/sdk/tests/server/websocket.test.ts
+++ b/packages/sdk/tests/server/websocket.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, rs } from '@rstest/core';
+import { SDK } from '@rsdoctor/types';
+import { Socket } from '../../src/sdk/server/socket';
+
+function createMockClient() {
+  const listeners = new Map<string, Set<(...args: any[]) => void>>();
+  const sent: string[] = [];
+  const client = {
+    readyState: 1,
+    sent,
+    send(message: string) {
+      sent.push(message);
+    },
+    on(event: string, listener: (...args: any[]) => void) {
+      if (!listeners.has(event)) {
+        listeners.set(event, new Set());
+      }
+      listeners.get(event)!.add(listener);
+    },
+    emit(event: string, ...args: any[]) {
+      listeners.get(event)?.forEach((listener) => listener(...args));
+    },
+  };
+  return client;
+}
+
+describe('server websocket transport', () => {
+  it('stores subscriptions received from clients', () => {
+    const socket = new Socket({} as never);
+
+    socket.handleClientMessage(
+      JSON.stringify({
+        type: 'subscribe',
+        api: SDK.ServerAPI.API.GetChunkGraph,
+        body: { page: 1 },
+      }),
+    );
+
+    expect(socket.getSubscriptions()).toStrictEqual([
+      {
+        api: SDK.ServerAPI.API.GetChunkGraph,
+        body: { page: 1 },
+      },
+    ]);
+  });
+
+  it('serializes push messages for websocket clients', () => {
+    const sent: string[] = [];
+    const socket = new Socket({} as never);
+
+    socket.attachClient({
+      readyState: 1,
+      send(message: string) {
+        sent.push(message);
+      },
+    } as never);
+
+    socket.sendAPIData(SDK.ServerAPI.APIExtends.GetCompileProgress, {
+      req: {
+        api: SDK.ServerAPI.APIExtends.GetCompileProgress,
+        body: undefined,
+      },
+      res: { percentage: 50, message: 'building' },
+    });
+
+    expect(sent).toStrictEqual([
+      JSON.stringify({
+        api: SDK.ServerAPI.APIExtends.GetCompileProgress,
+        payload: {
+          req: {
+            api: SDK.ServerAPI.APIExtends.GetCompileProgress,
+          },
+          res: { percentage: 50, message: 'building' },
+        },
+      }),
+    ]);
+  });
+
+  it('responds to request messages on the source websocket client', async () => {
+    const socket = new Socket({} as never);
+    (socket as any).loader = {
+      loadAPIData: rs.fn().mockResolvedValue([{ id: 1 }]),
+    };
+
+    const client = createMockClient();
+    socket.attachClient(client as never);
+
+    await socket.handleClientMessage(
+      JSON.stringify({
+        type: 'request',
+        id: 'request-1',
+        api: SDK.ServerAPI.API.GetAllModuleGraph,
+        body: {},
+      }),
+      client,
+    );
+
+    expect(client.sent).toStrictEqual([
+      JSON.stringify({
+        type: 'response',
+        id: 'request-1',
+        payload: [{ id: 1 }],
+      }),
+    ]);
+  });
+
+  it('removes subscriptions received from clients', async () => {
+    const socket = new Socket({} as never);
+    const client = createMockClient();
+    socket.attachClient(client as never);
+
+    await socket.handleClientMessage(
+      JSON.stringify({
+        type: 'subscribe',
+        api: SDK.ServerAPI.API.GetChunkGraph,
+        body: { page: 1 },
+      }),
+      client as never,
+    );
+    await socket.handleClientMessage(
+      JSON.stringify({
+        type: 'unsubscribe',
+        api: SDK.ServerAPI.API.GetChunkGraph,
+        body: { page: 1 },
+      }),
+      client as never,
+    );
+
+    expect(socket.getSubscriptions()).toStrictEqual([]);
+  });
+
+  it('removes client subscriptions when the websocket closes', async () => {
+    const socket = new Socket({} as never);
+    const firstClient = createMockClient();
+    const secondClient = createMockClient();
+    socket.attachClient(firstClient as never);
+    socket.attachClient(secondClient as never);
+
+    const message = JSON.stringify({
+      type: 'subscribe',
+      api: SDK.ServerAPI.API.GetChunkGraph,
+      body: { page: 1 },
+    });
+    await socket.handleClientMessage(message, firstClient as never);
+    await socket.handleClientMessage(message, secondClient as never);
+
+    firstClient.emit('close');
+    expect(socket.getSubscriptions()).toStrictEqual([
+      {
+        api: SDK.ServerAPI.API.GetChunkGraph,
+        body: { page: 1 },
+      },
+    ]);
+
+    secondClient.emit('close');
+    expect(socket.getSubscriptions()).toStrictEqual([]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,9 +117,6 @@ catalogs:
     react-router-dom:
       specifier: 6.30.3
       version: 6.30.3
-    socket.io-client:
-      specifier: 4.8.1
-      version: 4.8.1
     source-map:
       specifier: ^0.7.6
       version: 0.7.6
@@ -638,9 +635,6 @@ importers:
       prebundle:
         specifier: 'catalog:'
         version: 1.6.4(typescript@6.0.3)
-      socket.io-client:
-        specifier: 'catalog:'
-        version: 4.8.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -810,9 +804,6 @@ importers:
       react-markdown:
         specifier: 'catalog:'
         version: 9.1.0(@types/react@19.2.14)(react@19.2.6)
-      socket.io-client:
-        specifier: 'catalog:'
-        version: 4.8.1
       url-parse:
         specifier: 1.5.10
         version: 1.5.10
@@ -1104,12 +1095,12 @@ importers:
       safer-buffer:
         specifier: 2.1.2
         version: 2.1.2
-      socket.io:
-        specifier: 4.8.1
-        version: 4.8.1
       tapable:
         specifier: 2.3.3
         version: 2.3.3
+      ws:
+        specifier: 8.18.3
+        version: 8.18.3
     devDependencies:
       '@types/body-parser':
         specifier: 'catalog:'
@@ -1126,6 +1117,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.3
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       body-parser:
         specifier: 2.2.2
         version: 2.2.2
@@ -4145,6 +4139,9 @@ packages:
   '@types/url-parse@1.4.11':
     resolution: {integrity: sha512-FKvKIqRaykZtd4n47LbK/W/5fhQQ1X7cxxzG9A48h0BGN+S04NH7ervcCjM8tyR0lyGru83FAHSmw2ObgKoESg==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
@@ -5347,9 +5344,6 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
-
-  engine.io-client@6.6.3:
-    resolution: {integrity: sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==}
 
   engine.io-parser@5.2.3:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
@@ -8764,10 +8758,6 @@ packages:
   socket.io-adapter@2.5.5:
     resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
 
-  socket.io-client@4.8.1:
-    resolution: {integrity: sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==}
-    engines: {node: '>=10.0.0'}
-
   socket.io-parser@4.2.6:
     resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
     engines: {node: '>=10.0.0'}
@@ -9426,6 +9416,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -9449,10 +9451,6 @@ packages:
   xml-js@1.6.11:
     resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
     hasBin: true
-
-  xmlhttprequest-ssl@2.1.2:
-    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
-    engines: {node: '>=0.4.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -12950,6 +12948,10 @@ snapshots:
 
   '@types/url-parse@1.4.11': {}
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.12.3
+
   '@types/yargs-parser@21.0.3': {}
 
   '@types/yargs@17.0.33':
@@ -14379,18 +14381,6 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
-
-  engine.io-client@6.6.3:
-    dependencies:
-      '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7
-      engine.io-parser: 5.2.3
-      ws: 8.17.1
-      xmlhttprequest-ssl: 2.1.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   engine.io-parser@5.2.3: {}
 
@@ -18484,17 +18474,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  socket.io-client@4.8.1:
-    dependencies:
-      '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7
-      engine.io-client: 6.6.3
-      socket.io-parser: 4.2.6
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   socket.io-parser@4.2.6:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
@@ -19235,6 +19214,8 @@ snapshots:
 
   ws@8.17.1: {}
 
+  ws@8.18.3: {}
+
   ws@8.20.0: {}
 
   wsl-utils@0.1.0:
@@ -19246,8 +19227,6 @@ snapshots:
   xml-js@1.6.11:
     dependencies:
       sax: 1.4.1
-
-  xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,7 +51,6 @@ catalog:
   react-markdown: ^9.1.0
   react-router-dom: 6.30.3
   sirv: 3.0.2
-  socket.io-client: 4.8.1
   source-map: ^0.7.6
   tslib: 2.8.1
   typescript: ^6.0.3


### PR DESCRIPTION
## Summary
refactor(sdk): replace socket.io with native ws transport
It is the same as pr #1667 , but it is synchronized to the main branch.

## Related Links

<!--- Provide links of related issues or pages -->
