### PR TITLE
fix(core): avoid E1009 false positives for ESM entries

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -2,7 +2,7 @@ name: Ecosystem CI
 
 on:
   push:
-    branches: ['main']
+    branches: [main, v1.x]
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,10 @@ name: Lint
 on:
   # Triggers the workflow on pull request events but only for the main branch
   pull_request:
-    branches: [main]
+    branches: [main, v1.x]
 
   push:
-    branches: [main]
+    branches: [main, v1.x]
     paths-ignore:
       - 'document/**'
       - '*.md'

--- a/.github/workflows/test-ubuntu-node20.yml
+++ b/.github/workflows/test-ubuntu-node20.yml
@@ -4,10 +4,10 @@ name: Test (Ubuntu)
 on:
   # Triggers the workflow on pull request events for main and release branches
   pull_request:
-    branches: [main, release_*, release-*]
+    branches: [main, release_*, release-*, v1.x]
 
   push:
-    branches: [main, release_*, release-*]
+    branches: [main, release_*, release-*, v1.x]
     paths-ignore:
       - 'document/**'
       - '*.md'

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -4,10 +4,10 @@ name: Test (Ubuntu)
 on:
   # Triggers the workflow on pull request events for main and release branches
   pull_request:
-    branches: [main, release_*, release-*]
+    branches: [main, release_*, release-*, v1.x]
 
   push:
-    branches: [main, release_*, release-*]
+    branches: [main, release_*, release-*, v1.x]
     paths-ignore:
       - 'document/**'
       - '*.md'

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -4,10 +4,10 @@ name: Test (Windows)
 on:
   # Triggers the workflow on pull request events for main and release branches
   pull_request:
-    branches: [main, release_*, release-*]
+    branches: [main, release_*, release-*, v1.x]
 
   push:
-    branches: [main, release_*, release-*]
+    branches: [main, release_*, release-*, v1.x]
     paths-ignore:
       - "document/**"
       - "*.md"

--- a/packages/core/src/rules/rules/esm-resolved-to-cjs/index.ts
+++ b/packages/core/src/rules/rules/esm-resolved-to-cjs/index.ts
@@ -28,53 +28,187 @@ function normalizePathForCompare(filePath: string): string {
   return path.normalize(cleanPath);
 }
 
-/**
- * Extract the ESM entry path from a package.json object.
- * Checks (in priority order):
- *   1. exports["."]["import"]          — official conditional exports
- *   2. exports["."]["import"]["default"] — nested form
- *   3. exports["import"]               — top-level shorthand
- *   4. module                          — legacy bundler convention
- *
- * Returns an absolute path, or null if no ESM entry is declared.
- */
-function extractEsmEntry(pkgJson: FullPkgJson, pkgRoot: string): string | null {
-  const { exports: exportsField, module: moduleField } = pkgJson;
+function isDefinitelyEsmFile(filePath: string): boolean {
+  return path.extname(normalizePathForCompare(filePath)) === '.mjs';
+}
 
-  if (exportsField !== null && typeof exportsField === 'object') {
-    const exports = exportsField as Record<string, unknown>;
-    const dotEntry = exports['.'];
+function isDeclaredEsmEntry(
+  filePath: string,
+  esmEntries: string[],
+  toRealPath: (filePath: string) => string,
+): boolean {
+  const realPath = toRealPath(filePath);
+  return esmEntries.some((esmEntry) => realPath === toRealPath(esmEntry));
+}
 
-    if (dotEntry !== null && typeof dotEntry === 'object') {
-      const dot = dotEntry as Record<string, unknown>;
-      const importEntry = dot['import'];
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
 
-      if (typeof importEntry === 'string') {
-        return path.resolve(pkgRoot, importEntry);
-      }
-      if (importEntry !== null && typeof importEntry === 'object') {
-        const nested = (importEntry as Record<string, unknown>)['default'];
-        if (typeof nested === 'string') {
-          return path.resolve(pkgRoot, nested);
-        }
-      }
-    }
+function substituteExportPattern(target: string, wildcard: string): string {
+  return target.replace(/\*/g, wildcard);
+}
 
-    // exports["import"] top-level shorthand (no subpath)
-    const topImport = exports['import'];
-    if (typeof topImport === 'string') {
-      return path.resolve(pkgRoot, topImport);
-    }
-    if (topImport !== null && typeof topImport === 'object') {
-      const nested = (topImport as Record<string, unknown>)['default'];
-      if (typeof nested === 'string') {
-        return path.resolve(pkgRoot, nested);
-      }
-    }
+function toPackagePath(
+  pkgRoot: string,
+  target: string,
+  wildcard: string,
+): string {
+  return path.resolve(pkgRoot, substituteExportPattern(target, wildcard));
+}
+
+function collectStringTargets(value: unknown, wildcard: string): string[] {
+  if (typeof value === 'string') {
+    return [substituteExportPattern(value, wildcard)];
   }
 
-  if (typeof moduleField === 'string') {
-    return path.resolve(pkgRoot, moduleField);
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectStringTargets(item, wildcard));
+  }
+
+  if (!isRecord(value)) return [];
+
+  return Object.values(value).flatMap((child) =>
+    collectStringTargets(child, wildcard),
+  );
+}
+
+function collectEsmTargets(
+  exportEntry: unknown,
+  pkgRoot: string,
+  wildcard: string,
+): Set<string> {
+  const entries = new Set<string>();
+
+  const addTargets = (value: unknown): void => {
+    for (const target of collectStringTargets(value, wildcard)) {
+      entries.add(toPackagePath(pkgRoot, target, ''));
+    }
+  };
+
+  const visit = (value: unknown): void => {
+    if (typeof value === 'string' || Array.isArray(value)) {
+      addTargets(value);
+      return;
+    }
+
+    if (!isRecord(value)) return;
+
+    addTargets(value['import']);
+    addTargets(value['module']);
+
+    for (const child of Object.values(value)) {
+      if (isRecord(child) || Array.isArray(child)) {
+        visit(child);
+      }
+    }
+  };
+
+  visit(exportEntry);
+  return entries;
+}
+
+function hasSubpathExportKeys(exports: Record<string, unknown>): boolean {
+  return Object.keys(exports).some(
+    (key) => key === '.' || key.startsWith('./'),
+  );
+}
+
+function matchPatternExportKey(
+  patternKey: string,
+  exportKey: string,
+): string | null {
+  const wildcardIndex = patternKey.indexOf('*');
+  if (wildcardIndex < 0) return null;
+
+  const prefix = patternKey.slice(0, wildcardIndex);
+  const suffix = patternKey.slice(wildcardIndex + 1);
+  if (!exportKey.startsWith(prefix) || !exportKey.endsWith(suffix)) {
+    return null;
+  }
+
+  return exportKey.slice(prefix.length, exportKey.length - suffix.length);
+}
+
+function isPatternExportKey(key: string): boolean {
+  return key.indexOf('*') === key.lastIndexOf('*') && key.includes('*');
+}
+
+function patternKeyCompare(keyA: string, keyB: string): number {
+  const baseLengthA = keyA.includes('*') ? keyA.indexOf('*') + 1 : keyA.length;
+  const baseLengthB = keyB.includes('*') ? keyB.indexOf('*') + 1 : keyB.length;
+
+  if (baseLengthA > baseLengthB) return -1;
+  if (baseLengthB > baseLengthA) return 1;
+  if (!keyA.includes('*')) return 1;
+  if (!keyB.includes('*')) return -1;
+  if (keyA.length > keyB.length) return -1;
+  if (keyB.length > keyA.length) return 1;
+  return 0;
+}
+
+function resolveExportEntry(
+  exports: Record<string, unknown>,
+  exportKey: string,
+): { value: unknown; wildcard: string } | null {
+  if (Object.prototype.hasOwnProperty.call(exports, exportKey)) {
+    return { value: exports[exportKey], wildcard: '' };
+  }
+
+  const patternEntries = Object.entries(exports)
+    .filter(([key]) => isPatternExportKey(key))
+    .sort(([keyA], [keyB]) => patternKeyCompare(keyA, keyB));
+
+  for (const [key, value] of patternEntries) {
+    const wildcard = matchPatternExportKey(key, exportKey);
+    if (wildcard !== null) return { value, wildcard };
+  }
+
+  return null;
+}
+
+function resolveExportEntryForKey(
+  exportsField: unknown,
+  exportKey: string,
+): { value: unknown; wildcard: string } | null {
+  if (!isRecord(exportsField)) return null;
+  if (!hasSubpathExportKeys(exportsField)) {
+    return exportKey === '.' ? { value: exportsField, wildcard: '' } : null;
+  }
+
+  return resolveExportEntry(exportsField, exportKey);
+}
+
+/**
+ * Extract ESM entry paths from a package.json object.
+ * Resolves the export entry for the current request first, so another subpath
+ * cannot suppress a real ESM-to-CJS mismatch.
+ */
+function extractEsmEntries(
+  pkgJson: FullPkgJson,
+  pkgRoot: string,
+  exportKey: string,
+): Set<string> {
+  const { exports: exportsField, module: moduleField } = pkgJson;
+  const resolvedExport = resolveExportEntryForKey(exportsField, exportKey);
+  const entries = resolvedExport
+    ? collectEsmTargets(resolvedExport.value, pkgRoot, resolvedExport.wildcard)
+    : new Set<string>();
+
+  if (exportKey === '.' && typeof moduleField === 'string') {
+    entries.add(path.resolve(pkgRoot, moduleField));
+  }
+
+  return entries;
+}
+
+function getExportKeyFromRequest(
+  packageName: string,
+  request: string,
+): string | null {
+  if (request === packageName) return '.';
+  if (request.startsWith(`${packageName}/`)) {
+    return `.${request.slice(packageName.length)}`;
   }
 
   return null;
@@ -156,14 +290,23 @@ export const rule = defineRule<typeof title, Config>(() => {
         if (!pkg?.root) continue;
 
         const pkgJson = readPkgJson(pkg.root);
-        const esmEntry =
-          !ruleConfig.ignore.some((p) => pkg.name.includes(p)) &&
-          pkgJson &&
-          extractEsmEntry(pkgJson, pkg.root);
-        if (!esmEntry) continue;
+        if (ruleConfig.ignore.some((p) => pkg.name.includes(p)) || !pkgJson)
+          continue;
+
+        const exportKey = getExportKeyFromRequest(pkg.name, dep.request);
+        if (!exportKey) continue;
+
+        const esmEntries = extractEsmEntries(pkgJson, pkg.root, exportKey);
+        if (esmEntries.size === 0) continue;
+        const esmEntryList = Array.from(esmEntries);
 
         const resolvedModuleRealPath = toRealPath(dep.dependency.path);
-        if (resolvedModuleRealPath === toRealPath(esmEntry)) continue;
+        if (isDefinitelyEsmFile(resolvedModuleRealPath)) continue;
+
+        if (
+          isDeclaredEsmEntry(resolvedModuleRealPath, esmEntryList, toRealPath)
+        )
+          continue;
 
         const groupKey = `${pkg.name}::${resolvedModuleRealPath}`;
         const issuer = {
@@ -178,7 +321,7 @@ export const rule = defineRule<typeof title, Config>(() => {
           groups.set(groupKey, {
             packageName: pkg.name,
             packageVersion: pkg.version,
-            esmEntry,
+            esmEntry: esmEntryList[0]!,
             resolvedModule: {
               id: dep.dependency.id,
               path: dep.dependency.path,

--- a/packages/core/tests/rules/esm-resolved-to-cjs.test.ts
+++ b/packages/core/tests/rules/esm-resolved-to-cjs.test.ts
@@ -10,6 +10,7 @@ interface RunRuleOptions {
   request?: string;
   strictHarmonyModule?: boolean;
   ignore?: string[];
+  packageJson?: Record<string, unknown>;
 }
 
 async function runRule(options: RunRuleOptions) {
@@ -24,7 +25,7 @@ async function runRule(options: RunRuleOptions) {
     fs.writeFileSync(
       path.join(pkgRoot, 'package.json'),
       JSON.stringify(
-        {
+        options.packageJson ?? {
           name: 'up-fetch',
           version: '2.6.0',
           exports: {
@@ -112,5 +113,152 @@ describe('esm-resolved-to-cjs rule', () => {
     expect(reports).toHaveLength(1);
     expect(reports[0].detail.packageName).toBe('up-fetch');
     expect(reports[0].detail.resolvedModule.path).toBe(resolvedModulePath);
+  });
+
+  it('does not report when resolved module has a definite ESM extension', async () => {
+    const { reports } = await runRule({
+      resolvedModuleFile: 'nested/index.mjs',
+    });
+
+    expect(reports).toHaveLength(0);
+  });
+
+  it('does not report when resolved module is an ESM subpath export', async () => {
+    const { reports } = await runRule({
+      resolvedModuleFile: 'compat/index.js',
+      request: 'up-fetch/compat',
+      packageJson: {
+        name: 'up-fetch',
+        version: '2.6.0',
+        exports: {
+          '.': {
+            import: {
+              default: './dist/index.mjs',
+            },
+            require: {
+              default: './dist/index.js',
+            },
+          },
+          './compat': {
+            import: {
+              default: './dist/compat/index.js',
+            },
+            require: {
+              default: './dist/compat/index.cjs',
+            },
+          },
+        },
+      },
+    });
+
+    expect(reports).toHaveLength(0);
+  });
+
+  it('does not match ESM entries from unrelated subpath exports', async () => {
+    const { reports, resolvedModulePath } = await runRule({
+      resolvedModuleFile: 'index.cjs',
+      request: 'up-fetch',
+      packageJson: {
+        name: 'up-fetch',
+        version: '2.6.0',
+        exports: {
+          '.': {
+            import: {
+              default: './dist/index.mjs',
+            },
+            require: {
+              default: './dist/index.cjs',
+            },
+          },
+          './compat': {
+            import: {
+              default: './dist/index.cjs',
+            },
+          },
+        },
+      },
+    });
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0].detail.resolvedModule.path).toBe(resolvedModulePath);
+  });
+
+  it('does not report when resolved module matches an ESM subpath export pattern', async () => {
+    const { reports } = await runRule({
+      resolvedModuleFile: 'compat.js',
+      request: 'up-fetch/compat',
+      packageJson: {
+        name: 'up-fetch',
+        version: '2.6.0',
+        exports: {
+          './*': {
+            import: {
+              default: './dist/*.js',
+            },
+            require: {
+              default: './dist/*.cjs',
+            },
+          },
+        },
+      },
+    });
+
+    expect(reports).toHaveLength(0);
+  });
+
+  it('prefers the most specific matching ESM subpath export pattern', async () => {
+    const { reports } = await runRule({
+      resolvedModuleFile: 'feature/a.mjs',
+      request: 'up-fetch/feature/a',
+      packageJson: {
+        name: 'up-fetch',
+        version: '2.6.0',
+        exports: {
+          './*': {
+            import: {
+              default: './fallback/*.mjs',
+            },
+            require: {
+              default: './fallback/*.cjs',
+            },
+          },
+          './feature/*': {
+            import: {
+              default: './feature/*.mjs',
+            },
+            require: {
+              default: './feature/*.cjs',
+            },
+          },
+        },
+      },
+    });
+
+    expect(reports).toHaveLength(0);
+  });
+
+  it('reports when a subpath export pattern resolves to CJS instead of ESM', async () => {
+    const { reports, resolvedModulePath } = await runRule({
+      resolvedModuleFile: 'compat.cjs',
+      request: 'up-fetch/compat',
+      packageJson: {
+        name: 'up-fetch',
+        version: '2.6.0',
+        exports: {
+          './*': {
+            import: {
+              default: './dist/*.mjs',
+            },
+            require: {
+              default: './dist/*.cjs',
+            },
+          },
+        },
+      },
+    });
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0].detail.resolvedModule.path).toBe(resolvedModulePath);
+    expect(reports[0].detail.esmEntry).toContain(`${path.sep}compat.mjs`);
   });
 });


### PR DESCRIPTION
## Summary

- Backport #1690 to v1.x.
- Fix E1009 false positives when resolved modules match package ESM entries or subpath export patterns.

## Related Links

- The same with https://github.com/web-infra-dev/rsdoctor/pull/1690, so just forced to merged into v1.x without reviewers.

close: #1687 