### PR TITLE
chore: update v1.x agent skills

### DIFF
--- a/.agents/skills/create-draft-release-notes/SKILL.md
+++ b/.agents/skills/create-draft-release-notes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-draft-release-notes
-description: Create or update draft GitHub releases for the current project's main GitHub repository, then organize GitHub-generated release notes into user-friendly sections without rewriting release note items. Use for preparing, formatting, categorizing, creating, or updating GitHub release notes or draft releases.
+description: Create or update draft GitHub releases for the Rsdoctor `v1.x` maintenance branch, then organize GitHub-generated release notes into user-friendly sections without rewriting release note items. Use for preparing, formatting, categorizing, creating, or updating GitHub release notes or draft releases for 1.x releases.
 ---
 
 # Create Draft Release Notes
@@ -9,49 +9,55 @@ description: Create or update draft GitHub releases for the current project's ma
 
 Create a GitHub draft release, organize the generated notes by conventional commit type, and save the organized body back to the draft. Preserve each release note item exactly; only split accidentally joined bullets, move bullets into sections, and adjust headings.
 
+This skill targets the `v1.x` release line. Use `v1.x` as `base_branch` for draft release creation and previous-tag comparison.
+
 ## Draft Release Workflow
 
-Input: a release tag/title such as `v2.0.6`. If title and tag differ, ask for the tag.
+Input: a release tag/title such as `v1.5.13`. If title and tag differ, ask for the tag.
 
 1. Resolve `repo` as `<owner>/<repo>`.
-   Prefer an explicit repo from the user. Otherwise infer the current project's main GitHub repository from project metadata or the current GitHub remote. For npm projects, `package.json` `repository` is a useful signal; in monorepos, inspect the package or project being released rather than assuming the workspace root. Ignore subdirectory metadata such as `repository.directory` because GitHub releases are repository-level. If the repo is ambiguous, ask.
+   Prefer an explicit repo from the user. Otherwise infer the current project's canonical GitHub repository from project metadata or the current GitHub remote. For npm projects, `package.json` `repository` is a useful signal; in monorepos, inspect the package or project being released rather than assuming the workspace root. Ignore subdirectory metadata such as `repository.directory` because GitHub releases are repository-level. If the repo is ambiguous, ask.
 
 2. Set variables:
 
    ```bash
    repo="<owner>/<repo>"
-   release_tag="v2.0.6"
+   release_tag="v1.5.13"
    release_title="$release_tag"
+   base_branch="v1.x"
    ```
 
-3. Verify access and ensure the release does not already exist:
+3. Verify access, target branch, and ensure the release does not already exist.
+   Prefer the GitHub connector/plugin for repository lookup when available. Use `gh` for release creation and editing because the connector does not expose release operations.
 
    ```bash
    gh auth status
    gh repo view "$repo" --json nameWithOwner --jq '.nameWithOwner'
+   git ls-remote --heads origin "$base_branch"
    gh release view "$release_tag" -R "$repo" --json tagName,isDraft,url
    ```
 
    If the release exists, stop unless the user explicitly asked to update that draft.
 
-4. Infer the previous tag:
+4. Infer the previous 1.x tag:
 
    ```bash
-   previous_tag="$(gh release list -R "$repo" --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName')"
+   previous_tag="$(gh release list -R "$repo" --exclude-drafts --exclude-pre-releases --limit 100 --json tagName --jq '[.[].tagName | select(startswith("v1."))][0]')"
    gh release list -R "$repo" --exclude-drafts --exclude-pre-releases --limit 5
    ```
 
    Ask for confirmation if the previous tag is missing, surprising, or part of a non-standard range.
 
-5. Before creating anything, state the repo and range: `previous_tag -> release_tag`. If the user did not explicitly ask to create the draft in this turn, ask for confirmation.
+5. Before creating anything, state the repo, base branch, and range: `previous_tag -> release_tag` on `base_branch`. If the user did not explicitly ask to create the draft in this turn, ask for confirmation.
 
-6. Create the draft with GitHub-generated notes:
+6. Create the draft with GitHub-generated notes.
+   If the remote tag does not exist yet, pass `--target "$base_branch"` so GitHub creates the tag from the correct release line. If the remote tag already exists, validate that it is reachable from `origin/$base_branch`, then use `--verify-tag`.
 
    ```bash
-   gh release create "$release_tag" -R "$repo" --draft --generate-notes --notes-start-tag "$previous_tag" --title "$release_title"
+   gh release create "$release_tag" -R "$repo" --draft --generate-notes --notes-start-tag "$previous_tag" --target "$base_branch" --title "$release_title"
    ```
 
-   Add `--verify-tag` when the release must use an existing remote tag.
+   For an existing remote tag, replace `--target "$base_branch"` with `--verify-tag`.
 
 7. Organize and save the draft body:
 

--- a/.agents/skills/pr-creator/SKILL.md
+++ b/.agents/skills/pr-creator/SKILL.md
@@ -1,25 +1,28 @@
 ---
 name: pr-creator
-description: Use when asked to create a pull request for the Rsdoctor repository. Ensures the PR follows branch safety rules, Conventional Commits title convention, the project's PR template, and concise English writing style.
+description: Use when asked to create a pull request for the Rsdoctor repository's `v1.x` maintenance branch. Ensures the PR targets `v1.x`, follows branch safety rules, Conventional Commits title convention, the project's PR template, and concise English writing style.
 ---
 
 # Pull Request Creator
 
 ## Steps
 
-1. Confirm the current branch with `git branch --show-current`.
-   If it is `main`, create and switch to a new branch before doing anything else.
-   Use a descriptive branch name, for example `feat/add-xxx` or `fix/resolve-xxx`.
+1. Use `v1.x` as the PR base branch for Rsdoctor 1.x maintenance work, including bug fixes, dependency updates, docs, and release PRs.
 
-2. Review local changes with `git status --short`.
+2. Confirm the current branch with `git branch --show-current`.
+   If it is `v1.x`, create and switch to a new branch before doing anything else.
+   Use a descriptive branch name, for example `fix/v1-resolve-xxx` or `chore/v1-release-xxx`.
+
+3. Review local changes with `git status --short`.
    Do not revert unrelated user changes.
-   Before creating the PR, ensure the intended changes are committed and never commit directly on `main`.
+   Before creating the PR, ensure the intended changes are committed and never commit directly on `v1.x`.
+   If the current working branch appears not to be based on `v1.x`, stop and resolve that intentionally before pushing.
 
-3. Read `.github/PULL_REQUEST_TEMPLATE.md` and keep its structure exactly. The template has two sections:
+4. Read `.github/PULL_REQUEST_TEMPLATE.md` and keep its structure exactly. The template has two sections:
    - `## Summary`
    - `## Related Links`
 
-4. Draft the PR title in **Conventional Commits** format. Common scopes for Rsdoctor:
+5. Draft the PR title in **Conventional Commits** format. Common scopes for Rsdoctor:
    - `feat(core): add ...`
    - `fix(rspack-plugin): ...`
    - `fix(webpack-plugin): ...`
@@ -31,7 +34,7 @@ description: Use when asked to create a pull request for the Rsdoctor repository
    - `chore(deps): ...`
    - `release: v1.5.8`
 
-5. Write the PR body in concise, clear English.
+6. Write the PR body in concise, clear English.
    - In `Summary`, explain the user-facing problem or maintenance goal first, then the main change.
    - Keep it short: one compact paragraph or 2-4 bullets is usually enough.
    - Focus on what changed and why it matters; avoid low-signal implementation detail.
@@ -40,10 +43,12 @@ description: Use when asked to create a pull request for the Rsdoctor repository
      - `This PR fixes incorrect padding in URL labels to keep terminal output aligned across different label lengths.`
      - `This PR updates the English docs to clarify how the extraction option works and when to enable it.`
 
-6. Fill `Related Links` with issue links, design docs, related PRs, or discussion pages.
+7. Fill `Related Links` with issue links, design docs, related PRs, or discussion pages.
    If the PR upgrades an npm dependency, add a link to the upgraded version's release notes or tag page when available.
    If there is no relevant link, leave a short note such as `None`.
 
-7. Push the branch only after re-checking the branch name. Never push `main` directly.
+8. Push the branch only after re-checking both the branch name and the target base branch.
+   Never push `v1.x` directly.
 
-8. Create the PR with `gh pr create`.
+9. Create the PR against `v1.x`.
+   Prefer the GitHub connector/plugin when available. Use `gh pr create --base v1.x --head "$branch_name"` only as a fallback when the connector cannot create the PR.


### PR DESCRIPTION
## Summary
This pull request updates the documentation for the Rsdoctor release and pull request automation skills to target the `v1.x` maintenance branch rather than `main`. The instructions and examples are now tailored for 1.x releases, ensuring that automated release notes and pull requests follow the correct workflow and branch safety rules.

**Release notes skill updates:**

* [`.agents/skills/create-draft-release-notes/SKILL.md`](diffhunk://#diff-5ad5afd86b9d0714f5bc625a7bfc182e77d7d8ed4aaf861716175678deee39abL3-R3): Changed the skill description and workflow to explicitly target the `v1.x` maintenance branch, including using `v1.x` as `base_branch` for draft release creation and previous-tag comparison. Updated all example tags and commands to focus on the 1.x release line, and clarified steps for creating and verifying releases on the correct branch. 

**Pull request creator skill updates:**

* [`.agents/skills/pr-creator/SKILL.md`](diffhunk://#diff-aa00b5307eb78efb06b90ea985c1902f950735a1afb2ab2a3342f941ce3c6172L3-R25): Updated the skill description and workflow to ensure all pull requests target `v1.x` for maintenance work. Adjusted branch naming conventions, safety checks, and PR creation steps to prevent direct commits to `v1.x` and to use it as the base branch for PRs.
* [`.agents/skills/pr-creator/SKILL.md`](diffhunk://#diff-aa00b5307eb78efb06b90ea985c1902f950735a1afb2ab2a3342f941ce3c6172L34-R37): Updated the PR body and related links instructions to reflect the new workflow order and clarify best practices for concise writing and linking. 

## Related Links

<!--- Provide links of related issues or pages -->
