### PR TITLE
Release: v1.5.12

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/cli",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/client",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "main": "dist/index.html",
   "repository": {
     "type": "git",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/components",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "license": "MIT",
   "types": "dist/index.d.ts",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/core",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/docs",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "scripts": {
     "dev": "cross-env RSPRESS_PERSIST_CACHE=false rspress dev",
     "build": "cross-env RSPRESS_PERSIST_CACHE=false rspress build && sh build.sh",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/graph",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/rspack-plugin/package.json
+++ b/packages/rspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/rspack-plugin",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/sdk",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/types",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/utils",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/webpack-plugin",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",


### PR DESCRIPTION
## Summary
## What's Changed

### Bug Fixes 🐞

* fix(core): avoid E1009 false positives for ESM entries by @yifancong in https://github.com/web-infra-dev/rsdoctor/pull/1695

### Other Changes

* chore(deps): update pnpm workspace config by @chenjiahan in https://github.com/web-infra-dev/rsdoctor/pull/1659
* chore(deps): update typescript and nodejs->24 by @yifancong in https://github.com/web-infra-dev/rsdoctor/pull/1658
* chore(deps): update react and modern dependencies by @yifancong in https://github.com/web-infra-dev/rsdoctor/pull/1664
* chore(deps): update node.js to >=18.20.8 by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1671
* chore(deps): update dependency @ant-design/icons to v6 by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1672
* chore(deps): update dependency cross-env to v10 by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1673
* chore(deps): update dependency @rstest/core to v0.10.0 by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1683
* chore(deps): update dependency @rstack-dev/doc-ui to v1.13.3 by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1677
* chore(deps): update all patch dependencies by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1669
* chore(deps): update dependency rslog to v2 by @renovate[bot] in https://github.com/web-infra-dev/rsdoctor/pull/1678

**Full Changelog**: https://github.com/web-infra-dev/rsdoctor/compare/v1.5.11...v1.5.12
## Related Links

<!--- Provide links of related issues or pages -->
