### PR TITLE
perf(rspack-plugin): optimize the treeShaking control logic in Rspack

### DIFF
--- a/packages/core/src/build-utils/build/module-graph/rspack/transform.ts
+++ b/packages/core/src/build-utils/build/module-graph/rspack/transform.ts
@@ -1,6 +1,6 @@
 import {
   Dependency,
-  extractCodeFromLocation,
+  extractCodeFromSourceLines,
   Module,
   parseLocation,
 } from '@rsdoctor/graph';
@@ -243,6 +243,7 @@ export function extractSideEffectCodes(mg: SDK.ModuleGraphInstance) {
     const moduleSource = module.getSource();
     const source = moduleSource.source || moduleSource.parsedSource;
     if (!source) continue;
+    const sourceLines = source.split('\n');
 
     // Process each side effect location
     for (const sideEffectLocation of sideEffectLocations) {
@@ -251,7 +252,7 @@ export function extractSideEffectCodes(mg: SDK.ModuleGraphInstance) {
       if (!parsedLocation) continue;
 
       // Extract the code snippet
-      const code = extractCodeFromLocation(source, parsedLocation);
+      const code = extractCodeFromSourceLines(sourceLines, parsedLocation);
       if (code) {
         // Store the code in a separate data structure
         module.addSideEffectCode({

--- a/packages/core/src/inner-plugins/plugins/rspack.ts
+++ b/packages/core/src/inner-plugins/plugins/rspack.ts
@@ -74,8 +74,10 @@ export function applyRspackNativePlugin(
           plugin.modulesGraph,
           data,
         );
-        // Extract side effect codes after sources are available
-        ModuleGraphBuildUtils.extractSideEffectCodes(plugin.modulesGraph);
+        if (plugin.options.features.treeShaking) {
+          // Extract side effect codes after sources are available.
+          ModuleGraphBuildUtils.extractSideEffectCodes(plugin.modulesGraph);
+        }
       },
       assetPatchData: (data: Plugin.RspackNativeAssetPatch) => {
         ChunksBuildUtils.patchNativeAssets(plugin.chunkGraph!, data);

--- a/packages/core/tests/build/utils/rspack-transform.test.ts
+++ b/packages/core/tests/build/utils/rspack-transform.test.ts
@@ -1,7 +1,32 @@
 import { describe, it, expect } from '@rstest/core';
 import { ModuleGraph, ChunkGraph, Chunk } from '@rsdoctor/graph';
-import { patchNativeModuleGraph } from '@/build-utils/build/module-graph/rspack/transform';
+import {
+  extractSideEffectCodes,
+  patchNativeModuleGraph,
+  patchNativeModuleSources,
+} from '@/build-utils/build/module-graph/rspack/transform';
 import type { Plugin } from '@rsdoctor/types';
+
+function createNativeModule(
+  data: Partial<Plugin.RspackNativeModule> &
+    Pick<Plugin.RspackNativeModule, 'ukey' | 'identifier' | 'path'>,
+): Plugin.RspackNativeModule {
+  return {
+    isEntry: false,
+    kind: 'normal',
+    layer: undefined,
+    dependencies: [],
+    imported: [],
+    modules: [],
+    belongModules: [],
+    chunks: [],
+    issuerPath: [],
+    bailoutReason: [],
+    sideEffectsLocations: [],
+    exportsType: 'namespace',
+    ...data,
+  };
+}
 
 describe('Rspack native module graph transform', () => {
   it('should process bailoutReason from Rspack native plugin', () => {
@@ -15,56 +40,31 @@ describe('Rspack native module graph transform', () => {
     // Create mock Rspack native module graph data
     const rawModuleGraph: Plugin.RspackNativeModuleGraph = {
       modules: [
-        {
+        createNativeModule({
           ukey: 1,
           identifier: '/path/to/module1.js',
           path: '/path/to/module1.js',
-          isEntry: false,
-          kind: 'normal',
-          layer: undefined,
-          dependencies: [],
-          imported: [],
-          modules: [],
-          belongModules: [],
           chunks: [1],
-          issuerPath: [],
           bailoutReason: [
             'Statement with side_effects in source code at module1.js:5:1-10',
             'ModuleConcatenation bailout: Module is not an ECMAScript module',
           ],
-        },
-        {
+        }),
+        createNativeModule({
           ukey: 2,
           identifier: '/path/to/module2.js',
           path: '/path/to/module2.js',
-          isEntry: false,
-          kind: 'normal',
-          layer: undefined,
-          dependencies: [],
-          imported: [],
-          modules: [],
-          belongModules: [],
           chunks: [1],
-          issuerPath: [],
           bailoutReason: [
             'Statement with side_effects in source code at module2.js:3:1-8',
           ],
-        },
-        {
+        }),
+        createNativeModule({
           ukey: 3,
           identifier: '/path/to/module3.js',
           path: '/path/to/module3.js',
-          isEntry: false,
-          kind: 'normal',
-          layer: undefined,
-          dependencies: [],
-          imported: [],
-          modules: [],
-          belongModules: [],
           chunks: [1],
-          issuerPath: [],
-          bailoutReason: [],
-        },
+        }),
       ],
       dependencies: [],
       chunkModules: [
@@ -73,6 +73,7 @@ describe('Rspack native module graph transform', () => {
           modules: [1, 2, 3],
         },
       ],
+      connectionsOnlyImports: [],
     };
 
     // Apply the transform
@@ -109,25 +110,17 @@ describe('Rspack native module graph transform', () => {
 
     const rawModuleGraph: Plugin.RspackNativeModuleGraph = {
       modules: [
-        {
+        createNativeModule({
           ukey: 1,
           identifier: '/path/to/module.js',
           path: '/path/to/module.js',
-          isEntry: false,
-          kind: 'normal',
-          layer: undefined,
-          dependencies: [],
-          imported: [],
-          modules: [],
-          belongModules: [],
           chunks: [1],
-          issuerPath: [],
           bailoutReason: [
             'ModuleConcatenation bailout: Module is not an ECMAScript module',
             'ModuleConcatenation bailout: Module is an entry point',
             'Statement with side_effects in source code at module.js:1:1-5',
           ],
-        },
+        }),
       ],
       dependencies: [],
       chunkModules: [
@@ -136,6 +129,7 @@ describe('Rspack native module graph transform', () => {
           modules: [1],
         },
       ],
+      connectionsOnlyImports: [],
     };
 
     patchNativeModuleGraph(moduleGraph, chunkGraph, rawModuleGraph);
@@ -164,21 +158,12 @@ describe('Rspack native module graph transform', () => {
 
     const rawModuleGraph: Plugin.RspackNativeModuleGraph = {
       modules: [
-        {
+        createNativeModule({
           ukey: 1,
           identifier: '/path/to/module.js',
           path: '/path/to/module.js',
-          isEntry: false,
-          kind: 'normal',
-          layer: undefined,
-          dependencies: [],
-          imported: [],
-          modules: [],
-          belongModules: [],
           chunks: [1],
-          issuerPath: [],
-          bailoutReason: [],
-        } as Plugin.RspackNativeModule,
+        }),
       ],
       dependencies: [],
       chunkModules: [
@@ -187,6 +172,7 @@ describe('Rspack native module graph transform', () => {
           modules: [1],
         },
       ],
+      connectionsOnlyImports: [],
     };
 
     patchNativeModuleGraph(moduleGraph, chunkGraph, rawModuleGraph);
@@ -194,5 +180,73 @@ describe('Rspack native module graph transform', () => {
     const module = moduleGraph.getModuleById(1);
     expect(module).toBeTruthy();
     expect(module?.getBailoutReason()).toEqual([]);
+  });
+
+  it('should extract side effect code snippets from module sources', () => {
+    const moduleGraph = new ModuleGraph();
+    const chunkGraph = new ChunkGraph();
+
+    const chunk = new Chunk('1', 'main', 0, false, false);
+    chunkGraph.addChunk(chunk);
+
+    const rawModuleGraph: Plugin.RspackNativeModuleGraph = {
+      modules: [
+        createNativeModule({
+          ukey: 1,
+          identifier: '/path/to/module.js',
+          path: '/path/to/module.js',
+          chunks: [1],
+          sideEffectsLocations: [
+            {
+              location: '1:1-8',
+              nodeType: 'ExpressionStatement',
+              module: 1,
+              request: './module',
+            },
+            {
+              location: '2:1-9',
+              nodeType: 'ExpressionStatement',
+              module: 1,
+              request: './module',
+            },
+          ],
+        }),
+      ],
+      dependencies: [],
+      chunkModules: [
+        {
+          chunk: 1,
+          modules: [1],
+        },
+      ],
+      connectionsOnlyImports: [],
+    };
+
+    patchNativeModuleGraph(moduleGraph, chunkGraph, rawModuleGraph);
+    patchNativeModuleSources(moduleGraph, {
+      moduleOriginalSources: [
+        {
+          module: 1,
+          source: 'first();\nsecond();',
+          size: 17,
+        },
+      ],
+      jsonModuleSizes: [],
+    });
+    extractSideEffectCodes(moduleGraph);
+
+    const module = moduleGraph.getModuleById(1);
+    expect(module?.getSideEffectCodes()).toEqual([
+      {
+        moduleId: 1,
+        startLine: 1,
+        code: 'first();',
+      },
+      {
+        moduleId: 1,
+        startLine: 2,
+        code: 'second();',
+      },
+    ]);
   });
 });

--- a/packages/graph/src/graph/module-graph/utils.ts
+++ b/packages/graph/src/graph/module-graph/utils.ts
@@ -142,18 +142,15 @@ export function parseLocation(location: string): {
 }
 
 /**
- * Extract code snippet from source based on location
- * @param source The source code string
- * @param location Parsed location object
- * @returns Extracted code snippet
+ * Extract code from pre-split source lines. This helper intentionally does not
+ * split the source string so callers can reuse one lines array for many ranges.
  */
-export function extractCodeFromLocation(
-  source: string,
+export function extractCodeFromSourceLines(
+  lines: string[],
   location: ReturnType<typeof parseLocation>,
 ): string {
-  if (!source || !location) return '';
+  if (!lines.length || !location) return '';
 
-  const lines = source.split('\n');
   const {
     startLine,
     startColumn: OriginalStartColumn,

--- a/packages/graph/tests/utils.test.ts
+++ b/packages/graph/tests/utils.test.ts
@@ -2,11 +2,11 @@ import { expect, describe, it } from '@rstest/core';
 import {
   getModuleName,
   parseLocation,
-  extractCodeFromLocation,
+  extractCodeFromSourceLines,
 } from '../src/graph/module-graph/utils';
 import { readPackageJson } from '../src/graph/package-graph/utils';
 import { join } from 'path';
-import fse from 'fs-extra';
+import { readFileSync } from 'node:fs';
 /**
  * The following code is modified based on
  * https://github.com/relative-ci/bundle-stats/blob/master/packages/utils/src/webpack/__tests__/utils-get-module-name.js
@@ -130,8 +130,9 @@ describe('parseLocation', () => {
   });
 });
 
-describe('extractCodeFromLocation', () => {
+describe('extractCodeFromSourceLines', () => {
   const SOURCE = 'ABCDE\nFGHIJ\nKLMNO\nPQRST\nUVWXY';
+  const SOURCE_LINES = SOURCE.split('\n');
   // lines (1-indexed):
   //   1 → "ABCDE"
   //   2 → "FGHIJ"
@@ -141,14 +142,14 @@ describe('extractCodeFromLocation', () => {
 
   // ── Guard conditions ───────────────────────────────────────────────────────
   describe('guard conditions', () => {
-    it('returns empty string when source is empty', () => {
+    it('returns empty string when source lines are empty', () => {
       expect(
-        extractCodeFromLocation('', { startLine: 1, startColumn: 0 }),
+        extractCodeFromSourceLines([], { startLine: 1, startColumn: 0 }),
       ).toBe('');
     });
 
     it('returns empty string when location is null', () => {
-      expect(extractCodeFromLocation(SOURCE, null)).toBe('');
+      expect(extractCodeFromSourceLines(SOURCE_LINES, null)).toBe('');
     });
   });
 
@@ -157,7 +158,10 @@ describe('extractCodeFromLocation', () => {
     it('returns from startColumn to end of line (column 1-indexed → adjusted)', () => {
       // startColumn 1 → adjusted to 0 → "ABCDE".substring(0) = "ABCDE"
       expect(
-        extractCodeFromLocation(SOURCE, { startLine: 1, startColumn: 1 }),
+        extractCodeFromSourceLines(SOURCE_LINES, {
+          startLine: 1,
+          startColumn: 1,
+        }),
       ).toBe('ABCDE');
     });
   });
@@ -168,7 +172,7 @@ describe('extractCodeFromLocation', () => {
       // startColumn 1 → adjusted 0; endColumn 3 → used as-is
       // "ABCDE".substring(0, 3) = "ABC"
       expect(
-        extractCodeFromLocation(SOURCE, {
+        extractCodeFromSourceLines(SOURCE_LINES, {
           startLine: 1,
           startColumn: 1,
           endLine: 1,
@@ -186,7 +190,7 @@ describe('extractCodeFromLocation', () => {
       // line2: "FGHIJ" (full)
       // line3: "KLMNO".substring(0, 3) = "KLM"
       expect(
-        extractCodeFromLocation(SOURCE, {
+        extractCodeFromSourceLines(SOURCE_LINES, {
           startLine: 1,
           startColumn: 3,
           endLine: 3,
@@ -200,7 +204,10 @@ describe('extractCodeFromLocation', () => {
   describe('out-of-range line numbers', () => {
     it('returns empty string when startLine exceeds total line count', () => {
       expect(
-        extractCodeFromLocation('one line', { startLine: 5, startColumn: 0 }),
+        extractCodeFromSourceLines(['one line'], {
+          startLine: 5,
+          startColumn: 0,
+        }),
       ).toBe('');
     });
   });
@@ -211,7 +218,7 @@ describe('readPackageJson util', () => {
     expect(
       readPackageJson(join(__dirname, './fixture/index/index.js'), (file) => {
         try {
-          return fse.readJsonSync(file, { encoding: 'utf8' });
+          return JSON.parse(readFileSync(file, 'utf8'));
         } catch (e) {
           // console.log(e)
         }


### PR DESCRIPTION
## Summary
This pull request refactors how code snippets are extracted from module sources based on side effect locations, improving efficiency and test coverage. The main change is replacing the `extractCodeFromLocation` function with the more efficient `extractCodeFromSourceLines`, which reduces redundant string splitting. The update also ensures that side effect code extraction only occurs when tree shaking is enabled and adds comprehensive tests for these behaviors.

**Core functionality improvements:**

* Replaced `extractCodeFromLocation` with `extractCodeFromSourceLines` throughout the codebase for extracting code snippets, allowing callers to reuse pre-split source lines for multiple extractions and improving efficiency (`packages/graph/src/graph/module-graph/utils.ts`, `packages/core/src/build-utils/build/module-graph/rspack/transform.ts`, `packages/graph/tests/utils.test.ts`) 

* Updated the code extraction logic in `extractSideEffectCodes` to use pre-split source lines, reducing overhead when processing multiple side effect locations (`packages/core/src/build-utils/build/module-graph/rspack/transform.ts`)

**Feature gating and plugin behavior:**

* Modified the Rspack native plugin to only extract side effect codes when the `treeShaking` feature is enabled, preventing unnecessary processing (`packages/core/src/inner-plugins/plugins/rspack.ts`).


## Related Links

<!--- Provide links of related issues or pages -->
