### PR TITLE
chore(utils): inline es-toolkit types into collection.d.ts via dts.bundle

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -31,11 +31,11 @@
     },
     "./collection": {
       "import": {
-        "types": "./dist/common/collection.d.ts",
+        "types": "./dist/collection.d.ts",
         "default": "./dist/collection.js"
       },
       "require": {
-        "types": "./dist/common/collection.d.cts",
+        "types": "./dist/collection.d.cts",
         "default": "./dist/collection.cjs"
       }
     },
@@ -79,7 +79,7 @@
         "./dist/build/index.d.ts"
       ],
       "collection": [
-        "./dist/common/collection.d.ts"
+        "./dist/collection.d.ts"
       ],
       "error": [
         "./dist/error/index.d.ts"
@@ -124,6 +124,7 @@
     "strip-ansi": "^6.0.1"
   },
   "devDependencies": {
+    "@microsoft/api-extractor": "^7.58.7",
     "@types/babel__code-frame": "7.27.0",
     "@types/connect": "catalog:",
     "@types/deep-eql": "4.0.2",

--- a/packages/utils/rslib.config.ts
+++ b/packages/utils/rslib.config.ts
@@ -1,6 +1,10 @@
-import { defineConfig } from '@rslib/core';
+import { defineConfig, type LibConfig } from '@rslib/core';
 import { join } from 'path';
-import { dualPackage } from '../../scripts/rslib.base.config';
+import {
+  cjsConfig,
+  esmConfig,
+  pluginsConfig,
+} from '../../scripts/rslib.base.config';
 
 const prebundleConfigPath = join(__dirname, 'prebundle.config.mjs');
 const prebundleConfigModule = await import(prebundleConfigPath);
@@ -36,23 +40,42 @@ const externals = [
   },
 ];
 
+const mainEntry = {
+  common: './src/common/index.ts',
+  build: './src/build/index.ts',
+  error: './src/error/index.ts',
+  ruleUtils: './src/rule-utils/index.ts',
+  logger: './src/logger.ts',
+};
+
+// Main entries: bundled JS, bundleless dts via tsc (`dts.build`). These touch
+// node `fs` (`fs-extra`), which `dts.bundle` (API Extractor) cannot analyze.
+const mainLib = (base: LibConfig): LibConfig => ({
+  ...base,
+  source: { entry: mainEntry },
+  output: { ...base.output, externals },
+});
+
+// `collection` re-exports from `es-toolkit/compat`; bundle its `.d.ts` so its
+// types inline es-toolkit (via `dts.bundle` / API Extractor). Kept in a
+// separate lib (its own `source.entry`, no top-level entry to merge in) so the
+// fs-touching main entries never enter the API Extractor program.
+const collectionLib = (base: LibConfig): LibConfig => {
+  const baseDts = typeof base.dts === 'object' ? base.dts : {};
+  return {
+    ...base,
+    bundle: true,
+    source: { entry: { collection: './src/common/collection.ts' } },
+    dts: {
+      autoExtension: baseDts.autoExtension,
+      bundle: { bundledPackages: ['es-toolkit'] },
+    },
+  };
+};
+
+const dualFormat = [esmConfig, cjsConfig];
+
 export default defineConfig({
-  ...dualPackage,
-  source: {
-    entry: {
-      common: './src/common/index.ts',
-      build: './src/build/index.ts',
-      collection: './src/common/collection.ts',
-      error: './src/error/index.ts',
-      ruleUtils: './src/rule-utils/index.ts',
-      logger: './src/logger.ts',
-    },
-  },
-  lib: dualPackage.lib.map((libConfig) => ({
-    ...libConfig,
-    output: {
-      ...libConfig.output,
-      externals,
-    },
-  })),
+  lib: [...dualFormat.map(mainLib), ...dualFormat.map(collectionLib)],
+  plugins: pluginsConfig,
 });

--- a/packages/utils/src/common/collection.ts
+++ b/packages/utils/src/common/collection.ts
@@ -1,193 +1,27 @@
-import {
-  debounce as esDebounce,
-  defaults as esDefaults,
-  escape as esEscape,
-  escapeRegExp as esEscapeRegExp,
-  find as esFind,
-  get as esGet,
-  groupBy as esGroupBy,
-  isArray as esIsArray,
-  isEqual as esIsEqual,
-  isNumber as esIsNumber,
-  lowerCase as esLowerCase,
-  mapValues as esMapValues,
-  maxBy as esMaxBy,
-  minBy as esMinBy,
-  omit as esOmit,
-  omitBy as esOmitBy,
-  orderBy as esOrderBy,
-  pull as esPull,
-  snakeCase as esSnakeCase,
-  sumBy as esSumBy,
-  throttle as esThrottle,
-  unionBy as esUnionBy,
-  uniq as esUniq,
-  uniqBy as esUniqBy,
-  upperFirst as esUpperFirst,
+export {
+  debounce,
+  defaults,
+  escape,
+  escapeRegExp,
+  find,
+  get,
+  groupBy,
+  isArray,
+  isEqual,
+  isNumber,
+  lowerCase,
+  mapValues,
+  maxBy,
+  minBy,
+  omit,
+  omitBy,
+  orderBy,
+  pull,
+  snakeCase,
+  sumBy,
+  throttle,
+  unionBy,
+  uniq,
+  uniqBy,
+  upperFirst,
 } from 'es-toolkit/compat';
-
-type AnyFunction = (...args: any[]) => any;
-type CollectionKey = string | number | symbol;
-type CollectionPath = CollectionKey | readonly CollectionKey[];
-type CollectionIteratee<T, TResult = unknown> =
-  | ((value: T, index: number, collection: readonly T[]) => TResult)
-  | CollectionPath
-  | Partial<T>;
-type ObjectIteratee<T extends object, TResult = unknown> = (
-  value: T[keyof T],
-  key: keyof T,
-  object: T,
-) => TResult;
-
-export interface DebounceSettings {
-  leading?: boolean;
-  maxWait?: number;
-  trailing?: boolean;
-}
-
-export interface DebounceSettingsLeading extends DebounceSettings {
-  leading: true;
-}
-
-export interface DebouncedFunc<T extends AnyFunction> {
-  (...args: Parameters<T>): ReturnType<T> | undefined;
-  cancel(): void;
-  flush(): ReturnType<T> | undefined;
-}
-
-export interface DebouncedFuncLeading<
-  T extends AnyFunction,
-> extends DebouncedFunc<T> {
-  (...args: Parameters<T>): ReturnType<T>;
-  flush(): ReturnType<T>;
-}
-
-export interface ThrottleSettings {
-  leading?: boolean;
-  trailing?: boolean;
-}
-
-export type SortOrder = 'asc' | 'desc';
-
-export interface Debounce {
-  <T extends AnyFunction>(
-    func: T,
-    wait: number | undefined,
-    options: DebounceSettingsLeading,
-  ): DebouncedFuncLeading<T>;
-  <T extends AnyFunction>(
-    func: T,
-    wait?: number,
-    options?: DebounceSettings,
-  ): DebouncedFunc<T>;
-}
-
-export interface Throttle {
-  <T extends AnyFunction>(
-    func: T,
-    wait?: number,
-    options?: ThrottleSettings,
-  ): DebouncedFunc<T>;
-}
-
-export interface Get {
-  <TObject extends object, TKey extends keyof TObject>(
-    object: TObject,
-    path: TKey | readonly [TKey],
-  ): TObject[TKey];
-  <TObject extends object, TKey extends keyof TObject, TDefault>(
-    object: TObject | null | undefined,
-    path: TKey | readonly [TKey],
-    defaultValue: TDefault,
-  ): Exclude<TObject[TKey], undefined> | TDefault;
-  <TDefault = any>(
-    object: unknown,
-    path: CollectionPath,
-    defaultValue?: TDefault,
-  ): any;
-}
-
-export const debounce = esDebounce as Debounce;
-export const defaults = esDefaults as <T extends object, U extends object>(
-  object: T,
-  ...sources: U[]
-) => T & U;
-export const escape = esEscape as (value?: string | null) => string;
-export const escapeRegExp = esEscapeRegExp as (value?: string | null) => string;
-export const find = esFind as {
-  <T, U extends T>(
-    collection: ArrayLike<T> | null | undefined,
-    predicate: (
-      value: T,
-      index: number,
-      collection: ArrayLike<T>,
-    ) => value is U,
-    fromIndex?: number,
-  ): U | undefined;
-  <T>(
-    collection: ArrayLike<T> | null | undefined,
-    predicate?: CollectionIteratee<T, boolean>,
-    fromIndex?: number,
-  ): T | undefined;
-  <T extends object>(
-    collection: T | null | undefined,
-    predicate?:
-      | ObjectIteratee<T, boolean>
-      | Partial<T[keyof T]>
-      | CollectionPath,
-    fromIndex?: number,
-  ): T[keyof T] | undefined;
-};
-export const get = esGet as Get;
-export const groupBy = esGroupBy as <T>(
-  collection: readonly T[] | null | undefined,
-  iteratee: CollectionIteratee<T, CollectionKey>,
-) => Record<string, T[]>;
-export const isArray = esIsArray as <T = any>(value?: unknown) => value is T[];
-export const isEqual = esIsEqual as (value: unknown, other: unknown) => boolean;
-export const isNumber = esIsNumber as (value?: unknown) => value is number;
-export const lowerCase = esLowerCase as (value?: string | null) => string;
-export const mapValues = esMapValues as <T extends object, TResult>(
-  object: T | null | undefined,
-  iteratee: ObjectIteratee<T, TResult>,
-) => { [K in keyof T]: TResult };
-export const maxBy = esMaxBy as <T>(
-  collection: readonly T[] | null | undefined,
-  iteratee: CollectionIteratee<T>,
-) => T | undefined;
-export const minBy = esMinBy as <T>(
-  collection: readonly T[] | null | undefined,
-  iteratee: CollectionIteratee<T>,
-) => T | undefined;
-export const omit = esOmit as <T extends object>(
-  object: T | null | undefined,
-  paths: CollectionPath | readonly CollectionPath[],
-) => T;
-export const omitBy = esOmitBy as <T extends object>(
-  object: T | null | undefined,
-  predicate: ObjectIteratee<T, boolean>,
-) => Partial<T>;
-export const orderBy = esOrderBy as <T>(
-  collection: readonly T[] | null | undefined,
-  iteratees?: CollectionIteratee<T> | readonly CollectionIteratee<T>[],
-  orders?: SortOrder | readonly SortOrder[],
-) => T[];
-export const pull = esPull as <T>(array: T[], ...values: T[]) => T[];
-export const snakeCase = esSnakeCase as (value?: string | null) => string;
-export const sumBy = esSumBy as <T>(
-  collection: readonly T[] | null | undefined,
-  iteratee: CollectionIteratee<T, number>,
-) => number;
-export const throttle = esThrottle as Throttle;
-export const unionBy = esUnionBy as <T>(
-  collection: readonly T[] | null | undefined,
-  ...valuesOrIteratee: Array<readonly T[] | CollectionIteratee<T>>
-) => T[];
-export const uniq = esUniq as <T>(
-  array: readonly T[] | null | undefined,
-) => T[];
-export const uniqBy = esUniqBy as <T>(
-  array: readonly T[] | null | undefined,
-  iteratee: CollectionIteratee<T>,
-) => T[];
-export const upperFirst = esUpperFirst as (value?: string | null) => string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,7 +154,7 @@ importers:
         version: link:scripts/tsconfig
       '@rslib/core':
         specifier: 0.21.5
-        version: 0.21.5(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.21.5(@microsoft/api-extractor@7.58.7(@types/node@24.12.3))(core-js@3.49.0)(typescript@6.0.3)
       '@rslint/core':
         specifier: 'catalog:'
         version: 0.5.3(jiti@2.6.1)
@@ -464,7 +464,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 0.21.5
-        version: 0.21.5(core-js@3.49.0)(typescript@6.0.3)
+        version: 0.21.5(@microsoft/api-extractor@7.58.7(@types/node@24.12.3))(core-js@3.49.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: 'catalog:'
         version: 0.10.3(core-js@3.49.0)
@@ -1081,6 +1081,9 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
     devDependencies:
+      '@microsoft/api-extractor':
+        specifier: ^7.58.7
+        version: 7.58.7(@types/node@24.12.3)
       '@types/babel__code-frame':
         specifier: 7.27.0
         version: 7.27.0
@@ -2470,6 +2473,19 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
+  '@microsoft/api-extractor-model@7.33.8':
+    resolution: {integrity: sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==}
+
+  '@microsoft/api-extractor@7.58.7':
+    resolution: {integrity: sha512-yK6OycD46gIzLRpj6ueVUWPk1ACSpkN1LBo05gY1qPTylbWyUCanXfH7+VgkI5LJrJoRSQR5F04XuCffCXLOBw==}
+    hasBin: true
+
+  '@microsoft/tsdoc-config@0.18.1':
+    resolution: {integrity: sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==}
+
+  '@microsoft/tsdoc@0.16.0':
+    resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -3411,6 +3427,36 @@ packages:
       jsdom:
         optional: true
 
+  '@rushstack/node-core-library@5.23.1':
+    resolution: {integrity: sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/problem-matcher@0.2.1':
+    resolution: {integrity: sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/rig-package@0.7.3':
+    resolution: {integrity: sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==}
+
+  '@rushstack/terminal@0.24.0':
+    resolution: {integrity: sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/ts-command-line@5.3.9':
+    resolution: {integrity: sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==}
+
   '@shikijs/core@4.0.2':
     resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
     engines: {node: '>=20'}
@@ -3627,6 +3673,9 @@ packages:
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+
+  '@types/argparse@1.0.38':
+    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
   '@types/babel__code-frame@7.27.0':
     resolution: {integrity: sha512-Dwlo+LrxDx/0SpfmJ/BKveHf7QXWvLBLc+x03l5sbzykj3oB9nHygCpSECF1a+s+QIxbghe+KHqC90vGtxLRAA==}
@@ -3871,6 +3920,14 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -3894,6 +3951,9 @@ packages:
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   algoliasearch@5.49.2:
     resolution: {integrity: sha512-1K0wtDaRONwfhL4h8bbJ9qTjmY6rhGgRvvagXkMBsAOMNr+3Q2SffHECh9DIuNVrMA1JwA0zCwhyepgBZVakng==}
@@ -4590,6 +4650,10 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
   diffie-hellman@5.0.3:
     resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
 
@@ -5206,6 +5270,10 @@ packages:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
 
+  import-lazy@4.0.0:
+    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
+    engines: {node: '>=8'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -5367,6 +5435,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
@@ -7364,6 +7435,10 @@ packages:
   stream-http@3.2.0:
     resolution: {integrity: sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==}
 
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
   string-convert@0.2.1:
     resolution: {integrity: sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==}
 
@@ -7582,6 +7657,11 @@ packages:
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -9516,6 +9596,41 @@ snapshots:
       '@types/react': 19.2.15
       react: 19.2.6
 
+  '@microsoft/api-extractor-model@7.33.8(@types/node@24.12.3)':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@24.12.3)
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/api-extractor@7.58.7(@types/node@24.12.3)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@24.12.3)
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@24.12.3)
+      '@rushstack/rig-package': 0.7.3
+      '@rushstack/terminal': 0.24.0(@types/node@24.12.3)
+      '@rushstack/ts-command-line': 5.3.9(@types/node@24.12.3)
+      diff: 8.0.4
+      minimatch: 9.0.9
+      resolve: 1.22.10
+      semver: 7.7.4
+      source-map: 0.6.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/tsdoc-config@0.18.1':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      ajv: 8.18.0
+      jju: 1.4.0
+      resolve: 1.22.10
+
+  '@microsoft/tsdoc@0.16.0': {}
+
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.7)
@@ -10137,11 +10252,12 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rslib/core@0.21.5(core-js@3.49.0)(typescript@6.0.3)':
+  '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@24.12.3))(core-js@3.49.0)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.0.7(core-js@3.49.0)
-      rsbuild-plugin-dts: 0.21.5(@rsbuild/core@2.0.7(core-js@3.49.0))(typescript@6.0.3)
+      rsbuild-plugin-dts: 0.21.5(@microsoft/api-extractor@7.58.7(@types/node@24.12.3))(@rsbuild/core@2.0.7(core-js@3.49.0))(typescript@6.0.3)
     optionalDependencies:
+      '@microsoft/api-extractor': 7.58.7(@types/node@24.12.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -10575,6 +10691,45 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
+  '@rushstack/node-core-library@5.23.1(@types/node@24.12.3)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fs-extra: 11.3.0
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.10
+      semver: 7.7.4
+    optionalDependencies:
+      '@types/node': 24.12.3
+
+  '@rushstack/problem-matcher@0.2.1(@types/node@24.12.3)':
+    optionalDependencies:
+      '@types/node': 24.12.3
+
+  '@rushstack/rig-package@0.7.3':
+    dependencies:
+      jju: 1.4.0
+      resolve: 1.22.10
+
+  '@rushstack/terminal@0.24.0(@types/node@24.12.3)':
+    dependencies:
+      '@rushstack/node-core-library': 5.23.1(@types/node@24.12.3)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@24.12.3)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 24.12.3
+
+  '@rushstack/ts-command-line@5.3.9(@types/node@24.12.3)':
+    dependencies:
+      '@rushstack/terminal': 0.24.0(@types/node@24.12.3)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@shikijs/core@4.0.2':
     dependencies:
       '@shikijs/primitive': 4.0.2
@@ -10799,6 +10954,8 @@ snapshots:
   '@tybys/wasm-util@0.9.0':
     dependencies:
       tslib: 2.8.1
+
+  '@types/argparse@1.0.38': {}
 
   '@types/babel__code-frame@7.27.0': {}
 
@@ -11067,6 +11224,10 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  ajv-draft-04@1.0.0(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
@@ -11075,12 +11236,23 @@ snapshots:
     optionalDependencies:
       ajv: 8.17.1
 
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
   ajv-keywords@5.1.0(ajv@8.17.1):
     dependencies:
       ajv: 8.17.1
       fast-deep-equal: 3.1.3
 
   ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.5
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.0.5
@@ -11869,6 +12041,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  diff@8.0.4: {}
+
   diffie-hellman@5.0.3:
     dependencies:
       bn.js: 4.12.1
@@ -12636,6 +12810,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-lazy@4.0.0: {}
+
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.4: {}
@@ -12772,6 +12948,8 @@ snapshots:
       supports-color: 8.1.1
 
   jiti@2.6.1: {}
+
+  jju@1.4.0: {}
 
   jose@6.1.3: {}
 
@@ -14916,11 +15094,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.21.5(@rsbuild/core@2.0.7(core-js@3.49.0))(typescript@6.0.3):
+  rsbuild-plugin-dts@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@24.12.3))(@rsbuild/core@2.0.7(core-js@3.49.0))(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.7(core-js@3.49.0)
     optionalDependencies:
+      '@microsoft/api-extractor': 7.58.7(@types/node@24.12.3)
       typescript: 6.0.3
 
   rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.0.7(core-js@3.49.0)):
@@ -15302,6 +15481,8 @@ snapshots:
       readable-stream: 3.6.2
       xtend: 4.0.2
 
+  string-argv@0.3.2: {}
+
   string-convert@0.2.1: {}
 
   string-loader@0.0.1: {}
@@ -15515,6 +15696,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-typed-array: 1.1.15
+
+  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 


### PR DESCRIPTION
Builds on #1711. Inlines real es-toolkit types into `collection.d.ts` via rslib `dts.bundle` (API Extractor), instead of the ~190 hand-written declarations.

## Principle

`dts.bundle` (API Extractor) and `dts.build` (tsc) are two independent dts engines. API Extractor builds a full type model and treats `@types/node`'s ambient `declare module "fs"` as external; its simplified analysis throws `Unsupported export "renameSync"` (rushstack#3335) the moment an entry pulls the `fs` namespace into its public API — which the `build` entry does via `export * as fse from 'fs-extra'` (surfaced as `File.fse`).

So the fix is **not** "make API Extractor ignore fs" (impossible) but "never feed fs-touching code to API Extractor". One `defineConfig({ lib: [...] })`, each lib with its own `source.entry` (no top-level entry to merge), routes entries to the right engine:

```text
defineConfig({ lib: [...] })   each lib carries its own source.entry (nothing merged in)
│
├─ common / build / error / ruleUtils / logger   — touch node fs (build re-exports File.fse)
│   │
│   └─ dts.build  =  tsc  (no API Extractor → fs is never analyzed)
│        └─►  dist/<name>/index.d.ts        (bundleless, unchanged)
│
└─ collection   — fs-free, re-exports es-toolkit/compat
    │
    └─ dts.bundle  =  API Extractor,  bundledPackages: ['es-toolkit']
         └─►  dist/collection.d.ts          (es-toolkit types inlined)
```

Only the fs-free `collection` entry goes through API Extractor. No separate config, build ordering, or `cleanDistPath` workaround — it all runs in one `rslib build`.

The `./collection` types path moves from `dist/common/collection.d.ts` to `dist/collection.d.ts` because the inlined dts is emitted at the bundle's entry-keyed root path (the old `dist/common/` location now holds only the bundleless tsc re-export, kept on a separate path to avoid a write race between the two engines).

## Trade-off

Adds a build-time `@microsoft/api-extractor` dependency tree (an optional peer of rslib's dts plugin, not installed before) in exchange for dropping the hand-written types and tracking es-toolkit automatically. Lockfile change is limited to that tree and passes `--frozen-lockfile`.