### PR TITLE
fix(deps): relax rstack catalog ranges

### DIFF
--- a/.changeset/fix-rstack-catalog-ranges.md
+++ b/.changeset/fix-rstack-catalog-ranges.md
@@ -1,0 +1,5 @@
+---
+'@rsdoctor/core': patch
+---
+
+Use compatible ranges for Rsbuild and Rspack catalog dependencies to avoid publishing unnecessarily pinned Rstack versions.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,25 +7,25 @@ settings:
 catalogs:
   default:
     '@rsbuild/core':
-      specifier: 2.0.9
+      specifier: ^2.0.0
       version: 2.0.9
     '@rsbuild/plugin-check-syntax':
-      specifier: 1.6.1
+      specifier: ^1.6.1
       version: 1.6.1
     '@rsbuild/plugin-less':
-      specifier: 1.6.4
+      specifier: ^1.6.4
       version: 1.6.4
     '@rsbuild/plugin-node-polyfill':
       specifier: ^1.4.5
       version: 1.4.5
     '@rsbuild/plugin-react':
-      specifier: 2.0.1
+      specifier: ^2.0.0
       version: 2.0.1
     '@rsbuild/plugin-sass':
       specifier: ^1.5.3
       version: 1.5.3
     '@rsbuild/plugin-svgr':
-      specifier: 2.0.3
+      specifier: ^2.0.0
       version: 2.0.3
     '@rsbuild/plugin-type-check':
       specifier: ^1.3.5
@@ -34,16 +34,16 @@ catalogs:
       specifier: ^0.5.3
       version: 0.5.3
     '@rspack/cli':
-      specifier: 2.0.5
+      specifier: ^2.0.0
       version: 2.0.5
     '@rspack/core':
-      specifier: 2.0.5
+      specifier: ^2.0.0
       version: 2.0.5
     '@rspack/plugin-react-refresh':
-      specifier: 2.0.1
+      specifier: ^2.0.0
       version: 2.0.1
     '@rspack/resolver':
-      specifier: 0.2.8
+      specifier: ^0.2.8
       version: 0.2.8
     '@rstest/core':
       specifier: 0.10.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 catalogs:
   default:
     '@rsbuild/core':
-      specifier: ^2.0.0
+      specifier: ^2.0.9
       version: 2.0.9
     '@rsbuild/plugin-check-syntax':
       specifier: ^1.6.1
@@ -19,13 +19,13 @@ catalogs:
       specifier: ^1.4.5
       version: 1.4.5
     '@rsbuild/plugin-react':
-      specifier: ^2.0.0
+      specifier: ^2.0.1
       version: 2.0.1
     '@rsbuild/plugin-sass':
       specifier: ^1.5.3
       version: 1.5.3
     '@rsbuild/plugin-svgr':
-      specifier: ^2.0.0
+      specifier: ^2.0.3
       version: 2.0.3
     '@rsbuild/plugin-type-check':
       specifier: ^1.3.5
@@ -34,13 +34,13 @@ catalogs:
       specifier: ^0.5.3
       version: 0.5.3
     '@rspack/cli':
-      specifier: ^2.0.0
+      specifier: ^2.0.5
       version: 2.0.5
     '@rspack/core':
-      specifier: ^2.0.0
+      specifier: ^2.0.5
       version: 2.0.5
     '@rspack/plugin-react-refresh':
-      specifier: ^2.0.0
+      specifier: ^2.0.1
       version: 2.0.1
     '@rspack/resolver':
       specifier: ^0.2.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,18 +13,18 @@ allowBuilds:
   nx: false
 
 catalog:
-  '@rsbuild/core': ^2.0.0
+  '@rsbuild/core': ^2.0.9
   '@rsbuild/plugin-check-syntax': ^1.6.1
   '@rsbuild/plugin-less': ^1.6.4
   '@rsbuild/plugin-node-polyfill': ^1.4.5
-  '@rsbuild/plugin-react': ^2.0.0
+  '@rsbuild/plugin-react': ^2.0.1
   '@rsbuild/plugin-sass': ^1.5.3
-  '@rsbuild/plugin-svgr': ^2.0.0
+  '@rsbuild/plugin-svgr': ^2.0.3
   '@rsbuild/plugin-type-check': ^1.3.5
   '@rslint/core': ^0.5.3
-  '@rspack/cli': ^2.0.0
-  '@rspack/core': ^2.0.0
-  '@rspack/plugin-react-refresh': ^2.0.0
+  '@rspack/cli': ^2.0.5
+  '@rspack/core': ^2.0.5
+  '@rspack/plugin-react-refresh': ^2.0.1
   '@rspack/resolver': ^0.2.8
   '@rstest/core': 0.10.3
   '@types/body-parser': 1.19.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,19 +13,19 @@ allowBuilds:
   nx: false
 
 catalog:
-  '@rsbuild/core': 2.0.9
-  '@rsbuild/plugin-check-syntax': 1.6.1
-  '@rsbuild/plugin-less': 1.6.4
+  '@rsbuild/core': ^2.0.0
+  '@rsbuild/plugin-check-syntax': ^1.6.1
+  '@rsbuild/plugin-less': ^1.6.4
   '@rsbuild/plugin-node-polyfill': ^1.4.5
-  '@rsbuild/plugin-react': 2.0.1
+  '@rsbuild/plugin-react': ^2.0.0
   '@rsbuild/plugin-sass': ^1.5.3
-  '@rsbuild/plugin-svgr': 2.0.3
+  '@rsbuild/plugin-svgr': ^2.0.0
   '@rsbuild/plugin-type-check': ^1.3.5
   '@rslint/core': ^0.5.3
-  '@rspack/cli': 2.0.5
-  '@rspack/core': 2.0.5
-  '@rspack/plugin-react-refresh': 2.0.1
-  '@rspack/resolver': 0.2.8
+  '@rspack/cli': ^2.0.0
+  '@rspack/core': ^2.0.0
+  '@rspack/plugin-react-refresh': ^2.0.0
+  '@rspack/resolver': ^0.2.8
   '@rstest/core': 0.10.3
   '@types/body-parser': 1.19.6
   '@types/connect': 3.4.38


### PR DESCRIPTION
## Summary
This pull request updates the dependency version specifiers for Rsbuild and Rspack catalog dependencies to use compatible version ranges instead of pinned versions. This change helps avoid unnecessarily publishing new versions of Rstack when upstream dependencies are updated, making dependency management more flexible.

Dependency version range updates:

* Updated the `pnpm-workspace.yaml` catalog to use caret (`^`) ranges for all Rsbuild and Rspack dependencies, rather than exact versions.
* Updated the `pnpm-lock.yaml` file to reflect caret (`^`) ranges for Rsbuild and Rspack dependencies in both the `settings:` and `catalogs:` sections. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10-R28) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL37-R46)

Documentation:

* Added a changeset file explaining the rationale for using compatible ranges for Rsbuild and Rspack catalog dependencies.
## Related Links
#1713 
<!--- Provide links of related issues or pages -->
