### PR TITLE
fix(deps): relax rstack catalog ranges (#1714)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,47 +7,47 @@ settings:
 catalogs:
   default:
     '@rsbuild/core':
-      specifier: 2.0.6
-      version: 2.0.6
+      specifier: ^2.0.9
+      version: 2.0.11
     '@rsbuild/plugin-check-syntax':
-      specifier: 1.6.1
+      specifier: ^1.6.1
       version: 1.6.1
     '@rsbuild/plugin-less':
-      specifier: 1.6.3
-      version: 1.6.3
+      specifier: ^1.6.4
+      version: 1.6.4
     '@rsbuild/plugin-node-polyfill':
-      specifier: ^1.4.4
-      version: 1.4.4
+      specifier: ^1.4.5
+      version: 1.4.6
     '@rsbuild/plugin-react':
-      specifier: 2.0.0
-      version: 2.0.0
+      specifier: ^2.0.1
+      version: 2.0.1
     '@rsbuild/plugin-sass':
-      specifier: ^1.5.2
-      version: 1.5.2
+      specifier: ^1.5.3
+      version: 1.5.3
     '@rsbuild/plugin-svgr':
-      specifier: 2.0.2
-      version: 2.0.2
+      specifier: ^2.0.3
+      version: 2.0.3
     '@rsbuild/plugin-type-check':
-      specifier: ^1.3.4
-      version: 1.3.4
+      specifier: ^1.3.5
+      version: 1.3.6
     '@rslint/core':
       specifier: ^0.5.3
       version: 0.5.3
     '@rspack/cli':
-      specifier: 2.0.3
-      version: 2.0.3
+      specifier: ^2.0.5
+      version: 2.0.6
     '@rspack/core':
-      specifier: 2.0.3
-      version: 2.0.3
+      specifier: ^2.0.5
+      version: 2.0.6
     '@rspack/plugin-react-refresh':
-      specifier: 2.0.0
-      version: 2.0.0
+      specifier: ^2.0.1
+      version: 2.0.1
     '@rspack/resolver':
-      specifier: 0.2.8
+      specifier: ^0.2.8
       version: 0.2.8
     '@rstest/core':
-      specifier: 0.10.0
-      version: 0.10.0
+      specifier: 0.10.3
+      version: 0.10.3
     '@types/body-parser':
       specifier: 1.19.6
       version: 1.19.6
@@ -160,7 +160,7 @@ importers:
         version: 0.5.3(jiti@2.6.1)
       '@rstest/core':
         specifier: 'catalog:'
-        version: 0.10.0(core-js@3.49.0)
+        version: 0.10.3(core-js@3.49.0)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:scripts/test-helper
@@ -181,13 +181,13 @@ importers:
         version: 0.9.0
       nx:
         specifier: ^22.7.2
-        version: 22.7.2(@swc/core@1.15.11(@swc/helpers@0.5.21))
+        version: 22.7.2(@swc/core@1.15.11(@swc/helpers@0.5.23))
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.0.6(core-js@3.49.0))
+        version: 0.3.4(@rsbuild/core@2.0.11(core-js@3.49.0))
 
   e2e:
     devDependencies:
@@ -199,13 +199,13 @@ importers:
         version: 0.120.0(@types/react@19.2.14)
       '@lynx-js/rspeedy':
         specifier: ^0.14.3
-        version: 0.14.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 0.14.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.6(@swc/helpers@0.5.21))(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       '@playwright/test':
         specifier: 1.55.1
         version: 1.55.1
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 1.6.3(@rsbuild/core@1.7.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 1.6.4(@rsbuild/core@1.7.5)(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       '@rsdoctor/cli':
         specifier: workspace:*
         version: link:../packages/cli
@@ -229,7 +229,7 @@ importers:
         version: link:../packages/webpack-plugin
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.3(@swc/helpers@0.5.21)
+        version: 2.0.6(@swc/helpers@0.5.21)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.3
@@ -250,7 +250,7 @@ importers:
         version: 6.0.3
       webpack:
         specifier: ^5.105.4
-        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   e2e/cases/doctor-rspack/fixtures/loaders/esm: {}
 
@@ -268,10 +268,10 @@ importers:
     devDependencies:
       '@modern-js/app-tools':
         specifier: ^3.1.5
-        version: 3.1.5(@rspack/core@2.0.3(@swc/helpers@0.5.21))(core-js@3.49.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(rollup@4.59.0)(tsconfig-paths@4.2.0)(typescript@6.0.3)
+        version: 3.1.5(@rspack/core@2.0.6(@swc/helpers@0.5.21))(core-js@3.49.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(rollup@4.59.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@6.0.3)
       '@modern-js/runtime':
         specifier: ^3.1.5
-        version: 3.1.5(core-js@3.49.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 3.1.5(core-js@3.49.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@rsdoctor/webpack-plugin':
         specifier: workspace:*
         version: link:../../packages/webpack-plugin
@@ -295,7 +295,7 @@ importers:
         version: 2.29.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@arco-plugins/webpack-react':
         specifier: 1.4.9-beta.2
-        version: 1.4.9-beta.2(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 1.4.9-beta.2(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       '@rsdoctor/tsconfig':
         specifier: workspace:*
         version: link:../../scripts/tsconfig
@@ -313,10 +313,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       css-loader:
         specifier: 6.7.3
-        version: 6.7.3(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 6.7.3(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       less-loader:
         specifier: 11.1.0
-        version: 11.1.0(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 11.1.0(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -325,10 +325,10 @@ importers:
         version: 19.2.6(react@19.2.6)
       style-loader:
         specifier: 3.3.2
-        version: 3.3.2(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 3.3.2(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       ts-loader:
         specifier: 9.4.2
-        version: 9.4.2(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 9.4.2(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       tsx:
         specifier: ^4.19.3
         version: 4.19.3
@@ -337,7 +337,7 @@ importers:
         version: 6.0.3
       webpack:
         specifier: ^5.104.1
-        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   examples/rsbuild-minimal:
     dependencies:
@@ -356,10 +356,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.0.6(core-js@3.49.0)
+        version: 2.0.11(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.0.0(@rsbuild/core@2.0.6(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))
+        version: 2.0.1(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.23))
       '@rsdoctor/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -395,10 +395,10 @@ importers:
         version: 2.5.1
       css-loader:
         specifier: ^6.9.0
-        version: 6.11.0(@rspack/core@2.0.3(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 6.11.0(@rspack/core@2.0.6(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       less-loader:
         specifier: ^11.1.4
-        version: 11.1.4(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 11.1.4(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -411,13 +411,13 @@ importers:
         version: link:../../packages/rspack-plugin
       '@rspack/cli':
         specifier: 'catalog:'
-        version: 2.0.3(@rspack/core@2.0.3(@swc/helpers@0.5.17))
+        version: 2.0.6(@rspack/core@2.0.6(@swc/helpers@0.5.17))
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.3(@swc/helpers@0.5.17)
+        version: 2.0.6(@swc/helpers@0.5.17)
       '@rspack/plugin-react-refresh':
         specifier: 'catalog:'
-        version: 2.0.0(@rspack/core@2.0.3(@swc/helpers@0.5.17))(react-refresh@0.14.2)
+        version: 2.0.1(@rspack/core@2.0.6(@swc/helpers@0.5.17))(react-refresh@0.14.2)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
@@ -447,10 +447,10 @@ importers:
         version: 2.5.1
       css-loader:
         specifier: ^6.9.0
-        version: 6.11.0(@rspack/core@2.0.3(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 6.11.0(@rspack/core@2.0.6(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       less-loader:
         specifier: ^11.1.4
-        version: 11.1.4(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 11.1.4(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -463,13 +463,13 @@ importers:
         version: link:../../packages/rspack-plugin
       '@rspack/cli':
         specifier: 'catalog:'
-        version: 2.0.3(@rspack/core@2.0.3(@swc/helpers@0.5.17))
+        version: 2.0.6(@rspack/core@2.0.6(@swc/helpers@0.5.17))
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.3(@swc/helpers@0.5.17)
+        version: 2.0.6(@swc/helpers@0.5.17)
       '@rspack/plugin-react-refresh':
         specifier: 'catalog:'
-        version: 2.0.0(@rspack/core@2.0.3(@swc/helpers@0.5.17))(react-refresh@0.14.2)
+        version: 2.0.1(@rspack/core@2.0.6(@swc/helpers@0.5.17))(react-refresh@0.14.2)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
@@ -499,10 +499,10 @@ importers:
         version: 2.5.1
       css-loader:
         specifier: ^6.9.0
-        version: 6.11.0(@rspack/core@2.0.3(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 6.11.0(@rspack/core@2.0.6(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       less-loader:
         specifier: ^11.1.4
-        version: 11.1.4(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 11.1.4(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -515,13 +515,13 @@ importers:
         version: link:../../packages/rspack-plugin
       '@rspack/cli':
         specifier: 'catalog:'
-        version: 2.0.3(@rspack/core@2.0.3(@swc/helpers@0.5.17))
+        version: 2.0.6(@rspack/core@2.0.6(@swc/helpers@0.5.17))
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.3(@swc/helpers@0.5.17)
+        version: 2.0.6(@swc/helpers@0.5.17)
       '@rspack/plugin-react-refresh':
         specifier: 'catalog:'
-        version: 2.0.0(@rspack/core@2.0.3(@swc/helpers@0.5.17))(react-refresh@0.14.2)
+        version: 2.0.1(@rspack/core@2.0.6(@swc/helpers@0.5.17))(react-refresh@0.14.2)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
@@ -542,7 +542,7 @@ importers:
     dependencies:
       '@rspress/core':
         specifier: 2.0.11
-        version: 2.0.11(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)
+        version: 2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)
     devDependencies:
       '@rsdoctor/rspack-plugin':
         specifier: workspace:*
@@ -561,7 +561,7 @@ importers:
         version: 5.4.1
       css-loader:
         specifier: ^6.9.0
-        version: 6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.105.4)
+        version: 6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4)
       htmlparser2:
         specifier: 7.2.0
         version: 7.2.0
@@ -595,7 +595,7 @@ importers:
         version: 6.0.3
       webpack:
         specifier: ^5.105.4
-        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))(webpack-cli@5.1.4)
+        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))(webpack-cli@5.1.4)
       webpack-cli:
         specifier: 5.1.4
         version: 5.1.4(webpack@5.105.4)
@@ -607,7 +607,7 @@ importers:
         version: 0.21.5(core-js@3.49.0)(typescript@6.0.3)
       '@rstest/core':
         specifier: 'catalog:'
-        version: 0.10.0(core-js@3.49.0)
+        version: 0.10.3(core-js@3.49.0)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.3
@@ -631,7 +631,7 @@ importers:
         version: link:../utils
       '@rstest/core':
         specifier: 'catalog:'
-        version: 0.10.0(core-js@3.49.0)
+        version: 0.10.3(core-js@3.49.0)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.3
@@ -683,19 +683,19 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.0.6(core-js@3.49.0)
+        version: 2.0.11(core-js@3.49.0)
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.4(@rsbuild/core@2.0.6(core-js@3.49.0))
+        version: 1.4.6(@rsbuild/core@2.0.11(core-js@3.49.0))
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.0.0(@rsbuild/core@2.0.6(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))
+        version: 2.0.1(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.23))
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 1.5.2(@rsbuild/core@2.0.6(core-js@3.49.0))
+        version: 1.5.3(@rsbuild/core@2.0.11(core-js@3.49.0))
       '@rsbuild/plugin-type-check':
         specifier: 'catalog:'
-        version: 1.3.4(@rsbuild/core@2.0.6(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@6.0.3)
+        version: 1.3.6(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@6.0.3)
       '@rsdoctor/components':
         specifier: workspace:*
         version: link:../components
@@ -734,7 +734,7 @@ importers:
         version: 3.0.2
       source-map-loader:
         specifier: ^5.0.0
-        version: 5.0.0(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 5.0.0(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -819,16 +819,16 @@ importers:
     devDependencies:
       '@rsbuild/plugin-check-syntax':
         specifier: 'catalog:'
-        version: 1.6.1(@rsbuild/core@2.0.6(core-js@3.49.0))
+        version: 1.6.1(@rsbuild/core@2.0.11(core-js@3.49.0))
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.0.0(@rsbuild/core@2.0.6(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))
+        version: 2.0.1(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.23))
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 1.5.2(@rsbuild/core@2.0.6(core-js@3.49.0))
+        version: 1.5.3(@rsbuild/core@2.0.11(core-js@3.49.0))
       '@rsbuild/plugin-svgr':
         specifier: 'catalog:'
-        version: 2.0.2(@rsbuild/core@2.0.6(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(typescript@6.0.3)
+        version: 2.0.3(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.23))(typescript@6.0.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.3
@@ -858,7 +858,7 @@ importers:
     dependencies:
       '@rsbuild/plugin-check-syntax':
         specifier: 'catalog:'
-        version: 1.6.1(@rsbuild/core@2.0.6(core-js@3.49.0))
+        version: 1.6.1(@rsbuild/core@2.0.11(core-js@3.49.0))
       '@rsdoctor/graph':
         specifier: workspace:*
         version: link:../graph
@@ -895,7 +895,7 @@ importers:
     devDependencies:
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.3(@swc/helpers@0.5.21)
+        version: 2.0.6(@swc/helpers@0.5.23)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -916,7 +916,7 @@ importers:
         version: 2.3.0
       babel-loader:
         specifier: 10.1.1
-        version: 10.1.1(@babel/core@7.29.0)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 10.1.1(@babel/core@7.29.0)(@rspack/core@2.0.6(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       prebundle:
         specifier: 'catalog:'
         version: 1.6.4(typescript@6.0.3)
@@ -925,7 +925,7 @@ importers:
         version: 0.0.1
       ts-loader:
         specifier: ^9.5.7
-        version: 9.5.7(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+        version: 9.5.7(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -934,13 +934,13 @@ importers:
         version: 6.0.3
       webpack:
         specifier: ^5.105.4
-        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   packages/document:
     dependencies:
       '@rspress/core':
         specifier: 2.0.11
-        version: 2.0.11(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)
+        version: 2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)
       '@rstack-dev/doc-ui':
         specifier: 1.13.3
         version: 1.13.3
@@ -953,19 +953,19 @@ importers:
     devDependencies:
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 1.5.2(@rsbuild/core@2.0.6(core-js@3.49.0))
+        version: 1.5.3(@rsbuild/core@2.0.11(core-js@3.49.0))
       '@rsdoctor/types':
         specifier: workspace:*
         version: link:../types
       '@rspress/plugin-algolia':
         specifier: 2.0.11
-        version: 2.0.11(@algolia/client-search@5.49.2)(@rspress/core@2.0.11(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@types/react@19.2.14)(algoliasearch@5.49.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)
+        version: 2.0.11(@algolia/client-search@5.49.2)(@rspress/core@2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@types/react@19.2.14)(algoliasearch@5.49.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)
       '@rspress/plugin-client-redirects':
         specifier: 2.0.11
-        version: 2.0.11(@rspress/core@2.0.11(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1))
+        version: 2.0.11(@rspress/core@2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1))
       '@rspress/plugin-rss':
         specifier: 2.0.5
-        version: 2.0.5(@rspress/core@2.0.11(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1))
+        version: 2.0.5(@rspress/core@2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1))
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.3
@@ -989,13 +989,13 @@ importers:
         version: 19.0.1(react@19.2.6)
       rsbuild-plugin-google-analytics:
         specifier: ^1.0.5
-        version: 1.0.5(@rsbuild/core@2.0.6(core-js@3.49.0))
+        version: 1.0.5(@rsbuild/core@2.0.11(core-js@3.49.0))
       rsbuild-plugin-open-graph:
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.0.6(core-js@3.49.0))
+        version: 1.1.2(@rsbuild/core@2.0.11(core-js@3.49.0))
       rspress-plugin-font-open-sans:
         specifier: ^1.0.3
-        version: 1.0.3(@rspress/core@2.0.11(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1))
+        version: 1.0.3(@rspress/core@2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1))
       rspress-plugin-sitemap:
         specifier: ^1.2.1
         version: 1.2.1
@@ -1044,7 +1044,7 @@ importers:
         version: 6.0.3
       webpack:
         specifier: ^5.105.4
-        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   packages/graph/tests/fixture: {}
 
@@ -1070,7 +1070,7 @@ importers:
     devDependencies:
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.3(@swc/helpers@0.5.21)
+        version: 2.0.6(@swc/helpers@0.5.23)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.3
@@ -1173,11 +1173,11 @@ importers:
         version: 0.7.6
       webpack:
         specifier: 5.x
-        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
     devDependencies:
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.3(@swc/helpers@0.5.21)
+        version: 2.0.6(@swc/helpers@0.5.23)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.3
@@ -1305,16 +1305,16 @@ importers:
         version: 6.0.3
       webpack:
         specifier: ^5.105.4
-        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   scripts/test-helper:
     dependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.0.6(core-js@3.49.0)
+        version: 2.0.11(core-js@3.49.0)
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.3(@swc/helpers@0.5.21)
+        version: 2.0.6(@swc/helpers@0.5.23)
       '@types/lodash':
         specifier: ^4.17.24
         version: 4.17.24
@@ -1335,7 +1335,7 @@ importers:
         version: 2.0.1
       webpack:
         specifier: ^5.105.4
-        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+        version: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   scripts/tsconfig: {}
 
@@ -3320,6 +3320,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.0.11':
+    resolution: {integrity: sha512-Mpp/viUSkVdSWJkFipdZxM2nUztrBwSnMm6Q86bPzLHtHnXqQ3VFpSMlA4wWRyySNddP6s6efKiVpx0ZOCf7Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/core@2.0.6':
     resolution: {integrity: sha512-0/u7oTgPp9NsL7E7qXzYiOOPAsOJiDbOr0FmG6gizJDIpYK8nospogNrwQ00SG0had9fdhLI7XkhP160IaLnWw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3359,24 +3369,32 @@ packages:
     peerDependencies:
       '@rsbuild/core': ^1.3.0 || ^2.0.0-0
 
-  '@rsbuild/plugin-less@1.6.3':
-    resolution: {integrity: sha512-XyPn5XwetEuEKxEwcfjYUH4cLGxDssMlO4sRTTtVL1g9TUefAmqL9uO1sXDdrDzeh7eei8mZnubHUulZoO7WXw==}
+  '@rsbuild/plugin-less@1.6.4':
+    resolution: {integrity: sha512-cDlxi6Ne0K8ZK4PrTy/wSli5RyGkT8I55j/e0R7ZBvriHM7JL0MaA28ceiKAqy70Hy/eZ/btHTB35Sl1FAor1g==}
     peerDependencies:
       '@rsbuild/core': ^1.3.0 || ^2.0.0-0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-node-polyfill@1.4.4':
-    resolution: {integrity: sha512-V9Wh8FOprWBOaPvTK6ptj9A+SAkG1X1645sVf6HoIrJRNgtlrBECuadybMLFRBdihr6hiizz417d5RXy6X1hLQ==}
+  '@rsbuild/plugin-node-polyfill@1.4.6':
+    resolution: {integrity: sha512-uJHDmfinJe00h9JvZfzOeiYYpIkAOorMsX2nv9c6n+YQBFgQalJZ3O2q2CLoqtwspQl5Pa8WU1hsUvzRi1Ro3g==}
     peerDependencies:
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
+      '@rsbuild/core': ^1.0.0 || ^2.0.0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
 
   '@rsbuild/plugin-react@2.0.0':
     resolution: {integrity: sha512-/1gzt39EGUSFEqB83g46QoOwsgv172HI18i6au1b6lgIaX4sv9stuX4ijdHbHCp8PqYEq+MyQ99jIQMO6I+etg==}
+    peerDependencies:
+      '@rsbuild/core': ^2.0.0-0
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+
+  '@rsbuild/plugin-react@2.0.1':
+    resolution: {integrity: sha512-n5m3VxEm6m3Dv1VkI0WnxsildySJ6M+QjGIzkZDy5UebRCIJ1Q/hlQVyhofBL6C+AcsF9fGjlHQkeiteXJSr3Q==}
     peerDependencies:
       '@rsbuild/core': ^2.0.0-0
     peerDependenciesMeta:
@@ -3396,8 +3414,8 @@ packages:
     peerDependencies:
       '@rsbuild/core': ^1.3.0 || ^2.0.0-0
 
-  '@rsbuild/plugin-sass@1.5.2':
-    resolution: {integrity: sha512-T03UrWpLxsVLTTAe0ybXVfKneTlxTBj5Eze8keCcICv3QrdVp+y5I+3WrmqyFbQUsB2X9dSfDQSlez502ydoJQ==}
+  '@rsbuild/plugin-sass@1.5.3':
+    resolution: {integrity: sha512-NViSITZF3J3i96GfemWfTZBZ43CNZUgTaaKgfti0I7odwy36Qlo8MIAbGjOy8pBSygIYn7Xl4+Jw8qAbTysCBw==}
     peerDependencies:
       '@rsbuild/core': ^1.3.0 || ^2.0.0-0
     peerDependenciesMeta:
@@ -3420,8 +3438,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-svgr@2.0.2':
-    resolution: {integrity: sha512-RoTgyF60iKYpI+Os7/qKGn7cS5eZm8On2mqxN77Bo/l7pCLtKeiXa2p1YgLY1hohLCOJqSAysU7044nE0QfjLQ==}
+  '@rsbuild/plugin-svgr@2.0.3':
+    resolution: {integrity: sha512-k2dMtyscm6mZI/OuWPtrQ4AL2y2SphM3cYkLD9qQlFd8FufnCOP9bmgI4fisZNhyWsdN0WSmlkosGJxqltRf1A==}
     peerDependencies:
       '@rsbuild/core': ^2.0.0-0
     peerDependenciesMeta:
@@ -3436,10 +3454,10 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-type-check@1.3.4':
-    resolution: {integrity: sha512-ibOlMRVKeDfBBSd09YVzJjAUhX1KnTVbK0NK/rPBai3/DAovhUsmkxKDIsE+3HN93iGBSBiqOCIOrYFO2Z21Fw==}
+  '@rsbuild/plugin-type-check@1.3.6':
+    resolution: {integrity: sha512-KjsZTiAy98syAw8Ho8eco5js6CQp+LVcDFJe+apAguYeebbjSXfr86bKxVpVyJ0GCs+tlLNsiJNV7jO/LpHiAw==}
     peerDependencies:
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
+      '@rsbuild/core': ^1.0.0 || ^2.0.0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
@@ -3548,6 +3566,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.0.6':
+    resolution: {integrity: sha512-0giCKiWlBfcM4i2scv1j2k9HlSecO9Ybhaa5wsMUyvcFeKr9HbNHh7C2eDFlC6zaI85IUdY71TXF/g/Tcxr9MA==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@1.7.11':
     resolution: {integrity: sha512-a1+TtTE9ap6RalgFi7FGIgkJP6O4Vy6ctv+9WGJy53E4kuqHR0RygzaiVxCI/GMc/vBT9vY23hyrpWb3d1vtXA==}
     cpu: [x64]
@@ -3555,6 +3578,11 @@ packages:
 
   '@rspack/binding-darwin-x64@2.0.3':
     resolution: {integrity: sha512-K3evrbTgZNa8emEqk+AjDtbuoXZp5tPZz3pcEgETxuu3KanW8Zu+Fb+TUp1DEUcL0xOmHPPox8H2cZ3pF4Zmug==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.0.6':
+    resolution: {integrity: sha512-/mMo2IpI02aOKMlHbVbZue3TJxFqHGX+ibVTdEO+6bzRSuHs7+R9KM5U3XH2YxcWJy5Sid1X1T1pJAjsXcE3rA==}
     cpu: [x64]
     os: [darwin]
 
@@ -3566,6 +3594,12 @@ packages:
 
   '@rspack/binding-linux-arm64-gnu@2.0.3':
     resolution: {integrity: sha512-aPLDaaTtX1wqjLYAIHc2MGDQZtv1Hbjx47oaaefbWz5GbAnSA4P8jdYIeeGRyrqvQ0WqJXIWXgT0d/iXtes00A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.0.6':
+    resolution: {integrity: sha512-H6ACzeM1KBxYDEF8YAim3501Jb1aCsSG79Gjm1M4pwJ5OJPK2ydiJEa438ugXmh0962eKYMHI2yZY0sQq8txaw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -3582,6 +3616,12 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.0.6':
+    resolution: {integrity: sha512-QTFmBg0n+L397Wi8CIjbd5pe/hxpHnqCDaG1A7e2NWX8Fj9zulAoKLiKflQa1ELEhAY4Foq88aX75+Ilt2tHcw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-x64-gnu@1.7.11':
     resolution: {integrity: sha512-cuOJMfCOvb2Wgsry5enXJ3iT1FGUjdPqtGUBVupQlEG4ntSYsQ2PtF4wIDVasR3wdxC5nQbipOrDiN/u6fYsdQ==}
     cpu: [x64]
@@ -3590,6 +3630,12 @@ packages:
 
   '@rspack/binding-linux-x64-gnu@2.0.3':
     resolution: {integrity: sha512-fAhiMuV5omT53YMft+f3Y9euAFgspuyBAk9ZpeW2buL2TkuUMwP07adhhvQfKdQ5gpELfzmjQaRDGqaIT8UWiA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.0.6':
+    resolution: {integrity: sha512-rerCAz022zf0ewxI+7n3SrqLEaxCL+MXRxKjK5FLUGFa8UkIrivq+VUP/1OB6JLh2Bucebc7Y9WoWHvtk22mLA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -3606,12 +3652,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.0.6':
+    resolution: {integrity: sha512-96IgOFXQjX6Wbxd+DCYJFy2r/VMu1OoHifW4Cr3kGTYDKoQOIMLwb0ieu/ILp2dGWFMZo5S8odiByAmNICAOIA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@1.7.11':
     resolution: {integrity: sha512-OtrmnPUVJMxjNa3eDMfHyPdtlLRmmp/aIm0fQHlAOATbZvlGm12q7rhPW5BXTu1yh+1rQ1/uqvz+SzKEZXuJaQ==}
     cpu: [wasm32]
 
   '@rspack/binding-wasm32-wasi@2.0.3':
     resolution: {integrity: sha512-x2fsw7GzNZEnw444ikj4/b8kVjM0Y0TllxmizHpYZ9gmaQrOk5OXo9RQdz+l4zzoGors0l2IZP5Cc4GJNCaSoQ==}
+    cpu: [wasm32]
+
+  '@rspack/binding-wasm32-wasi@2.0.6':
+    resolution: {integrity: sha512-0aWiF+qmdb0csp1x+MaR2o1pscoquLaEbLTVdKjmoTRs6sguMemtB1ObnVTahAUL73P66WePuNpFAJ81zNdqzQ==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@1.7.11':
@@ -3621,6 +3677,11 @@ packages:
 
   '@rspack/binding-win32-arm64-msvc@2.0.3':
     resolution: {integrity: sha512-jqlxuVPdrgMuwj/HEjSkC/jmhl4fAuKyob36zJXq2uAusn2FRJ4kClGe1fLFpfxRXFVQAWwlAOwLJg8T0suuaA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.0.6':
+    resolution: {integrity: sha512-BX638A1MXsjc2E3tUskVh3X/WBIHjLKK+lo395v7MmEL9u2BA6l3F6RyW+YaJOt5aEOOv83iA7iCZsviVZ49Uw==}
     cpu: [arm64]
     os: [win32]
 
@@ -3634,6 +3695,11 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.0.6':
+    resolution: {integrity: sha512-DCK/+MlN35uvH7tp4j0hbg8wIs9MHArMIrNZXtiD8xP6DNw2wrXcGC1VaxxR5apyWpqXAfIL/KsXBiWS3ygCvg==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@1.7.11':
     resolution: {integrity: sha512-EeQXayoQk/uBkI3pdoXfQBXNIUrADq56L3s/DFyM2pJeUDrWmhfIw2UFIGkYPTMSCo8F2JcdcGM32FGJrSnU0Q==}
     cpu: [x64]
@@ -3644,14 +3710,22 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@2.0.6':
+    resolution: {integrity: sha512-TxutgzdEX9BkAU/5liKxdQmggJ23INz7EZDWtzSJO6C2SiSYzTJdyPQDIJi1ddkM5TX/drzH184gAJMVOQefng==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@1.7.11':
     resolution: {integrity: sha512-2MGdy2s2HimsDT444Bp5XnALzNRxuBNc7y0JzyuqKbHBywd4x2NeXyhWXXoxufaCFu5PBc9Qq9jyfjW2Aeh06Q==}
 
   '@rspack/binding@2.0.3':
     resolution: {integrity: sha512-4exVNhGhW5RFHjK87XeTKbkA/qAgI5NHJlT1jNqiJv0gcUXLqTOEU3w7f8+f9zUo4JMFvPc0c9veOi4M19YYTg==}
 
-  '@rspack/cli@2.0.3':
-    resolution: {integrity: sha512-h/Xbkupx82UaPr5Ye3hNORi5eXmpEGSPri7WkEOrKIcT+Y3h603kujCQziNIPX3G4UURWPiksIArp1GBTF+A9w==}
+  '@rspack/binding@2.0.6':
+    resolution: {integrity: sha512-z5EO9mPlmYNpHAlRGub0Chr6D+Klgy+tX36n7tCm7VRGRlwTmTU9wSENrYbHcCpFbegtrE0s30rDeTBeOu+JiQ==}
+
+  '@rspack/cli@2.0.6':
+    resolution: {integrity: sha512-WLyep+aWGhGnj6lMaxzb78FbzlCqfZhc9fERFIqpx8SygH4M6ZR6wDxsh9AfAJxfMJT/aQ3JIbT/eg9I0AAeyg==}
     hasBin: true
     peerDependencies:
       '@rspack/core': ^2.0.0-0
@@ -3681,11 +3755,32 @@ packages:
       '@swc/helpers':
         optional: true
 
+  '@rspack/core@2.0.6':
+    resolution: {integrity: sha512-ronRqH1T2dYdMFVOQbGvDNxYaLugQK8qhNYYtS2DbOvPKQYvdIYWDenL9k/WV+hLoknnPWMn2ME2cKJcK3Po+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
   '@rspack/lite-tapable@1.1.0':
     resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
 
   '@rspack/plugin-react-refresh@2.0.0':
     resolution: {integrity: sha512-Cf6CxBStNDJbiXMc/GmsvG1G8PRlUpa0MSfWsMTI+e8npzuTN/p8nwLs3shriBZOLciqgkSZpBtPTd10BLpj1g==}
+    peerDependencies:
+      '@rspack/core': ^2.0.0-0
+      react-refresh: '>=0.10.0 <1.0.0'
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+
+  '@rspack/plugin-react-refresh@2.0.1':
+    resolution: {integrity: sha512-rYmxHJeDhN9/neZJgEjSFqG20A2Mu1mKv8+15kgwyuIDFSd3cgP3OVxwXLz5UmZSmWAfSzayDmmU1tBT0j1Nxw==}
     peerDependencies:
       '@rspack/core': ^2.0.0-0
       react-refresh: '>=0.10.0 <1.0.0'
@@ -3779,8 +3874,8 @@ packages:
   '@rstack-dev/doc-ui@1.13.3':
     resolution: {integrity: sha512-g9T8mG1I5ch3CHnzktl/PPFwJmxgRBLUi8NC6pGDwp3JQfKzaylDNK2LcPM4kjLP60+9fv2gFDSrLHE6jFu8uQ==}
 
-  '@rstest/core@0.10.0':
-    resolution: {integrity: sha512-TfmMZ/fvGuGCJbOfVE+Fj8mNxs0opSvEaQZm4lkXMZ/Rdvx4d0yIzHSKZ31bOIAUZIiltMXHoTwu8+pwyBHZyg==}
+  '@rstest/core@0.10.3':
+    resolution: {integrity: sha512-UiJ1td7KszgAfPVroNKnQQ60S0EeyHdPZArng08ffMMCmwo/6aeLmjk4s+W/ojR5iredelM9Z0Yc01vN3kSaeA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -3996,6 +4091,9 @@ packages:
 
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@swc/plugin-loadable-components@11.9.0':
     resolution: {integrity: sha512-USHRzCUb22lIk+cMbcRD8kTGYHTrW+wCI+PViieve6SUaaXeW5/jQ6g4CD5trJgk9f+oN+3sgXTK1If+F7hLfQ==}
@@ -4739,6 +4837,10 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
@@ -6234,10 +6336,6 @@ packages:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
-    hasBin: true
-
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -6316,8 +6414,8 @@ packages:
       less: ^3.5.0 || ^4.0.0
       webpack: ^5.0.0
 
-  less-loader@12.3.2:
-    resolution: {integrity: sha512-uLV5c702ff2jBvO7qewpkLRzkh/I9QW07ur2NKkv8TVTrtX2lrKjEbEU/LLXAn7cgpCIBbkfyUm4qYXCQs5/+w==}
+  less-loader@12.3.3:
+    resolution: {integrity: sha512-F0+ErFFDj3Pt+nVrCN6VlEGEzocv9s7x/aR9v2riI+WM83UAfTYBDBjGPJnT55lBLR6JSI4fmWblt+aA2JN6/w==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
@@ -6792,6 +6890,11 @@ packages:
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7523,6 +7626,10 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -8204,6 +8311,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
@@ -8479,14 +8590,30 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sass-embedded-all-unknown@1.100.0:
+    resolution: {integrity: sha512-auFtXY/kwYILmSVjtBDwyj0axcLbYYiffOKWoaXHnI5bsYwiRbBh3EneR1rpbX2ZIZCrwX93i5pxKLTZF/662Q==}
+    cpu: ['!arm', '!arm64', '!riscv64', '!x64']
+
   sass-embedded-all-unknown@1.99.0:
     resolution: {integrity: sha512-qPIRG8Uhjo6/OKyAKixTnwMliTz+t9K6Duk0mx5z+K7n0Ts38NSJz2sjDnc7cA/8V9Lb3q09H38dZ1CLwD+ssw==}
     cpu: ['!arm', '!arm64', '!riscv64', '!x64']
+
+  sass-embedded-android-arm64@1.100.0:
+    resolution: {integrity: sha512-W+Ru9JwTnfU0UX3jSZcbqFdtKFMcYdfFwytc57h2DgnqCOIiAqI2E06mABZBZC+r3LwXCBuS5GbXAGeVgvVDkA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [android]
 
   sass-embedded-android-arm64@1.99.0:
     resolution: {integrity: sha512-fNHhdnP23yqqieCbAdym4N47AleSwjbNt6OYIYx4DdACGdtERjQB4iOX/TaKsW034MupfF7SjnAAK8w7Ptldtg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
+    os: [android]
+
+  sass-embedded-android-arm@1.100.0:
+    resolution: {integrity: sha512-70f3HgX2pFNmzpGQ86n5e6QfWn2fP4QUQGfFQK0P1XH73ZLIzLo2YqygrGKGKeeqtc5eU2Wl1/xQzhzuKnO4kw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm]
     os: [android]
 
   sass-embedded-android-arm@1.99.0:
@@ -8495,10 +8622,22 @@ packages:
     cpu: [arm]
     os: [android]
 
+  sass-embedded-android-riscv64@1.100.0:
+    resolution: {integrity: sha512-icU3o0V/uCSytSpf+tX5Lf51BvyQEbLzDUJfUi9etSauYBGHpPKkdtdZH0si4v98phq11Kl8rSV1SggksxF1Hg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [riscv64]
+    os: [android]
+
   sass-embedded-android-riscv64@1.99.0:
     resolution: {integrity: sha512-4zqDFRvgGDTL5vTHuIhRxUpXFoh0Cy7Gm5Ywk19ASd8Settmd14YdPRZPmMxfgS1GH292PofV1fq1ifiSEJWBw==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
+    os: [android]
+
+  sass-embedded-android-x64@1.100.0:
+    resolution: {integrity: sha512-mevF9VQk6gEYByy8+jusaHGmd7Usb2ytX/DsEOd0JtOGCtcf1kh575xJ6OUBDIcJ15uLnbau/0iy1eP6WVBvWA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
     os: [android]
 
   sass-embedded-android-x64@1.99.0:
@@ -8507,10 +8646,22 @@ packages:
     cpu: [x64]
     os: [android]
 
+  sass-embedded-darwin-arm64@1.100.0:
+    resolution: {integrity: sha512-1PVlYi61POo93IT/FfrG1mc1tAHxeSTyUALF2aOFmXGWjVXr3bQzEQiBGCOvQbj/ix+5hNyXFXcEMEyKvtUJJA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   sass-embedded-darwin-arm64@1.99.0:
     resolution: {integrity: sha512-u61/7U3IGLqoO6gL+AHeiAtlTPFwJK1+964U8gp45ZN0hzh1yrARf5O1mivXv8NnNgJvbG2wWJbiNZP0lG/lTg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
+    os: [darwin]
+
+  sass-embedded-darwin-x64@1.100.0:
+    resolution: {integrity: sha512-x97o3JnGyImZNCIVs9wQHJUE5QCvmVIKaH1cwrz/5dK7OT1FpeNiW+u9TUomP9hG6Ekjd8EL8NBHpxTfIhdjmg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
     os: [darwin]
 
   sass-embedded-darwin-x64@1.99.0:
@@ -8519,10 +8670,24 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  sass-embedded-linux-arm64@1.100.0:
+    resolution: {integrity: sha512-Dwjmj8Z6VRy7rAi53JAdEwIyUjpfl7PhpSc2/LpQPQx+aO5Dp7Spaipkax0ufJl1SoDUdchCsM4y/88YaluorQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: glibc
+
   sass-embedded-linux-arm64@1.99.0:
     resolution: {integrity: sha512-btNcFpItcB56L40n8hDeL7sRSMLDXQ56nB5h2deddJx1n60rpKSElJmkaDGHtpkrY+CTtDRV0FZDjHeTJddYew==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
+    os: [linux]
+    libc: glibc
+
+  sass-embedded-linux-arm@1.100.0:
+    resolution: {integrity: sha512-9Ul7O1eKrc5YlhwWjkp8tZPSe3UEwSZ1uwUZOQom1HL0pRlBA6F/IlGZYFTLwnHMIP1fc77MMNaBRfc05mKMpw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm]
     os: [linux]
     libc: glibc
 
@@ -8533,10 +8698,24 @@ packages:
     os: [linux]
     libc: glibc
 
+  sass-embedded-linux-musl-arm64@1.100.0:
+    resolution: {integrity: sha512-XpACJB2KjSLjf2e9uuvGVdOURsoNrFqgRiihhXyUHK9W0t3LIHb7z5MA/7XGPIT9bWSOO2zyw+rH/FHtDV/Yrg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: musl
+
   sass-embedded-linux-musl-arm64@1.99.0:
     resolution: {integrity: sha512-Hi2bt/IrM5P4FBKz6EcHAlniwfpoz9mnTdvSd58y+avA3SANM76upIkAdSayA8ZGwyL3gZokru1AKDPF9lJDNw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
+    os: [linux]
+    libc: musl
+
+  sass-embedded-linux-musl-arm@1.100.0:
+    resolution: {integrity: sha512-sl0JgbGloPyJg66XXx5UDSDScZ0oU85DpMQU4JU/sCUCFj1Z8zZ69SJWKTCNE4/jwnce7WI2zPCV5AG+RHOZJw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm]
     os: [linux]
     libc: musl
 
@@ -8547,10 +8726,24 @@ packages:
     os: [linux]
     libc: musl
 
+  sass-embedded-linux-musl-riscv64@1.100.0:
+    resolution: {integrity: sha512-ShvI0Kx04mwoCARwZ0UjiT97isQvzO80tAt91zmFyHLN9kelc/IrQi940farSm2xQVPCKdeVyeG0ekBsokSpYQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: musl
+
   sass-embedded-linux-musl-riscv64@1.99.0:
     resolution: {integrity: sha512-mKqGvVaJ9rHMqyZsF0kikQe4NO0f4osb67+X6nLhBiVDKvyazQHJ3zJQreNefIE36yL2sjHIclSB//MprzaQDg==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
+    os: [linux]
+    libc: musl
+
+  sass-embedded-linux-musl-x64@1.100.0:
+    resolution: {integrity: sha512-TDBCRWNuS4RDLQXvRc1gjZlWiWTWaWGp0Bwu/IKwJxov81lsvrCs3TihTyNXtW7V5aoN4Ky3r0QOkNb3mwmBnA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
     os: [linux]
     libc: musl
 
@@ -8561,10 +8754,24 @@ packages:
     os: [linux]
     libc: musl
 
+  sass-embedded-linux-riscv64@1.100.0:
+    resolution: {integrity: sha512-j4ENJGOheO+fm3j/yorLxCjBP6/XskrZx7dTLlT+lXYwN/qqCqoA/gsNLI0McS3DFM6GBwPiffzWsdWS8t6sEQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: glibc
+
   sass-embedded-linux-riscv64@1.99.0:
     resolution: {integrity: sha512-mevFPIFAVhrH90THifxLfOntFmHtcEKOcdWnep2gJ0X4DVva4AiVIRlQe/7w9JFx5+gnDRE1oaJJkzuFUuYZsA==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
+    os: [linux]
+    libc: glibc
+
+  sass-embedded-linux-x64@1.100.0:
+    resolution: {integrity: sha512-0vUSN8j0WGtCJIOPh//EmUvYGHW0QOe5iul8qyhPk50MAcw49MA0r34AhftjDdx94ILPF6vApFs0gwHPQRlpVA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
     os: [linux]
     libc: glibc
 
@@ -8575,14 +8782,30 @@ packages:
     os: [linux]
     libc: glibc
 
+  sass-embedded-unknown-all@1.100.0:
+    resolution: {integrity: sha512-c+naBgWId4MIpToXcI0DgqetjdAkwTTAxFAuOaBz7HUXLdyG1oZRrEvSsbe41nEdQOKH0vgofVFCeSQgoXOG9A==}
+    os: ['!android', '!darwin', '!linux', '!win32']
+
   sass-embedded-unknown-all@1.99.0:
     resolution: {integrity: sha512-P7MxiUtL/XzGo3PX0CaB8lNNEFLQWKikPA8pbKytx9ZCLZSDkt2NJcdAbblB/sqMs4AV3EK2NadV8rI/diq3xg==}
     os: ['!android', '!darwin', '!linux', '!win32']
+
+  sass-embedded-win32-arm64@1.100.0:
+    resolution: {integrity: sha512-iE+yxj+hUXwwbqpHkXxgAWTzeRfcWxJ7SSTQEPMk48lwq3oCrWLlz5sQuWHbuTK/i0GKQfROdP+hOmPi89yjUg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [win32]
 
   sass-embedded-win32-arm64@1.99.0:
     resolution: {integrity: sha512-8whpsW7S+uO8QApKfQuc36m3P9EISzbVZOgC79goob4qGy09u8Gz/rYvw8h1prJDSjltpHGhOzBE6LDz7WvzVw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
+    os: [win32]
+
+  sass-embedded-win32-x64@1.100.0:
+    resolution: {integrity: sha512-qI4F8MI7/KYoy9NdjJfhSspG42WPkADSNDvwEV7qWvCSFC83koJssRsKO2/PfY+niZz6BG65Ic/D+A11h959hw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
     os: [win32]
 
   sass-embedded-win32-x64@1.99.0:
@@ -8591,9 +8814,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  sass-embedded@1.100.0:
+    resolution: {integrity: sha512-Ut8wlQSk19tm7jMK6mz6cF1+e+E7tUnW2tM02zQDPnOTcVbV8qCQG8UWxZkkNlY50+hV3hqP24OOkUlMz8xBpw==}
+    engines: {node: '>=16.0.0'}
+    hasBin: true
+
   sass-embedded@1.99.0:
     resolution: {integrity: sha512-gF/juR1aX02lZHkvwxdF80SapkQeg2fetoDF6gIQkNbSw5YEUFspMkyGTjPjgZSgIHuZpy+Wz4PlebKnLXMjdg==}
     engines: {node: '>=16.0.0'}
+    hasBin: true
+
+  sass@1.100.0:
+    resolution: {integrity: sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==}
+    engines: {node: '>=20.19.0'}
     hasBin: true
 
   sass@1.99.0:
@@ -9060,6 +9293,15 @@ packages:
 
   ts-checker-rspack-plugin@1.3.0:
     resolution: {integrity: sha512-89oK/BtApjdid1j9CGjPGiYry+EZBhsnTAM481/8ipgr/y2IOgCbW1HPnan+fs5FnzlpUgf9dWGNZ4Ayw3Bd8A==}
+    peerDependencies:
+      '@rspack/core': ^1.0.0 || ^2.0.0-0
+      typescript: '>=3.8.0'
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+
+  ts-checker-rspack-plugin@1.3.1:
+    resolution: {integrity: sha512-4VBjKblnJwypq+2aWZ9V65HENAmU/2s04d717YhLjC65MKitTTnqKeHE6GGB5C4S+2BnqZ9MtJt5AvS7nldaLQ==}
     peerDependencies:
       '@rspack/core': ^1.0.0 || ^2.0.0-0
       typescript: '>=3.8.0'
@@ -9753,7 +9995,7 @@ snapshots:
       lodash: 4.17.21
       micromatch: 4.0.8
 
-  '@arco-plugins/webpack-react@1.4.9-beta.2(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))':
+  '@arco-plugins/webpack-react@1.4.9-beta.2(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
       '@arco-plugins/utils': 1.2.1
       '@babel/core': 7.26.0
@@ -9766,7 +10008,7 @@ snapshots:
       chalk: 4.1.2
       loader-utils: 2.0.4
       lodash: 4.17.21
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
     transitivePeerDependencies:
       - supports-color
 
@@ -11192,7 +11434,7 @@ snapshots:
       '@types/react': 19.2.14
       preact: '@lynx-js/internal-preact@10.29.1-20260424024911-12b794f'
 
-  '@lynx-js/rspeedy@0.14.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))':
+  '@lynx-js/rspeedy@0.14.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.6(@swc/helpers@0.5.21))(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
       '@lynx-js/cache-events-webpack-plugin': 0.0.3
       '@lynx-js/chunk-loading-webpack-plugin': 0.3.3
@@ -11200,8 +11442,8 @@ snapshots:
       '@lynx-js/webpack-dev-transport': 0.2.0
       '@lynx-js/websocket': 0.0.4
       '@rsbuild/core': 1.7.5
-      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.5)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
-      '@rsdoctor/rspack-plugin': 1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@1.7.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.5)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/rspack-plugin': 1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@1.7.5)(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -11316,12 +11558,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modern-js/app-tools@3.1.5(@rspack/core@2.0.3(@swc/helpers@0.5.21))(core-js@3.49.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(rollup@4.59.0)(tsconfig-paths@4.2.0)(typescript@6.0.3)':
+  '@modern-js/app-tools@3.1.5(@rspack/core@2.0.6(@swc/helpers@0.5.21))(core-js@3.49.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(rollup@4.59.0)(tsconfig-paths@4.2.0)(tslib@2.8.1)(typescript@6.0.3)':
     dependencies:
       '@babel/parser': 7.29.2
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@modern-js/builder': 3.1.5(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@modern-js/builder': 3.1.5(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(tslib@2.8.1)(typescript@6.0.3)
       '@modern-js/i18n-utils': 3.1.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@modern-js/plugin': 3.1.5(core-js@3.49.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@modern-js/plugin-data-loader': 3.1.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -11367,7 +11609,7 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@modern-js/builder@3.1.5(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@modern-js/builder@3.1.5(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(tslib@2.8.1)(typescript@6.0.3)':
     dependencies:
       '@modern-js/utils': 3.1.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@rsbuild/core': 2.0.0(core-js@3.49.0)
@@ -11375,12 +11617,12 @@ snapshots:
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.0(core-js@3.49.0))
       '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@2.0.0(core-js@3.49.0))
       '@rsbuild/plugin-less': 1.6.0(@rsbuild/core@2.0.0(core-js@3.49.0))
-      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.0(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))
+      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.0(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.21))
       '@rsbuild/plugin-rem': 1.0.5(@rsbuild/core@2.0.0(core-js@3.49.0))
       '@rsbuild/plugin-sass': 1.5.0(@rsbuild/core@2.0.0(core-js@3.49.0))
       '@rsbuild/plugin-source-build': 1.0.4(@rsbuild/core@2.0.0(core-js@3.49.0))
-      '@rsbuild/plugin-svgr': 2.0.0(@rsbuild/core@2.0.0(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(typescript@6.0.3)
-      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(typescript@6.0.3)
+      '@rsbuild/plugin-svgr': 2.0.0(@rsbuild/core@2.0.0(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.21))(typescript@6.0.3)
+      '@rsbuild/plugin-type-check': 1.3.3(@rsbuild/core@2.0.0(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@6.0.3)
       '@rsbuild/plugin-typed-css-modules': 1.2.1(@rsbuild/core@2.0.0(core-js@3.49.0))
       '@swc/core': 1.15.11(@swc/helpers@0.5.21)
       '@swc/helpers': 0.5.21
@@ -11398,8 +11640,8 @@ snapshots:
       postcss-media-minmax: 5.0.0(postcss@8.5.14)
       postcss-nesting: 12.1.5(postcss@8.5.14)
       postcss-page-break: 3.0.4(postcss@8.5.14)
-      rsbuild-plugin-rsc: 0.0.3(@rsbuild/core@2.0.0(core-js@3.49.0))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      rspack-manifest-plugin: 5.2.1(@rspack/core@2.0.3(@swc/helpers@0.5.21))
+      rsbuild-plugin-rsc: 0.0.3(@rsbuild/core@2.0.0(core-js@3.49.0))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      rspack-manifest-plugin: 5.2.1(@rspack/core@2.0.6(@swc/helpers@0.5.21))
       ts-deepmerge: 7.0.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -11462,14 +11704,14 @@ snapshots:
       - react
       - react-dom
 
-  '@modern-js/render@3.1.5(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@modern-js/render@3.1.5(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@modern-js/types': 3.1.5
       '@modern-js/utils': 3.1.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-server-dom-rspack: 0.0.2(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-server-dom-rspack: 0.0.2(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   '@modern-js/runtime-utils@3.1.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -11483,13 +11725,13 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@modern-js/runtime@3.1.5(core-js@3.49.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@modern-js/runtime@3.1.5(core-js@3.49.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@loadable/component': 5.16.7(react@19.2.6)
       '@loadable/server': 5.16.7(@loadable/component@5.16.7(react@19.2.6))(react@19.2.6)
       '@modern-js/plugin': 3.1.5(core-js@3.49.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@modern-js/plugin-data-loader': 3.1.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@modern-js/render': 3.1.5(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@modern-js/render': 3.1.5(react-dom@19.2.6(react@19.2.6))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@modern-js/runtime-utils': 3.1.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@modern-js/types': 3.1.5
       '@modern-js/utils': 3.1.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -11936,6 +12178,15 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
+  '@rsbuild/core@2.0.11(core-js@3.49.0)':
+    dependencies:
+      '@rspack/core': 2.0.6(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    optionalDependencies:
+      core-js: 3.49.0
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
   '@rsbuild/core@2.0.6(core-js@3.49.0)':
     dependencies:
       '@rspack/core': 2.0.3(@swc/helpers@0.5.21)
@@ -11969,7 +12220,7 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0(core-js@3.49.0)
 
-  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.0.6(core-js@3.49.0))':
+  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.0.11(core-js@3.49.0))':
     dependencies:
       acorn: 8.16.0
       browserslist-to-es-version: 1.3.0
@@ -11977,11 +12228,11 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.6
     optionalDependencies:
-      '@rsbuild/core': 2.0.6(core-js@3.49.0)
+      '@rsbuild/core': 2.0.11(core-js@3.49.0)
 
-  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.5)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))':
+  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.5)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
-      css-minimizer-webpack-plugin: 7.0.2(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+      css-minimizer-webpack-plugin: 7.0.2(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       reduce-configs: 1.1.2
     optionalDependencies:
       '@rsbuild/core': 1.7.5
@@ -11996,7 +12247,7 @@ snapshots:
 
   '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@2.0.0(core-js@3.49.0))':
     dependencies:
-      css-minimizer-webpack-plugin: 7.0.2(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+      css-minimizer-webpack-plugin: 7.0.2(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       reduce-configs: 1.1.2
     optionalDependencies:
       '@rsbuild/core': 2.0.0(core-js@3.49.0)
@@ -12015,11 +12266,11 @@ snapshots:
       deepmerge: 4.3.1
       reduce-configs: 1.1.2
 
-  '@rsbuild/plugin-less@1.6.3(@rsbuild/core@1.7.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))':
+  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@1.7.5)(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.4
-      less-loader: 12.3.2(@rspack/core@2.0.3(@swc/helpers@0.5.21))(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+      less-loader: 12.3.3(@rspack/core@2.0.6(@swc/helpers@0.5.21))(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       reduce-configs: 1.1.2
     optionalDependencies:
       '@rsbuild/core': 1.7.5
@@ -12027,7 +12278,7 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.4(@rsbuild/core@2.0.6(core-js@3.49.0))':
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.0.11(core-js@3.49.0))':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -12053,23 +12304,41 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.6(core-js@3.49.0)
+      '@rsbuild/core': 2.0.11(core-js@3.49.0)
 
-  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.0(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))':
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.0(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.21))':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.0.0(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.6(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))':
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.6(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.21))':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.0.6(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.6(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.23))':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.6(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.0.6(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.23))':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.6(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.0.11(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
@@ -12089,15 +12358,15 @@ snapshots:
       reduce-configs: 1.1.2
       sass-embedded: 1.99.0
 
-  '@rsbuild/plugin-sass@1.5.2(@rsbuild/core@2.0.6(core-js@3.49.0))':
+  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.0.11(core-js@3.49.0))':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
-      postcss: 8.5.14
+      postcss: 8.5.15
       reduce-configs: 1.1.2
-      sass-embedded: 1.99.0
+      sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.6(core-js@3.49.0)
+      '@rsbuild/core': 2.0.11(core-js@3.49.0)
 
   '@rsbuild/plugin-source-build@1.0.4(@rsbuild/core@2.0.0(core-js@3.49.0))':
     dependencies:
@@ -12107,9 +12376,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.0.0(core-js@3.49.0)
 
-  '@rsbuild/plugin-svgr@2.0.0(@rsbuild/core@2.0.0(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.0(@rsbuild/core@2.0.0(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.21))(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.0(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))
+      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.0(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.21))
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)
@@ -12122,27 +12391,27 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-svgr@2.0.2(@rsbuild/core@2.0.6(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.3(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.23))(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.6(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.23))
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.6(core-js@3.49.0)
+      '@rsbuild/core': 2.0.11(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.3.3(@rsbuild/core@2.0.0(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.3.0(@rspack/core@2.0.3(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.3.0(@rspack/core@2.0.6(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@6.0.3)
     optionalDependencies:
       '@rsbuild/core': 2.0.0(core-js@3.49.0)
     transitivePeerDependencies:
@@ -12150,14 +12419,14 @@ snapshots:
       - tslib
       - typescript
 
-  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.6(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.3.6(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.3.0(@rspack/core@2.0.3(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.3.1(@rspack/core@2.0.6(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.0.6(core-js@3.49.0)
+      '@rsbuild/core': 2.0.11(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - tslib
@@ -12169,13 +12438,13 @@ snapshots:
 
   '@rsdoctor/client@1.5.9': {}
 
-  '@rsdoctor/core@1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@1.7.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))':
+  '@rsdoctor/core@1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@1.7.5)(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@1.7.5)
-      '@rsdoctor/graph': 1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
-      '@rsdoctor/sdk': 1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
-      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
-      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+      '@rsdoctor/graph': 1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/sdk': 1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       '@rspack/resolver': 0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       browserslist-load-config: 1.0.1
       es-toolkit: 1.45.1
@@ -12193,10 +12462,10 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/graph@1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))':
+  '@rsdoctor/graph@1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
-      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
-      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       es-toolkit: 1.45.1
       path-browserify: 1.0.1
       source-map: 0.7.6
@@ -12204,15 +12473,15 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@1.7.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))':
+  '@rsdoctor/rspack-plugin@1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@1.7.5)(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
-      '@rsdoctor/core': 1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@1.7.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
-      '@rsdoctor/graph': 1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
-      '@rsdoctor/sdk': 1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
-      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
-      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+      '@rsdoctor/core': 1.5.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@1.7.5)(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/graph': 1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/sdk': 1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
     optionalDependencies:
-      '@rspack/core': 2.0.3(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.6(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -12222,12 +12491,12 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))':
+  '@rsdoctor/sdk@1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
       '@rsdoctor/client': 1.5.9
-      '@rsdoctor/graph': 1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
-      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
-      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+      '@rsdoctor/graph': 1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       launch-editor: 2.13.2
       safer-buffer: 2.1.2
       socket.io: 4.8.1
@@ -12239,20 +12508,20 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/types@1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))':
+  '@rsdoctor/types@1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
       '@types/tapable': 2.3.0
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 2.0.3(@swc/helpers@0.5.21)
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+      '@rspack/core': 2.0.6(@swc/helpers@0.5.21)
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
-  '@rsdoctor/utils@1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))':
+  '@rsdoctor/utils@1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.6(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       '@types/estree': 1.0.5
       acorn: 8.16.0
       acorn-import-attributes: 1.9.5(acorn@8.16.0)
@@ -12318,10 +12587,16 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.0.3':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.0.6':
+    optional: true
+
   '@rspack/binding-darwin-x64@1.7.11':
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.3':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.0.6':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.7.11':
@@ -12330,10 +12605,16 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@2.0.3':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.0.6':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@1.7.11':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.3':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.0.6':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.7.11':
@@ -12342,10 +12623,16 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@2.0.3':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.0.6':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@1.7.11':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.0.3':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.0.6':
     optional: true
 
   '@rspack/binding-wasm32-wasi@1.7.11':
@@ -12360,10 +12647,20 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.0.6':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@1.7.11':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@2.0.3':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.0.6':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.7.11':
@@ -12372,10 +12669,16 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@2.0.3':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.0.6':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@1.7.11':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.0.3':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.0.6':
     optional: true
 
   '@rspack/binding@1.7.11':
@@ -12404,9 +12707,22 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.3
       '@rspack/binding-win32-x64-msvc': 2.0.3
 
-  '@rspack/cli@2.0.3(@rspack/core@2.0.3(@swc/helpers@0.5.17))':
+  '@rspack/binding@2.0.6':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.0.6
+      '@rspack/binding-darwin-x64': 2.0.6
+      '@rspack/binding-linux-arm64-gnu': 2.0.6
+      '@rspack/binding-linux-arm64-musl': 2.0.6
+      '@rspack/binding-linux-x64-gnu': 2.0.6
+      '@rspack/binding-linux-x64-musl': 2.0.6
+      '@rspack/binding-wasm32-wasi': 2.0.6
+      '@rspack/binding-win32-arm64-msvc': 2.0.6
+      '@rspack/binding-win32-ia32-msvc': 2.0.6
+      '@rspack/binding-win32-x64-msvc': 2.0.6
+
+  '@rspack/cli@2.0.6(@rspack/core@2.0.6(@swc/helpers@0.5.17))':
     dependencies:
-      '@rspack/core': 2.0.3(@swc/helpers@0.5.17)
+      '@rspack/core': 2.0.6(@swc/helpers@0.5.17)
 
   '@rspack/core@1.7.11(@swc/helpers@0.5.21)':
     dependencies:
@@ -12416,11 +12732,14 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.21
 
-  '@rspack/core@2.0.3(@swc/helpers@0.5.17)':
+  '@rspack/core@1.7.11(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/binding': 2.0.3
+      '@module-federation/runtime-tools': 0.22.0
+      '@rspack/binding': 1.7.11
+      '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
-      '@swc/helpers': 0.5.17
+      '@swc/helpers': 0.5.23
+    optional: true
 
   '@rspack/core@2.0.3(@swc/helpers@0.5.21)':
     dependencies:
@@ -12428,19 +12747,43 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.21
 
+  '@rspack/core@2.0.6(@swc/helpers@0.5.17)':
+    dependencies:
+      '@rspack/binding': 2.0.6
+    optionalDependencies:
+      '@swc/helpers': 0.5.17
+
+  '@rspack/core@2.0.6(@swc/helpers@0.5.21)':
+    dependencies:
+      '@rspack/binding': 2.0.6
+    optionalDependencies:
+      '@swc/helpers': 0.5.21
+
+  '@rspack/core@2.0.6(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.0.6
+    optionalDependencies:
+      '@swc/helpers': 0.5.23
+
   '@rspack/lite-tapable@1.1.0': {}
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.3(@swc/helpers@0.5.17))(react-refresh@0.14.2)':
-    dependencies:
-      react-refresh: 0.14.2
-    optionalDependencies:
-      '@rspack/core': 2.0.3(@swc/helpers@0.5.17)
-
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.0.3(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.6(@swc/helpers@0.5.21)
+
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.6(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+    dependencies:
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rspack/core': 2.0.6(@swc/helpers@0.5.23)
+
+  '@rspack/plugin-react-refresh@2.0.1(@rspack/core@2.0.6(@swc/helpers@0.5.17))(react-refresh@0.14.2)':
+    dependencies:
+      react-refresh: 0.14.2
+    optionalDependencies:
+      '@rspack/core': 2.0.6(@swc/helpers@0.5.17)
 
   '@rspack/resolver-binding-darwin-arm64@0.2.8':
     optional: true
@@ -12493,12 +12836,12 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@rspress/core@2.0.11(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)':
+  '@rspress/core@2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.21))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
       '@rsbuild/core': 2.0.6(core-js@3.49.0)
-      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.6(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))
+      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.6(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.21))
       '@rspress/shared': 2.0.11(core-js@3.49.0)
       '@shikijs/rehype': 4.0.2
       '@types/unist': 3.0.3
@@ -12543,11 +12886,61 @@ snapshots:
       - micromark-util-types
       - supports-color
 
-  '@rspress/plugin-algolia@2.0.11(@algolia/client-search@5.49.2)(@rspress/core@2.0.11(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@types/react@19.2.14)(algoliasearch@5.49.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)':
+  '@rspress/core@2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)':
+    dependencies:
+      '@mdx-js/mdx': 3.1.1
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@rsbuild/core': 2.0.6(core-js@3.49.0)
+      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.6(core-js@3.49.0))(@rspack/core@2.0.6(@swc/helpers@0.5.23))
+      '@rspress/shared': 2.0.11(core-js@3.49.0)
+      '@shikijs/rehype': 4.0.2
+      '@types/unist': 3.0.3
+      '@unhead/react': 2.1.15(react@19.2.6)
+      body-scroll-lock: 4.0.0-beta.0
+      clsx: 2.1.1
+      copy-to-clipboard: 3.3.3
+      flexsearch: 0.8.212
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-jsx-runtime: 2.3.6
+      mdast-util-mdx: 3.0.0
+      mdast-util-mdxjs-esm: 2.0.1
+      medium-zoom: 1.1.0
+      nprogress: 0.2.0
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-lazy-with-preload: 2.2.1
+      react-reconciler: 0.33.0(react@19.2.6)
+      react-render-to-markdown: 19.0.1(react@19.2.6)
+      react-router-dom: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      rehype-external-links: 3.0.0
+      rehype-raw: 7.0.0
+      remark-cjk-friendly: 2.0.1(@types/mdast@4.0.4)(micromark-util-types@2.0.1)(micromark@4.0.1)(unified@11.0.5)
+      remark-cjk-friendly-gfm-strikethrough: 2.0.1(@types/mdast@4.0.4)(micromark-util-types@2.0.1)(micromark@4.0.1)(unified@11.0.5)
+      remark-gfm: 4.0.1
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      scroll-into-view-if-needed: 3.1.0
+      shiki: 4.0.2
+      unified: 11.0.5
+      unist-util-remove: 4.0.0
+      unist-util-visit: 5.1.0
+      unist-util-visit-children: 3.0.0
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - '@rspack/core'
+      - '@types/mdast'
+      - '@types/react'
+      - core-js
+      - micromark
+      - micromark-util-types
+      - supports-color
+
+  '@rspress/plugin-algolia@2.0.11(@algolia/client-search@5.49.2)(@rspress/core@2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@types/react@19.2.14)(algoliasearch@5.49.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)':
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@algolia/client-search@5.49.2)(@types/react@19.2.14)(algoliasearch@5.49.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)
-      '@rspress/core': 2.0.11(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)
+      '@rspress/core': 2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -12556,13 +12949,13 @@ snapshots:
       - react-dom
       - search-insights
 
-  '@rspress/plugin-client-redirects@2.0.11(@rspress/core@2.0.11(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1))':
+  '@rspress/plugin-client-redirects@2.0.11(@rspress/core@2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1))':
     dependencies:
-      '@rspress/core': 2.0.11(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)
+      '@rspress/core': 2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)
 
-  '@rspress/plugin-rss@2.0.5(@rspress/core@2.0.11(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1))':
+  '@rspress/plugin-rss@2.0.5(@rspress/core@2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1))':
     dependencies:
-      '@rspress/core': 2.0.11(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)
+      '@rspress/core': 2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)
       feed: 5.2.0
 
   '@rspress/shared@2.0.11(core-js@3.49.0)':
@@ -12576,9 +12969,9 @@ snapshots:
 
   '@rstack-dev/doc-ui@1.13.3': {}
 
-  '@rstest/core@0.10.0(core-js@3.49.0)':
+  '@rstest/core@0.10.3(core-js@3.49.0)':
     dependencies:
-      '@rsbuild/core': 2.0.6(core-js@3.49.0)
+      '@rsbuild/core': 2.0.11(core-js@3.49.0)
       '@types/chai': 5.2.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -12639,54 +13032,54 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.26.0)':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.26.0)':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.26.0)':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.26.0)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.26.0)':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.26.0)':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.26.0)':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.26.0)':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.26.0)':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.26.0
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.26.0)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.26.0)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.26.0)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.26.0)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.26.0)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.26.0)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.26.0)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.26.0)
+      '@babel/core': 7.29.0
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
 
   '@svgr/core@8.1.0(typescript@6.0.3)':
     dependencies:
-      '@babel/core': 7.26.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.26.0)
+      '@babel/core': 7.29.0
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@6.0.3)
       snake-case: 3.0.4
@@ -12701,8 +13094,8 @@ snapshots:
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@6.0.3))':
     dependencies:
-      '@babel/core': 7.26.0
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.26.0)
+      '@babel/core': 7.29.0
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
@@ -12779,6 +13172,24 @@ snapshots:
       '@swc/core-win32-x64-msvc': 1.15.11
       '@swc/helpers': 0.5.21
 
+  '@swc/core@1.15.11(@swc/helpers@0.5.23)':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.26
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.11
+      '@swc/core-darwin-x64': 1.15.11
+      '@swc/core-linux-arm-gnueabihf': 1.15.11
+      '@swc/core-linux-arm64-gnu': 1.15.11
+      '@swc/core-linux-arm64-musl': 1.15.11
+      '@swc/core-linux-x64-gnu': 1.15.11
+      '@swc/core-linux-x64-musl': 1.15.11
+      '@swc/core-win32-arm64-msvc': 1.15.11
+      '@swc/core-win32-ia32-msvc': 1.15.11
+      '@swc/core-win32-x64-msvc': 1.15.11
+      '@swc/helpers': 0.5.23
+    optional: true
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.17':
@@ -12786,6 +13197,10 @@ snapshots:
       tslib: 2.8.1
 
   '@swc/helpers@0.5.21':
+    dependencies:
+      tslib: 2.8.1
+
+  '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
 
@@ -13096,17 +13511,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))(webpack-cli@5.1.4)
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))(webpack-cli@5.1.4)
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))(webpack-cli@5.1.4)
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@xtuc/ieee754@1.2.0': {}
@@ -13424,13 +13839,13 @@ snapshots:
 
   b-validate@1.5.3: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.0)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))):
+  babel-loader@10.1.1(@babel/core@7.29.0)(@rspack/core@2.0.6(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       '@babel/core': 7.29.0
       find-up: 5.0.0
     optionalDependencies:
-      '@rspack/core': 2.0.3(@swc/helpers@0.5.21)
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+      '@rspack/core': 2.0.6(@swc/helpers@0.5.23)
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   babel-plugin-import@1.13.8:
     dependencies:
@@ -13592,7 +14007,7 @@ snapshots:
 
   browserslist-to-es-version@1.3.0:
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.2
 
   browserslist@4.28.1:
     dependencies:
@@ -13739,6 +14154,11 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+    optional: true
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
     optional: true
 
   chownr@3.0.0: {}
@@ -13923,7 +14343,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.0
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -13998,7 +14418,7 @@ snapshots:
     dependencies:
       postcss: 8.5.14
 
-  css-loader@6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.21))(webpack@5.105.4):
+  css-loader@6.11.0(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -14009,10 +14429,10 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.2
     optionalDependencies:
-      '@rspack/core': 1.7.11(@swc/helpers@0.5.21)
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))(webpack-cli@5.1.4)
+      '@rspack/core': 1.7.11(@swc/helpers@0.5.23)
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))(webpack-cli@5.1.4)
 
-  css-loader@6.11.0(@rspack/core@2.0.3(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))):
+  css-loader@6.11.0(@rspack/core@2.0.6(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -14023,10 +14443,10 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.2
     optionalDependencies:
-      '@rspack/core': 2.0.3(@swc/helpers@0.5.17)
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+      '@rspack/core': 2.0.6(@swc/helpers@0.5.17)
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
-  css-loader@6.7.3(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))):
+  css-loader@6.7.3(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -14036,9 +14456,9 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.7.2
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
-  css-minimizer-webpack-plugin@7.0.2(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))):
+  css-minimizer-webpack-plugin@7.0.2(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 7.1.2(postcss@8.5.14)
@@ -14046,7 +14466,7 @@ snapshots:
       postcss: 8.5.14
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   css-select@5.1.0:
     dependencies:
@@ -15382,10 +15802,6 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.0:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -15439,23 +15855,23 @@ snapshots:
       picocolors: 1.1.1
       shell-quote: 1.8.3
 
-  less-loader@11.1.0(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))):
+  less-loader@11.1.0(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       klona: 2.0.6
       less: 4.6.4
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
-  less-loader@11.1.4(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))):
+  less-loader@11.1.4(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       less: 4.6.4
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
-  less-loader@12.3.2(@rspack/core@2.0.3(@swc/helpers@0.5.21))(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))):
+  less-loader@12.3.3(@rspack/core@2.0.6(@swc/helpers@0.5.21))(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       less: 4.6.4
     optionalDependencies:
-      '@rspack/core': 2.0.3(@swc/helpers@0.5.21)
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+      '@rspack/core': 2.0.6(@swc/helpers@0.5.21)
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   less@4.6.4:
     dependencies:
@@ -16125,7 +16541,7 @@ snapshots:
     dependencies:
       schema-utils: 4.3.0
       tapable: 2.2.3
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))(webpack-cli@5.1.4)
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))(webpack-cli@5.1.4)
 
   mini-svg-data-uri@1.4.4: {}
 
@@ -16176,6 +16592,8 @@ snapshots:
       picocolors: 1.1.1
 
   nanoid@3.3.11: {}
+
+  nanoid@3.3.12: {}
 
   ndepe@0.1.13(rollup@4.59.0):
     dependencies:
@@ -16243,7 +16661,7 @@ snapshots:
 
   number-precision@1.6.0: {}
 
-  nx@22.7.2(@swc/core@1.15.11(@swc/helpers@0.5.21)):
+  nx@22.7.2(@swc/core@1.15.11(@swc/helpers@0.5.23)):
     dependencies:
       '@emnapi/core': 1.4.5
       '@emnapi/runtime': 1.4.5
@@ -16366,7 +16784,7 @@ snapshots:
       '@nx/nx-linux-x64-musl': 22.7.2
       '@nx/nx-win32-arm64-msvc': 22.7.2
       '@nx/nx-win32-x64-msvc': 22.7.2
-      '@swc/core': 1.15.11(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.11(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - debug
 
@@ -16994,6 +17412,12 @@ snapshots:
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -17788,9 +18212,9 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.6(react@19.2.6)
 
-  react-server-dom-rspack@0.0.2(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-server-dom-rspack@0.0.2(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@rspack/core': 2.0.3(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.6(@swc/helpers@0.5.21)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -17854,6 +18278,9 @@ snapshots:
       picomatch: 2.3.1
 
   readdirp@4.1.2:
+    optional: true
+
+  readdirp@5.0.0:
     optional: true
 
   rechoir@0.8.0:
@@ -18126,39 +18553,39 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.6(core-js@3.49.0)):
+  rsbuild-plugin-google-analytics@1.0.5(@rsbuild/core@2.0.11(core-js@3.49.0)):
     optionalDependencies:
-      '@rsbuild/core': 2.0.6(core-js@3.49.0)
+      '@rsbuild/core': 2.0.11(core-js@3.49.0)
 
-  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.6(core-js@3.49.0)):
+  rsbuild-plugin-open-graph@1.1.2(@rsbuild/core@2.0.11(core-js@3.49.0)):
     optionalDependencies:
-      '@rsbuild/core': 2.0.6(core-js@3.49.0)
+      '@rsbuild/core': 2.0.11(core-js@3.49.0)
 
-  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.6(core-js@3.49.0)):
+  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.11(core-js@3.49.0)):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.17
     optionalDependencies:
-      '@rsbuild/core': 2.0.6(core-js@3.49.0)
+      '@rsbuild/core': 2.0.11(core-js@3.49.0)
 
-  rsbuild-plugin-rsc@0.0.3(@rsbuild/core@2.0.0(core-js@3.49.0))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
+  rsbuild-plugin-rsc@0.0.3(@rsbuild/core@2.0.0(core-js@3.49.0))(react-server-dom-rspack@0.0.2(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
     dependencies:
       '@rsbuild/core': 2.0.0(core-js@3.49.0)
-      react-server-dom-rspack: 0.0.2(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-server-dom-rspack: 0.0.2(@rspack/core@2.0.6(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   rslog@1.3.2: {}
 
   rslog@2.1.1: {}
 
-  rspack-manifest-plugin@5.2.1(@rspack/core@2.0.3(@swc/helpers@0.5.21)):
+  rspack-manifest-plugin@5.2.1(@rspack/core@2.0.6(@swc/helpers@0.5.21)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
-      '@rspack/core': 2.0.3(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.6(@swc/helpers@0.5.21)
 
-  rspress-plugin-font-open-sans@1.0.3(@rspress/core@2.0.11(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)):
+  rspress-plugin-font-open-sans@1.0.3(@rspress/core@2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)):
     dependencies:
-      '@rspress/core': 2.0.11(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)
+      '@rspress/core': 2.0.11(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1)
 
   rspress-plugin-sitemap@1.2.1: {}
 
@@ -18188,51 +18615,103 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sass-embedded-all-unknown@1.100.0:
+    dependencies:
+      sass: 1.100.0
+    optional: true
+
   sass-embedded-all-unknown@1.99.0:
     dependencies:
       sass: 1.99.0
     optional: true
 
+  sass-embedded-android-arm64@1.100.0:
+    optional: true
+
   sass-embedded-android-arm64@1.99.0:
+    optional: true
+
+  sass-embedded-android-arm@1.100.0:
     optional: true
 
   sass-embedded-android-arm@1.99.0:
     optional: true
 
+  sass-embedded-android-riscv64@1.100.0:
+    optional: true
+
   sass-embedded-android-riscv64@1.99.0:
+    optional: true
+
+  sass-embedded-android-x64@1.100.0:
     optional: true
 
   sass-embedded-android-x64@1.99.0:
     optional: true
 
+  sass-embedded-darwin-arm64@1.100.0:
+    optional: true
+
   sass-embedded-darwin-arm64@1.99.0:
+    optional: true
+
+  sass-embedded-darwin-x64@1.100.0:
     optional: true
 
   sass-embedded-darwin-x64@1.99.0:
     optional: true
 
+  sass-embedded-linux-arm64@1.100.0:
+    optional: true
+
   sass-embedded-linux-arm64@1.99.0:
+    optional: true
+
+  sass-embedded-linux-arm@1.100.0:
     optional: true
 
   sass-embedded-linux-arm@1.99.0:
     optional: true
 
+  sass-embedded-linux-musl-arm64@1.100.0:
+    optional: true
+
   sass-embedded-linux-musl-arm64@1.99.0:
+    optional: true
+
+  sass-embedded-linux-musl-arm@1.100.0:
     optional: true
 
   sass-embedded-linux-musl-arm@1.99.0:
     optional: true
 
+  sass-embedded-linux-musl-riscv64@1.100.0:
+    optional: true
+
   sass-embedded-linux-musl-riscv64@1.99.0:
+    optional: true
+
+  sass-embedded-linux-musl-x64@1.100.0:
     optional: true
 
   sass-embedded-linux-musl-x64@1.99.0:
     optional: true
 
+  sass-embedded-linux-riscv64@1.100.0:
+    optional: true
+
   sass-embedded-linux-riscv64@1.99.0:
     optional: true
 
+  sass-embedded-linux-x64@1.100.0:
+    optional: true
+
   sass-embedded-linux-x64@1.99.0:
+    optional: true
+
+  sass-embedded-unknown-all@1.100.0:
+    dependencies:
+      sass: 1.100.0
     optional: true
 
   sass-embedded-unknown-all@1.99.0:
@@ -18240,11 +18719,46 @@ snapshots:
       sass: 1.99.0
     optional: true
 
+  sass-embedded-win32-arm64@1.100.0:
+    optional: true
+
   sass-embedded-win32-arm64@1.99.0:
+    optional: true
+
+  sass-embedded-win32-x64@1.100.0:
     optional: true
 
   sass-embedded-win32-x64@1.99.0:
     optional: true
+
+  sass-embedded@1.100.0:
+    dependencies:
+      '@bufbuild/protobuf': 2.6.0
+      colorjs.io: 0.5.2
+      immutable: 5.1.5
+      rxjs: 7.8.1
+      supports-color: 8.1.1
+      sync-child-process: 1.0.2
+      varint: 6.0.0
+    optionalDependencies:
+      sass-embedded-all-unknown: 1.100.0
+      sass-embedded-android-arm: 1.100.0
+      sass-embedded-android-arm64: 1.100.0
+      sass-embedded-android-riscv64: 1.100.0
+      sass-embedded-android-x64: 1.100.0
+      sass-embedded-darwin-arm64: 1.100.0
+      sass-embedded-darwin-x64: 1.100.0
+      sass-embedded-linux-arm: 1.100.0
+      sass-embedded-linux-arm64: 1.100.0
+      sass-embedded-linux-musl-arm: 1.100.0
+      sass-embedded-linux-musl-arm64: 1.100.0
+      sass-embedded-linux-musl-riscv64: 1.100.0
+      sass-embedded-linux-musl-x64: 1.100.0
+      sass-embedded-linux-riscv64: 1.100.0
+      sass-embedded-linux-x64: 1.100.0
+      sass-embedded-unknown-all: 1.100.0
+      sass-embedded-win32-arm64: 1.100.0
+      sass-embedded-win32-x64: 1.100.0
 
   sass-embedded@1.99.0:
     dependencies:
@@ -18274,6 +18788,15 @@ snapshots:
       sass-embedded-unknown-all: 1.99.0
       sass-embedded-win32-arm64: 1.99.0
       sass-embedded-win32-x64: 1.99.0
+
+  sass@1.100.0:
+    dependencies:
+      chokidar: 5.0.0
+      immutable: 5.1.5
+      source-map-js: 1.2.1
+    optionalDependencies:
+      '@parcel/watcher': 2.5.1
+    optional: true
 
   sass@1.99.0:
     dependencies:
@@ -18518,11 +19041,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))):
+  source-map-loader@5.0.0(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   source-map-support@0.5.21:
     dependencies:
@@ -18611,9 +19134,9 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
-  style-loader@3.3.2(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))):
+  style-loader@3.3.2(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   style-to-js@1.1.16:
     dependencies:
@@ -18707,25 +19230,25 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.4.0(@swc/core@1.15.11(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))):
+  terser-webpack-plugin@5.4.0(@swc/core@1.15.11(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.0
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
     optionalDependencies:
-      '@swc/core': 1.15.11(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.11(@swc/helpers@0.5.23)
 
-  terser-webpack-plugin@5.4.0(@swc/core@1.15.11(@swc/helpers@0.5.21))(webpack@5.105.4):
+  terser-webpack-plugin@5.4.0(@swc/core@1.15.11(@swc/helpers@0.5.23))(webpack@5.105.4):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.0
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))(webpack-cli@5.1.4)
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))(webpack-cli@5.1.4)
     optionalDependencies:
-      '@swc/core': 1.15.11(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.11(@swc/helpers@0.5.23)
 
   terser@5.46.0:
     dependencies:
@@ -18783,7 +19306,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.3.0(@rspack/core@2.0.3(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.3.0(@rspack/core@2.0.6(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chokidar: 3.6.0
@@ -18791,20 +19314,32 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.0.3(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.6(@swc/helpers@0.5.21)
+    transitivePeerDependencies:
+      - tslib
+
+  ts-checker-rspack-plugin@1.3.1(@rspack/core@2.0.6(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@6.0.3):
+    dependencies:
+      '@rspack/lite-tapable': 1.1.0
+      chokidar: 3.6.0
+      memfs: 4.57.2(tslib@2.8.1)
+      picocolors: 1.1.1
+      typescript: 6.0.3
+    optionalDependencies:
+      '@rspack/core': 2.0.6(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - tslib
 
   ts-deepmerge@7.0.3: {}
 
-  ts-loader@9.4.2(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))):
+  ts-loader@9.4.2(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.12.0
       micromatch: 4.0.8
       semver: 7.7.2
       typescript: 6.0.3
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   ts-loader@9.4.2(typescript@6.0.3)(webpack@5.105.4):
     dependencies:
@@ -18813,9 +19348,9 @@ snapshots:
       micromatch: 4.0.8
       semver: 7.7.2
       typescript: 6.0.3
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))(webpack-cli@5.1.4)
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))(webpack-cli@5.1.4)
 
-  ts-loader@9.5.7(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))):
+  ts-loader@9.5.7(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.20.0
@@ -18823,7 +19358,7 @@ snapshots:
       semver: 7.7.4
       source-map: 0.7.6
       typescript: 6.0.3
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -19105,7 +19640,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))(webpack-cli@5.1.4)
+      webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
   webpack-merge@5.10.0:
@@ -19116,7 +19651,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)):
+  webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -19140,7 +19675,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.4.0(@swc/core@1.15.11(@swc/helpers@0.5.21))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21)))
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.11(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:
@@ -19148,7 +19683,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.21))(webpack-cli@5.1.4):
+  webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -19172,7 +19707,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.4.0(@swc/core@1.15.11(@swc/helpers@0.5.21))(webpack@5.105.4)
+      terser-webpack-plugin: 5.4.0(@swc/core@1.15.11(@swc/helpers@0.5.23))(webpack@5.105.4)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,20 +13,20 @@ allowBuilds:
   nx: false
 
 catalog:
-  '@rsbuild/core': 2.0.6
-  '@rsbuild/plugin-check-syntax': 1.6.1
-  '@rsbuild/plugin-less': 1.6.3
-  '@rsbuild/plugin-node-polyfill': ^1.4.4
-  '@rsbuild/plugin-react': 2.0.0
-  '@rsbuild/plugin-sass': ^1.5.2
-  '@rsbuild/plugin-svgr': 2.0.2
-  '@rsbuild/plugin-type-check': ^1.3.4
+  '@rsbuild/core': ^2.0.9
+  '@rsbuild/plugin-check-syntax': ^1.6.1
+  '@rsbuild/plugin-less': ^1.6.4
+  '@rsbuild/plugin-node-polyfill': ^1.4.5
+  '@rsbuild/plugin-react': ^2.0.1
+  '@rsbuild/plugin-sass': ^1.5.3
+  '@rsbuild/plugin-svgr': ^2.0.3
+  '@rsbuild/plugin-type-check': ^1.3.5
   '@rslint/core': ^0.5.3
-  '@rspack/cli': 2.0.3
-  '@rspack/core': 2.0.3
-  '@rspack/plugin-react-refresh': 2.0.0
-  '@rspack/resolver': 0.2.8
-  '@rstest/core': 0.10.0
+  '@rspack/cli': ^2.0.5
+  '@rspack/core': ^2.0.5
+  '@rspack/plugin-react-refresh': ^2.0.1
+  '@rspack/resolver': ^0.2.8
+  '@rstest/core': 0.10.3
   '@types/body-parser': 1.19.6
   '@types/connect': 3.4.38
   '@types/estree': 1.0.5


### PR DESCRIPTION
## Summary
This pull request updates several dependencies in the `catalog` section of the `pnpm-workspace.yaml` file to newer versions, switching many from fixed versions to caret (`^`) ranges to allow for minor and patch updates. This helps keep the project up-to-date with the latest features and fixes from these packages.

**Dependency updates:**

* Updated `@rsbuild` and `@rspack` related packages to newer versions and changed their versioning to use caret (`^`) ranges, enabling automatic minor and patch upgrades.
* Bumped `@rstest/core` from `0.10.0` to `0.10.3`.
## Related Links
#1713 
<!--- Provide links of related issues or pages -->
