### PR TITLE
fix(agent-cli): publish declaration entry

### DIFF
--- a/packages/agent-cli/rslib.config.ts
+++ b/packages/agent-cli/rslib.config.ts
@@ -15,8 +15,13 @@ export default defineConfig({
         },
       },
       bundle: true,
-      dts: false,
+      dts: true,
       format: 'esm',
+      redirect: {
+        dts: {
+          extension: true,
+        },
+      },
       syntax: 'es2021',
     },
   ],

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -1,8 +1,11 @@
 import { cac } from 'cac';
+import { createRequire } from 'node:module';
 
-import packageJson from '../package.json';
 import { createRsdoctorCliToolExecutor } from './executor';
 import { describeSubcommands, getToolCatalog, runAiCli } from './commands';
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../package.json') as { version: string };
 
 function parseStringOption(value: unknown, fallback: string) {
   return typeof value === 'string' ? value : fallback;

--- a/packages/agent-cli/src/commands/index.ts
+++ b/packages/agent-cli/src/commands/index.ts
@@ -12,7 +12,7 @@ function parseAiArgs(argv: string[]) {
     .parse(['node', 'rsdoctor-agent', ...argv], { run: false });
 
   return {
-    args: parsed.args,
+    args: [...parsed.args],
     dataFile:
       typeof parsed.options.dataFile === 'string'
         ? parsed.options.dataFile

--- a/packages/agent-cli/tsconfig.json
+++ b/packages/agent-cli/tsconfig.json
@@ -3,11 +3,12 @@
   "compilerOptions": {
     "experimentalDecorators": true,
     "outDir": "./dist",
+    "types": ["node"],
     "paths": {
       "@/*": ["./src/*"]
     },
-    "rootDir": "."
+    "rootDir": "src"
   },
-  "include": ["src", "tests"],
+  "include": ["src"],
   "exclude": ["**/node_modules"]
 }


### PR DESCRIPTION
## Summary
- enable declaration generation for @rsdoctor/agent-cli so the advertised types entry is published
- keep generated declaration imports NodeNext-compatible with .js extensions
- make the declaration project source-only and use a runtime package.json load for CLI version metadata

## Reproduction
Published @rsdoctor/agent-cli@0.1.0 advertises `types: ./dist/index.d.ts`, but the npm tarball only contains `dist/index.js`. A strict TypeScript consumer importing the module value fails with TS7016 because `dist/index.d.ts` is missing.

## Validation
- `corepack pnpm@10.33.4 --filter @rsdoctor/agent-cli build`
- `corepack pnpm@10.33.4 --filter @rsdoctor/agent-cli test` (31 passed)
- `corepack pnpm@10.33.4 --filter @rsdoctor/agent-cli pack --pack-destination /private/tmp/rsdoctor-agent-repro/patched`
- clean consumer with `moduleResolution: NodeNext`, `skipLibCheck: false`: `npx tsc --noEmit` passed against the packed tarball
- packed tarball runtime import passed
- packed tarball `rsdoctor-agent --help` passed
- `git diff --check`