### PR TITLE
fix(docs): correct Rspress cache env variable

### DIFF
--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -2,8 +2,8 @@
   "name": "@rsdoctor/docs",
   "version": "1.5.11",
   "scripts": {
-    "dev": "cross-env RSPRESS_PERSIST_CACHE=false rspress dev",
-    "build": "cross-env RSPRESS_PERSIST_CACHE=false rspress build && sh build.sh",
+    "dev": "cross-env RSPRESS_PERSISTENT_CACHE=false rspress dev",
+    "build": "cross-env RSPRESS_PERSISTENT_CACHE=false rspress build && sh build.sh",
     "preview": "rspress preview"
   },
   "repository": {


### PR DESCRIPTION
## Summary

- Fix the docs package scripts to use `RSPRESS_PERSISTENT_CACHE=false`, which is the environment variable read by Rspress v2.
- Keep Rspress persistent cache disabled for docs dev and build commands to avoid reusing stale SSR bundles in CI.

## Related Links

None
