### PR TITLE
fix: depLoc is null problem

### DIFF
--- a/packages/graph/src/transform/webpack/compatible.ts
+++ b/packages/graph/src/transform/webpack/compatible.ts
@@ -60,7 +60,7 @@ export function getDependencyPosition(
 ): SDK.StatementInstance | undefined {
   const { loc: depLoc } = dep;
 
-  if (depLoc === undefined || !('start' in depLoc)) {
+  if (!depLoc || !('start' in depLoc)) {
     return;
   }
 

--- a/packages/graph/tests/webpack-compatible.test.ts
+++ b/packages/graph/tests/webpack-compatible.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from '@rstest/core';
+import { getDependencyPosition } from '../src/transform/webpack/compatible';
+
+describe('Webpack/compatible/getDependencyPosition', () => {
+  it('returns undefined when dependency loc is null', () => {
+    let result: ReturnType<typeof getDependencyPosition>;
+
+    expect(() => {
+      result = getDependencyPosition({ loc: null } as any, {} as any);
+    }).not.toThrow();
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
This pull request addresses a minor bug in the `getDependencyPosition` function and adds a corresponding test to ensure correct behavior when the dependency location is `null`.

Bug fix and test coverage:

* Improved the null check in the `getDependencyPosition` function in `compatible.ts` to handle cases where the dependency location (`loc`) is `null`, preventing potential runtime errors.
* Added a test in `webpack-compatible.test.ts` to verify that `getDependencyPosition` returns `undefined` and does not throw an error when the dependency location is `null`.
## Related Links

<!--- Provide links of related issues or pages -->
