### PR TITLE
fix: sync treemap root and sidebar size modes

### DIFF
--- a/packages/components/src/components/Charts/TreeMap.tsx
+++ b/packages/components/src/components/Charts/TreeMap.tsx
@@ -179,8 +179,6 @@ export const TreeMap: React.FC<TreeMapProps> = memo(
         else if (sizeType === 'gzip') val = node.gzipSize || 0;
         else if (sizeType === 'value') val = node.value || 0;
 
-        if (!val && node.value) val = node.value;
-
         // Include chunk path in nodeId for non-root nodes to ensure uniqueness across chunks
         const nodeIdString =
           level === 0
@@ -917,7 +915,7 @@ const AssetTreemapWithFilterInner: React.FC<{
                       <span title={name}>{name}</span>
                     </Checkbox>
                     <span className={Styles['size-tag']}>
-                      {formatSize(getChunkSize(name, 'value'))}
+                      {formatSize(getChunkSize(name, sizeType))}
                     </span>
                   </div>
                 ))}

--- a/packages/components/src/pages/BundleSize/components/index.tsx
+++ b/packages/components/src/pages/BundleSize/components/index.tsx
@@ -236,12 +236,22 @@ export const WebpackModulesOverallBase: React.FC<
 
                           const computedTreeData: TreeNode[] = data
                             .filter((item) => isTargetFileType(item.asset.path))
-                            .map((item) => ({
-                              name: item.asset.path,
-                              value: item.asset.size,
-                              children: flattenTreemapData(item.modules)
-                                .children,
-                            }));
+                            .map((item) => {
+                              const moduleTree = flattenTreemapData(
+                                item.modules,
+                              );
+                              const hasModules = item.modules.length > 0;
+                              return {
+                                name: item.asset.path,
+                                sourceSize: hasModules
+                                  ? (moduleTree.sourceSize ?? 0)
+                                  : item.asset.size,
+                                bundledSize: item.asset.size,
+                                gzipSize: item.asset.gzipSize ?? 0,
+                                children: moduleTree.children,
+                              };
+                            });
+
                           return (
                             <AssetTreemapWithFilter
                               treeData={computedTreeData}


### PR DESCRIPTION
## Summary

Fix Treemap size modes in the Bundle Size page so that the Stat / Parsed / Gzipped switch is applied consistently across the whole chart.

Previously the size switch only affected inner module nodes. Top-level asset nodes were created with just a value field, so when switching to Parsed or Gzipped they had no matching size and silently fell back to the raw value. As a result, the outer asset blocks never changed proportion when toggling size modes — only the modules inside them did. The sidebar chunk list had the same problem: it was hardcoded to read value and ignored the active size mode.

> In fact, `TreeMap.tsx` was always designed around three size metrics. The leaf module act correctly, but the top-level asset nodes were constructe with only a single value field (`asset.size`). When the renderer tried to read bundledSize or gzipSize for an asset node, it got undefined, but the issue went unnoticed because of a fallback in the renderer...

## Changes

- Build top-level asset nodes with explicit sourceSize / bundledSize / gzipSize instead of a single value, so each size mode has real data to render:
  - Stat uses the module tree's aggregated source size, falling back to asset.size when the asset has no modules (e.g. HTML). This mirrors webpack-bundle-analyzer's `asset.tree.size || asset.size`(https://github.com/webpack/webpack-bundle-analyzer/blob/5ec0e7cadeccdd1ccaa8f6fb5f6a3a56bdf73d85/src/analyzer.js#L418)
  - Parsed uses `asset.size`
  - Gzipped uses `asset.gzipSize`, defaulting to 0 when gzip data is unavailable.
- Make the sidebar chunk list display sizes according to the active sizeType instead of always showing value.
- Remove the `if (!val && node.value) val = node.value` fallback in TreeMap — it masked missing per-mode data by silently reverting to the raw value

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/7861#issuecomment-4705998012