### PR TITLE
fix(sdk): restrict report server exposure

### DIFF
--- a/packages/cli/src/commands/bundle-diff.ts
+++ b/packages/cli/src/commands/bundle-diff.ts
@@ -11,9 +11,9 @@ import {
 import { Commands } from '../constants';
 import {
   Client,
+  Constants,
   Manifest as ManifestType,
   SDK,
-  Constants,
 } from '@rsdoctor/types';
 import { Manifest, Algorithm, Graph } from '@rsdoctor/utils/common';
 import { RsdoctorSDK } from '@rsdoctor/sdk';
@@ -135,7 +135,9 @@ example: ${bin} ${Commands.BundleDiff} --baseline="x.json" --current="x.json"
 
     if (json && html) {
       spinner.fail(
-        red('Options "--json" and "--html" cannot be used together. Please choose one.'),
+        red(
+          'Options "--json" and "--html" cannot be used together. Please choose one.',
+        ),
       );
       return null;
     } else if (json) {
@@ -201,10 +203,8 @@ example: ${bin} ${Commands.BundleDiff} --baseline="x.json" --current="x.json"
 
       spinner.text = `server bootstrap success`;
 
-      const localBaselineManifestUrl =
-        baselineSdk.server.origin + SDK.ServerAPI.API.BundleDiffManifest;
-      const localCurrentManifestUrl =
-        currentSdk.server.origin + SDK.ServerAPI.API.BundleDiffManifest;
+      const localBaselineManifestUrl = `${baselineSdk.server.origin}${SDK.ServerAPI.API.BundleDiffManifest}`;
+      const localCurrentManifestUrl = `${currentSdk.server.origin}${SDK.ServerAPI.API.BundleDiffManifest}`;
 
       baselineSdk.server.getClientUrl(
         Client.RsdoctorClientRoutes.BundleDiff,

--- a/packages/components/src/components/Opener/ide.tsx
+++ b/packages/components/src/components/Opener/ide.tsx
@@ -26,9 +26,11 @@ async function openInEditor(
     const base =
       typeof window !== 'undefined' && window.location?.origin
         ? window.location.origin
-        : '';
-    const url = `${base}${OPEN_IN_EDITOR_PATH}?file=${encodeURIComponent(fileSpec)}&editor=${editor}`;
-    const res = await fetch(url, { method: 'GET' });
+        : 'http://127.0.0.1';
+    const url = new URL(OPEN_IN_EDITOR_PATH, base);
+    url.searchParams.set('file', fileSpec);
+    url.searchParams.set('editor', editor);
+    const res = await fetch(url.toString(), { method: 'GET' });
     if (!res.ok) {
       urlSchemeFallback();
     }

--- a/packages/components/src/utils/data/local.test.ts
+++ b/packages/components/src/utils/data/local.test.ts
@@ -75,7 +75,7 @@ describe('LocalServerDataLoader', () => {
     globalThis.fetch = fetchMock as typeof fetch;
     const loader = new LocalServerDataLoader({
       data: {},
-      __SOCKET__PORT__: '3083',
+      __SOCKET__URL__: 'ws://127.0.0.1:3083',
     } as any);
 
     const task = loader.loadAPI(SDK.ServerAPI.API.GetAllModuleGraph, {} as any);
@@ -93,6 +93,7 @@ describe('LocalServerDataLoader', () => {
     );
 
     await expect(task).resolves.toStrictEqual([{ id: 1 }]);
+    expect(socket.url).toBe('ws://127.0.0.1:3083');
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/components/src/utils/data/local.ts
+++ b/packages/components/src/utils/data/local.ts
@@ -20,6 +20,10 @@ type DataUpdateSubscription = {
 export class LocalServerDataLoader extends BaseDataLoader {
   protected events: Map<string, DataUpdateSubscription> = new Map();
 
+  protected get socketTarget() {
+    return this.get('__SOCKET__URL__') || this.get('__SOCKET__PORT__') || '';
+  }
+
   public isLocal() {
     return true;
   }
@@ -69,14 +73,14 @@ export class LocalServerDataLoader extends BaseDataLoader {
     const [api, body] = args;
     // request limitation key
     const key = body ? `${api}_${JSON.stringify(body)}` : `${api}`;
-    const socketPort = this.get('__SOCKET__PORT__') ?? '';
+    const socketTarget = this.socketTarget;
 
     return this.limit(key, async () => {
       try {
         return (await requestServerAPI(
           api,
           body as SDK.ServerAPI.InferRequestBodyType<T>,
-          socketPort,
+          socketTarget,
         )) as R;
       } catch (err) {
         this.log(`loadAPI error: `, key);
@@ -120,8 +124,7 @@ export class LocalServerDataLoader extends BaseDataLoader {
     }
 
     subscription.listeners.add(fn);
-    const socketPort = this.get('__SOCKET__PORT__') ?? '';
-    subscribeServerAPI(api, normalizedBody, fn, socketPort);
+    subscribeServerAPI(api, normalizedBody, fn, this.socketTarget);
   }
 
   public removeOnDataUpdate<
@@ -132,8 +135,7 @@ export class LocalServerDataLoader extends BaseDataLoader {
     fn: (response: SDK.ServerAPI.SocketResponseType<T>) => void,
   ) {
     const key = `${api}::${JSON.stringify(body ?? null)}`;
-    const socketPort = this.get('__SOCKET__PORT__') ?? '';
-    unsubscribeServerAPI(api, body, fn, socketPort);
+    unsubscribeServerAPI(api, body, fn, this.socketTarget);
     this.events.get(key)?.listeners.delete(fn);
   }
 }

--- a/packages/components/src/utils/request.ts
+++ b/packages/components/src/utils/request.ts
@@ -25,7 +25,10 @@ function resolveRequestUrl(url: string): string {
 }
 
 async function requestText(url: string, timeout: number) {
-  const res = await Fetch.fetchWithTimeout(resolveRequestUrl(url), { timeout });
+  const requestUrl = resolveRequestUrl(url);
+  const res = await Fetch.fetchWithTimeout(requestUrl, {
+    timeout,
+  });
   return res.text();
 }
 
@@ -152,12 +155,13 @@ export async function postServerAPI<
     SDK.ServerAPI.InferRequestBodyType<T>,
   R extends SDK.ServerAPI.InferResponseType<T> =
     SDK.ServerAPI.InferResponseType<T>,
->(...args: B extends void ? [api: T] : [api: T, body: B]): Promise<R> {
-  const [api, body] = args;
+>(api: T, body?: B | null): Promise<R> {
   const timeout = process.env.NODE_ENV === 'development' ? 10000 : 60000;
   const requestInit: Fetch.FetchOptions = {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+    },
     timeout,
   };
 

--- a/packages/components/src/utils/request.ts
+++ b/packages/components/src/utils/request.ts
@@ -155,7 +155,8 @@ export async function postServerAPI<
     SDK.ServerAPI.InferRequestBodyType<T>,
   R extends SDK.ServerAPI.InferResponseType<T> =
     SDK.ServerAPI.InferResponseType<T>,
->(api: T, body?: B | null): Promise<R> {
+>(...args: B extends void ? [api: T] : [api: T, body: B]): Promise<R> {
+  const [api, body] = args;
   const timeout = process.env.NODE_ENV === 'development' ? 10000 : 60000;
   const requestInit: Fetch.FetchOptions = {
     method: 'POST',

--- a/packages/components/src/utils/socket.ts
+++ b/packages/components/src/utils/socket.ts
@@ -64,6 +64,10 @@ function getDefaultSocketUrl() {
 }
 
 function getSocketUrl(socketPort?: string) {
+  if (socketPort?.startsWith('ws://') || socketPort?.startsWith('wss://')) {
+    return socketPort;
+  }
+
   if (typeof location === 'undefined') {
     return socketPort ? `ws://localhost:${socketPort}` : '';
   }

--- a/packages/sdk/src/sdk/server/apis/base.ts
+++ b/packages/sdk/src/sdk/server/apis/base.ts
@@ -1,7 +1,6 @@
 import { Data } from '@rsdoctor/utils/common';
 import { Manifest, SDK } from '@rsdoctor/types';
-
-const FORBIDDEN_DATA_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+import { loadStoreDataByKey } from '../data';
 
 export class BaseAPI implements Manifest.ManifestDataLoader {
   [key: string | symbol]: any;
@@ -27,33 +26,8 @@ export class BaseAPI implements Manifest.ManifestDataLoader {
 
   public async loadData(key: string): Promise<void>;
 
-  public async loadData(key: Manifest.RsdoctorManifestObjectKeys) {
+  public async loadData(key: string) {
     const data = this.ctx.sdk.getStoreData();
-
-    const sep = '.';
-    const keys = key.split(sep);
-    if (
-      keys.some((key) => FORBIDDEN_DATA_KEYS.has(key)) ||
-      !Object.prototype.hasOwnProperty.call(data, keys[0])
-    ) {
-      throw new Error(`Invalid data key: ${key}`);
-    }
-
-    let res = data[key];
-
-    if (key.includes(sep)) {
-      res = keys.reduce((target, key) => {
-        if (
-          target === null ||
-          typeof target !== 'object' ||
-          !Object.prototype.hasOwnProperty.call(target, key)
-        ) {
-          throw new Error(`Invalid data key: ${keys.join(sep)}`);
-        }
-        return target[key];
-      }, data);
-    }
-
-    return res;
+    return loadStoreDataByKey(data, key);
   }
 }

--- a/packages/sdk/src/sdk/server/apis/base.ts
+++ b/packages/sdk/src/sdk/server/apis/base.ts
@@ -1,6 +1,8 @@
 import { Data } from '@rsdoctor/utils/common';
 import { Manifest, SDK } from '@rsdoctor/types';
 
+const FORBIDDEN_DATA_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 export class BaseAPI implements Manifest.ManifestDataLoader {
   [key: string | symbol]: any;
   public readonly ctx!: SDK.ServerAPI.APIContext;
@@ -29,11 +31,27 @@ export class BaseAPI implements Manifest.ManifestDataLoader {
     const data = this.ctx.sdk.getStoreData();
 
     const sep = '.';
+    const keys = key.split(sep);
+    if (
+      keys.some((key) => FORBIDDEN_DATA_KEYS.has(key)) ||
+      !Object.prototype.hasOwnProperty.call(data, keys[0])
+    ) {
+      throw new Error(`Invalid data key: ${key}`);
+    }
 
     let res = data[key];
 
     if (key.includes(sep)) {
-      res = key.split(sep).reduce((t, k) => t[k], data);
+      res = keys.reduce((target, key) => {
+        if (
+          target === null ||
+          typeof target !== 'object' ||
+          !Object.prototype.hasOwnProperty.call(target, key)
+        ) {
+          throw new Error(`Invalid data key: ${keys.join(sep)}`);
+        }
+        return target[key];
+      }, data);
     }
 
     return res;

--- a/packages/sdk/src/sdk/server/data.ts
+++ b/packages/sdk/src/sdk/server/data.ts
@@ -1,0 +1,46 @@
+import { Manifest } from '@rsdoctor/types';
+
+const FORBIDDEN_DATA_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export function loadStoreDataByKey<
+  T extends Manifest.RsdoctorManifestMappingKeys,
+>(
+  data: Manifest.RsdoctorManifestData,
+  key: T,
+): Manifest.InferManifestDataValue<T>;
+
+export function loadStoreDataByKey(
+  data: Manifest.RsdoctorManifestData,
+  key: string,
+): unknown;
+
+export function loadStoreDataByKey(
+  data: Manifest.RsdoctorManifestData,
+  key: string,
+) {
+  const sep = '.';
+  const keys = key.split(sep);
+  if (
+    keys.some((part) => FORBIDDEN_DATA_KEYS.has(part)) ||
+    !Object.prototype.hasOwnProperty.call(data, keys[0])
+  ) {
+    throw new Error(`Invalid data key: ${key}`);
+  }
+
+  let res: unknown = data[key as keyof Manifest.RsdoctorManifestData];
+
+  if (key.includes(sep)) {
+    res = keys.reduce<unknown>((target, part) => {
+      if (
+        target === null ||
+        typeof target !== 'object' ||
+        !Object.prototype.hasOwnProperty.call(target, part)
+      ) {
+        throw new Error(`Invalid data key: ${keys.join(sep)}`);
+      }
+      return (target as Record<string, unknown>)[part];
+    }, data);
+  }
+
+  return res;
+}

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -20,7 +20,7 @@ export * from './utils';
 
 /** Path for launch-editor: open file in editor from the UI (see https://github.com/yyx990803/launch-editor) */
 const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
-const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
 const LISTEN_RETRY_LIMIT = 10;
 
 export type ISocketType = { port: number; socketUrl: string };

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -4,7 +4,6 @@ import serve from 'sirv';
 import { Bundle, GlobalConfig } from '@rsdoctor/utils/common';
 import assert from 'assert';
 import bodyParser from 'body-parser';
-import cors from 'cors';
 import { PassThrough } from 'stream';
 import { Socket } from './socket';
 import { Router } from './router';
@@ -12,16 +11,16 @@ import * as APIs from './apis';
 import { chalk, logger } from '@rsdoctor/utils/logger';
 import { openBrowser } from '@/sdk/utils/openBrowser';
 import path from 'path';
-import { getLocalIpAddress } from './utils';
 import { Lodash } from '@rsdoctor/utils/common';
 import { createRequire } from 'module';
-import { ServerResponse } from 'http';
+import { IncomingMessage, ServerResponse } from 'http';
 
 const require = createRequire(import.meta.url);
 export * from './utils';
 
 /** Path for launch-editor: open file in editor from the UI (see https://github.com/yyx990803/launch-editor) */
 const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
 
 export type ISocketType = { port: number; socketUrl: string };
 
@@ -60,8 +59,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
   }
 
   public get host(): string {
-    const host = getLocalIpAddress();
-    return host;
+    return Server.defaultHost;
   }
 
   public get origin(): string {
@@ -71,7 +69,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
   public get socketUrl(): ISocketType {
     return {
       port: this.port,
-      socketUrl: `ws://localhost:${this.port}`,
+      socketUrl: `ws://${this.host}:${this.port}`,
     };
   }
 
@@ -79,15 +77,54 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     return this._innerClientPath;
   }
 
+  private isLocalOrigin(origin: string) {
+    try {
+      const url = new URL(origin);
+      return (
+        (url.protocol === 'http:' || url.protocol === 'https:') &&
+        LOCAL_HOSTNAMES.has(url.hostname) &&
+        url.port === String(this.port)
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  private setCorsHeaders(req: IncomingMessage, res: ServerResponse) {
+    const origin = req.headers.origin;
+    if (typeof origin !== 'string' || !this.isLocalOrigin(origin)) {
+      return false;
+    }
+
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    return true;
+  }
+
+  private createSecurityMiddleware(): Thirdparty.connect.NextHandleFunction {
+    return (req, res, next) => {
+      const isCorsAllowed = this.setCorsHeaders(req, res);
+      if (req.method?.toUpperCase() === 'OPTIONS') {
+        res.statusCode = isCorsAllowed ? 204 : 403;
+        res.end();
+        return;
+      }
+
+      next();
+    };
+  }
+
   async bootstrap() {
     if (!this.disposed) {
       return;
     }
 
-    const port = Server.getPortSync(this.port);
+    const port = Server.getPortSync(this.port, this.host);
     // rewrite port when the default port is unavailable
     this.port = port;
-    this._server = await Server.createServer(port);
+    this._server = await Server.createServer(port, this.host);
     this._socket = new Socket({
       sdk: this.sdk,
       server: this._server.server,
@@ -103,17 +140,12 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
 
     this.disposed = false;
 
-    this.app.use(cors());
+    this.app.use(this.createSecurityMiddleware());
     this.app.use(bodyParser.json({ limit: '500mb' }));
     const clientHtmlPath = this._innerClientPath
       ? this._innerClientPath
       : require.resolve('@rsdoctor/client');
     const clientDistPath = path.resolve(clientHtmlPath, '..');
-    this.app.use(
-      serve(clientDistPath, {
-        dev: true,
-      }),
-    );
 
     // launch-editor: open file in editor (VSCode, Cursor, etc.) from the UI
     this.app.use(
@@ -170,6 +202,12 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
 
     await this._router.setup();
 
+    this.app.use(
+      serve(clientDistPath, {
+        dev: true,
+      }),
+    );
+
     process.once('exit', () => this.dispose());
     process.once('SIGINT', () => this.dispose(0));
     process.once('SIGTERM', () => this.dispose(0));
@@ -200,8 +238,6 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
         try {
           const body = await cb(req, res, next);
 
-          res.setHeader('Access-Control-Allow-Origin', '*');
-          res.setHeader('Access-Control-Allow-Credentials', 'true');
           res.statusCode = 200;
 
           if (Buffer.isBuffer(body)) {
@@ -222,7 +258,6 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
         } catch (error) {
           res.statusCode = 500;
           res.end((error as Error).message);
-          return next(error);
         }
         return;
       }

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -21,8 +21,13 @@ export * from './utils';
 /** Path for launch-editor: open file in editor from the UI (see https://github.com/yyx990803/launch-editor) */
 const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
 const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+const LISTEN_RETRY_LIMIT = 10;
 
 export type ISocketType = { port: number; socketUrl: string };
+
+function isAddressInUseError(error: unknown) {
+  return (error as { code?: string }).code === 'EADDRINUSE';
+}
 
 export class RsdoctorServer implements SDK.RsdoctorServerInstance {
   private _server!: Common.PromiseReturnType<typeof Server.createServer>;
@@ -116,15 +121,39 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     };
   }
 
+  private async createInnerServer() {
+    let expectedPort = this.port;
+    let lastError: unknown;
+
+    for (let retry = 0; retry < LISTEN_RETRY_LIMIT; retry++) {
+      const port = Server.getPortSync(expectedPort, this.host);
+
+      try {
+        return {
+          port,
+          server: await Server.createServer(port, this.host),
+        };
+      } catch (error) {
+        if (!isAddressInUseError(error)) {
+          throw error;
+        }
+        lastError = error;
+        expectedPort = port + 1;
+      }
+    }
+
+    throw lastError;
+  }
+
   async bootstrap() {
     if (!this.disposed) {
       return;
     }
 
-    const port = Server.getPortSync(this.port, this.host);
+    const { port, server } = await this.createInnerServer();
     // rewrite port when the default port is unavailable
     this.port = port;
-    this._server = await Server.createServer(port, this.host);
+    this._server = server;
     this._socket = new Socket({
       sdk: this.sdk,
       server: this._server.server,

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -87,8 +87,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
       const url = new URL(origin);
       return (
         (url.protocol === 'http:' || url.protocol === 'https:') &&
-        LOCAL_HOSTNAMES.has(url.hostname) &&
-        url.port === String(this.port)
+        LOCAL_HOSTNAMES.has(url.hostname)
       );
     } catch {
       return false;

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -157,6 +157,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
       sdk: this.sdk,
       server: this._server.server,
       port: this.port,
+      isOriginAllowed: (origin) => !origin || this.isLocalOrigin(origin),
     });
     await this._socket.bootstrap();
 

--- a/packages/sdk/src/sdk/server/router.ts
+++ b/packages/sdk/src/sdk/server/router.ts
@@ -10,6 +10,22 @@ interface RouterOptions {
 
 type APIConstructor = Common.Constructor<typeof BaseAPI>;
 
+type StandardMethodDecoratorContext = {
+  name: PropertyKey;
+  addInitializer(initializer: (this: unknown) => void): void;
+};
+
+function isStandardMethodDecoratorContext(
+  value: unknown,
+): value is StandardMethodDecoratorContext {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'name' in value &&
+    typeof (value as { addInitializer?: unknown }).addInitializer === 'function'
+  );
+}
+
 export class Router {
   static routes = {
     /**
@@ -25,35 +41,79 @@ export class Router {
     >(),
   };
 
+  private static addRoute(
+    method: keyof typeof Router.routes,
+    constructor: APIConstructor,
+    propertyKey: PropertyKey,
+    pathname: string,
+  ) {
+    const routes = Router.routes[method];
+    if (!routes.has(constructor)) {
+      routes.set(constructor, []);
+    }
+
+    const apiRoutes = routes.get(constructor)!;
+    if (
+      !apiRoutes.some(
+        ([registeredKey, registeredPathname]) =>
+          registeredKey === propertyKey && registeredPathname === pathname,
+      )
+    ) {
+      apiRoutes.push([propertyKey, pathname]);
+    }
+  }
+
   static get(pathname: string): MethodDecorator {
-    return (<T extends Common.Function>(
-      target: Common.Constructor<typeof BaseAPI>,
-      propertyKey: PropertyKey,
-      descriptor: TypedPropertyDescriptor<T>,
+    return ((
+      target: object,
+      contextOrKey: PropertyKey | StandardMethodDecoratorContext,
     ) => {
-      const routes = Router.routes.get;
-      const constructor = target.constructor as APIConstructor;
-      if (!routes.has(constructor)) {
-        routes.set(constructor, []);
+      if (isStandardMethodDecoratorContext(contextOrKey)) {
+        contextOrKey.addInitializer(function (this: unknown) {
+          Router.addRoute(
+            'get',
+            (this as BaseAPI).constructor as APIConstructor,
+            contextOrKey.name,
+            pathname,
+          );
+        });
+        return target;
       }
-      routes.get(constructor)!.push([propertyKey, pathname]);
-      return descriptor;
+
+      Router.addRoute(
+        'get',
+        (target as { constructor: APIConstructor }).constructor,
+        contextOrKey,
+        pathname,
+      );
+      return;
     }) as MethodDecorator;
   }
 
   static post(pathname: string): MethodDecorator {
-    return (<T extends Common.Function>(
-      target: Common.Constructor<typeof BaseAPI>,
-      propertyKey: PropertyKey,
-      descriptor: TypedPropertyDescriptor<T>,
+    return ((
+      target: object,
+      contextOrKey: PropertyKey | StandardMethodDecoratorContext,
     ) => {
-      const routes = Router.routes.post;
-      const constructor = target.constructor as APIConstructor;
-      if (!routes.has(constructor)) {
-        routes.set(constructor, []);
+      if (isStandardMethodDecoratorContext(contextOrKey)) {
+        contextOrKey.addInitializer(function (this: unknown) {
+          Router.addRoute(
+            'post',
+            (this as BaseAPI).constructor as APIConstructor,
+            contextOrKey.name,
+            pathname,
+          );
+        });
+        return target;
       }
-      routes.get(constructor)!.push([propertyKey, pathname]);
-      return descriptor;
+
+      Router.addRoute(
+        'post',
+        (target as { constructor: APIConstructor }).constructor,
+        contextOrKey,
+        pathname,
+      );
+      return;
     }) as MethodDecorator;
   }
 
@@ -61,25 +121,32 @@ export class Router {
 
   public async setup() {
     const { apis, sdk, server } = this.options;
+    const instances = new Map<APIConstructor, BaseAPI>();
 
     apis.forEach((API) => {
-      const obj = new API(sdk, server);
-      Router.routes.get.forEach((v, cons) => {
-        v.forEach(([key, pathname]) => {
-          if (cons === API) {
-            // api class match
-            server.get(pathname, this.wrapAPIFunction(obj, key));
-          }
-        });
-      });
+      if (typeof API === 'function' && !instances.has(API)) {
+        instances.set(API, new API(sdk, server));
+      }
+    });
 
-      Router.routes.post.forEach((v, cons) => {
-        v.forEach(([key, pathname]) => {
-          if (cons === API) {
-            // api class match
-            server.post(pathname, this.wrapAPIFunction(obj, key));
-          }
-        });
+    const getInstance = (API: APIConstructor) => {
+      if (!instances.has(API)) {
+        instances.set(API, new API(sdk, server));
+      }
+      return instances.get(API)!;
+    };
+
+    Router.routes.get.forEach((routes, API) => {
+      const obj = getInstance(API);
+      routes.forEach(([key, pathname]) => {
+        server.get(pathname, this.wrapAPIFunction(obj, key));
+      });
+    });
+
+    Router.routes.post.forEach((routes, API) => {
+      const obj = getInstance(API);
+      routes.forEach(([key, pathname]) => {
+        server.post(pathname, this.wrapAPIFunction(obj, key));
       });
     });
   }

--- a/packages/sdk/src/sdk/server/socket/api.ts
+++ b/packages/sdk/src/sdk/server/socket/api.ts
@@ -1,5 +1,6 @@
 import { Data } from '@rsdoctor/utils/common';
 import { Manifest, SDK } from '@rsdoctor/types';
+import { loadStoreDataByKey } from '../data';
 
 interface SocketAPILoaderOptions {
   sdk: SDK.RsdoctorBuilderSDKInstance;
@@ -24,16 +25,7 @@ export class SocketAPILoader implements Manifest.ManifestDataLoader {
 
   public async loadData(key: string) {
     const data = this.options.sdk.getStoreData();
-
-    const sep = '.';
-
-    let res = data[key];
-
-    if (key.includes(sep)) {
-      res = key.split(sep).reduce((t, k) => t[k], data);
-    }
-
-    return res;
+    return loadStoreDataByKey(data, key);
   }
 
   get loadAPIData() {

--- a/packages/sdk/src/sdk/server/socket/index.ts
+++ b/packages/sdk/src/sdk/server/socket/index.ts
@@ -7,6 +7,7 @@ interface SocketOptions {
   sdk: SDK.RsdoctorBuilderSDKInstance;
   server: Server;
   port: number;
+  isOriginAllowed?: (origin?: string) => boolean;
 }
 
 type Subscription = {
@@ -40,8 +41,18 @@ export class Socket {
     this.loader = new SocketAPILoader({ sdk: options.sdk });
   }
 
+  protected isOriginAllowed(origin?: string) {
+    return !origin || this.options.isOriginAllowed?.(origin) !== false;
+  }
+
   public bootstrap() {
-    this.server = new WebSocketServer({ server: this.options.server });
+    const verifyClient = (info: { origin?: string }) =>
+      this.isOriginAllowed(info.origin);
+
+    this.server = new WebSocketServer({
+      server: this.options.server,
+      verifyClient,
+    });
     this.server.on('connection', (client) => {
       this.attachClient(client);
     });

--- a/packages/sdk/tests/server/apis/data.test.ts
+++ b/packages/sdk/tests/server/apis/data.test.ts
@@ -19,4 +19,12 @@ describe('test server/apis/data.ts', () => {
 
     spy.mockRestore();
   });
+
+  it('rejects invalid data keys', async () => {
+    const res = await target.post(SDK.ServerAPI.API.LoadDataByKey, {
+      key: '__proto__.polluted',
+    } as never);
+
+    expect(res.text).toBe('Invalid data key: __proto__.polluted');
+  });
 });

--- a/packages/sdk/tests/server/apis/index.test.ts
+++ b/packages/sdk/tests/server/apis/index.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from '@rstest/core';
 import { SDK } from '@rsdoctor/types';
 import { Router } from '../../../src/sdk/server/router';
-
-// make sure the decorators work.
-import '../../../src/sdk/server/apis';
+import * as APIs from '../../../src/sdk/server/apis';
 
 describe('ensure all of the apis implementation for server', () => {
   const apis = Object.values(SDK.ServerAPI.API);
+
+  Object.values(APIs).forEach((API) => {
+    if (typeof API === 'function') {
+      new API({} as never, {} as never);
+    }
+  });
 
   it(`ensure server`, async () => {
     const { get, post } = Router.routes;

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -49,7 +49,7 @@ describe('test server/apis/project.ts', () => {
     expect(env.port).toEqual(target.server.port);
   });
 
-  it('only allows local same-port CORS preflight requests', async () => {
+  it('only allows local CORS preflight requests', async () => {
     await expect(
       optionsWithOrigin('https://example.com'),
     ).resolves.toStrictEqual({
@@ -62,6 +62,13 @@ describe('test server/apis/project.ts', () => {
     ).resolves.toStrictEqual({
       statusCode: 204,
       allowOrigin: `http://127.0.0.1:${target.server.port}`,
+    });
+
+    await expect(
+      optionsWithOrigin(`http://127.0.0.1:${target.server.port + 1}`),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: `http://127.0.0.1:${target.server.port + 1}`,
     });
   });
 

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, rs } from '@rstest/core';
 import { Manifest, SDK } from '@rsdoctor/types';
 import { Manifest as ManifestShared } from '@rsdoctor/utils/common';
+import { request } from 'http';
 import { cwd, setupSDK } from '../../utils';
 import { getLocalIpAddress } from '../../../src/sdk/server/utils';
 
@@ -9,11 +10,59 @@ rs.setConfig({ testTimeout: 50000 });
 describe('test server/apis/project.ts', () => {
   const target = setupSDK();
 
+  function optionsWithOrigin(origin: string) {
+    return new Promise<{
+      statusCode: number;
+      allowOrigin: string | string[] | undefined;
+    }>((resolve, reject) => {
+      const url = new URL(
+        `${target.server.origin}${SDK.ServerAPI.API.Manifest}`,
+      );
+      const req = request(
+        {
+          hostname: url.hostname,
+          port: url.port,
+          path: url.pathname,
+          method: 'OPTIONS',
+          headers: { Origin: origin },
+        },
+        (res) => {
+          res.on('data', () => {});
+          res.on('close', () => {
+            resolve({
+              statusCode: res.statusCode || 0,
+              allowOrigin: res.headers['access-control-allow-origin'],
+            });
+          });
+        },
+      );
+
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
   it(`test api: ${SDK.ServerAPI.API.Env}`, async () => {
     const env = (await target.get(SDK.ServerAPI.API.Env)).toJSON();
 
     expect(env.ip).toEqual(getLocalIpAddress());
     expect(env.port).toEqual(target.server.port);
+  });
+
+  it('only allows local same-port CORS preflight requests', async () => {
+    await expect(
+      optionsWithOrigin('https://example.com'),
+    ).resolves.toStrictEqual({
+      statusCode: 403,
+      allowOrigin: undefined,
+    });
+
+    await expect(
+      optionsWithOrigin(`http://127.0.0.1:${target.server.port}`),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: `http://127.0.0.1:${target.server.port}`,
+    });
   });
 
   it(`test api: ${SDK.ServerAPI.API.Manifest}`, async () => {

--- a/packages/sdk/tests/server/utils.test.ts
+++ b/packages/sdk/tests/server/utils.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from '@rstest/core';
+import { Server } from '@rsdoctor/utils/build';
+import type { AddressInfo } from 'net';
+import { RsdoctorSDK } from '../../src/sdk';
 import { getDataByPagination } from '../../src/sdk/server/utils';
 
 describe('test server/utils.ts', () => {
@@ -321,5 +324,48 @@ describe('test server/utils.ts', () => {
         hasNextPage: false,
       },
     });
+  });
+});
+
+describe('test server bootstrap', () => {
+  it('retries with another port when the preferred port is occupied', async () => {
+    const occupied = await Server.createServer(0);
+    const { port } = occupied.server.address() as AddressInfo;
+    const sdk = new RsdoctorSDK({
+      name: 'test',
+      root: process.cwd(),
+      port,
+    });
+
+    try {
+      await sdk.bootstrap();
+      expect(sdk.server.port).not.toEqual(port);
+    } finally {
+      await sdk.dispose();
+      await occupied.close();
+    }
+  });
+
+  it('retries when concurrent servers race for the same port', async () => {
+    const port = await Server.getPort(
+      10000 + Math.floor(Math.random() * 10000),
+    );
+    const first = new RsdoctorSDK({
+      name: 'test-first',
+      root: process.cwd(),
+      port,
+    });
+    const second = new RsdoctorSDK({
+      name: 'test-second',
+      root: process.cwd(),
+      port,
+    });
+
+    try {
+      await Promise.all([first.bootstrap(), second.bootstrap()]);
+      expect(first.server.port).not.toEqual(second.server.port);
+    } finally {
+      await Promise.all([first.dispose(), second.dispose()]);
+    }
   });
 });

--- a/packages/sdk/tests/server/websocket.test.ts
+++ b/packages/sdk/tests/server/websocket.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it, rs } from '@rstest/core';
 import { SDK } from '@rsdoctor/types';
+import WebSocket from 'ws';
 import { Socket } from '../../src/sdk/server/socket';
+import { setupSDK } from '../utils';
+
+type SocketResponseMessage = {
+  type: 'response';
+  id: string;
+  payload?: unknown;
+  error?: string;
+};
 
 function createMockClient() {
   const listeners = new Map<string, Set<(...args: any[]) => void>>();
@@ -22,6 +31,66 @@ function createMockClient() {
     },
   };
   return client;
+}
+
+function getSocketUrl(origin: string) {
+  return origin.replace(/^http/, 'ws');
+}
+
+function waitForSocketRejection(socketUrl: string, origin: string) {
+  return new Promise<void>((resolve, reject) => {
+    const client = new WebSocket(socketUrl, { origin });
+    const timer = setTimeout(() => {
+      client.close();
+      reject(new Error('Timed out waiting for websocket rejection.'));
+    }, 5000);
+
+    client.once('open', () => {
+      clearTimeout(timer);
+      client.close();
+      reject(new Error('WebSocket accepted a blocked origin.'));
+    });
+    client.once('error', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+function requestSocketAPI(
+  socketUrl: string,
+  origin: string,
+  message: Record<string, unknown>,
+) {
+  return new Promise<SocketResponseMessage>((resolve, reject) => {
+    const client = new WebSocket(socketUrl, { origin });
+    const timer = setTimeout(() => {
+      client.close();
+      reject(new Error('Timed out waiting for websocket response.'));
+    }, 5000);
+
+    const finish = (cb: () => void) => {
+      clearTimeout(timer);
+      client.close();
+      cb();
+    };
+
+    client.once('open', () => {
+      client.send(JSON.stringify(message));
+    });
+    client.once('message', (data) => {
+      finish(() => {
+        try {
+          resolve(JSON.parse(data.toString()) as SocketResponseMessage);
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+    client.once('error', (error) => {
+      finish(() => reject(error));
+    });
+  });
 }
 
 describe('server websocket transport', () => {
@@ -154,5 +223,37 @@ describe('server websocket transport', () => {
 
     secondClient.emit('close');
     expect(socket.getSubscriptions()).toStrictEqual([]);
+  });
+
+  describe('server websocket origin and data access', () => {
+    const target = setupSDK();
+
+    it('rejects websocket connections from non-local origins', async () => {
+      await expect(
+        waitForSocketRejection(
+          getSocketUrl(target.server.origin),
+          'https://example.com',
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects invalid data keys through websocket requests', async () => {
+      await expect(
+        requestSocketAPI(
+          getSocketUrl(target.server.origin),
+          target.server.origin,
+          {
+            type: 'request',
+            id: 'request-1',
+            api: SDK.ServerAPI.API.LoadDataByKey,
+            body: { key: '__proto__.polluted' },
+          },
+        ),
+      ).resolves.toStrictEqual({
+        type: 'response',
+        id: 'request-1',
+        error: 'Invalid data key: __proto__.polluted',
+      });
+    });
   });
 });

--- a/packages/utils/src/build/server.ts
+++ b/packages/utils/src/build/server.ts
@@ -116,8 +116,13 @@ export async function createServer(
     },
   };
 
-  return new Promise<typeof res>((resolve) => {
+  return new Promise<typeof res>((resolve, reject) => {
+    const onError = (error: Error) => {
+      reject(error);
+    };
+    server.once('error', onError);
     server.listen(port, host, () => {
+      server.off('error', onError);
       resolve(res);
     });
   });

--- a/packages/utils/src/build/server.ts
+++ b/packages/utils/src/build/server.ts
@@ -2,12 +2,14 @@ import connect from 'connect';
 import http from 'http';
 import os from 'os';
 import gp from 'get-port';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { Thirdparty } from '@rsdoctor/types';
 import { random } from '../common/algorithm';
 
 // see https://neo4j.com/developer/kb/list-of-restricted-ports-in-browsers
 const RESTRICTED_PORTS = [3659, 4045, 6000, 6665, 6666, 6667, 6668, 6669];
+
+export const defaultHost = '127.0.0.1';
 
 function getRandomPort(min: number, max: number) {
   let port: number;
@@ -19,21 +21,24 @@ function getRandomPort(min: number, max: number) {
 
 export const defaultPort = getRandomPort(3000, 8999);
 
-export async function getPort(expectPort: number) {
-  return gp({ port: expectPort });
+export async function getPort(expectPort: number, host = defaultHost) {
+  return gp({ port: expectPort, host });
 }
 
-export const createGetPortSyncFunctionString = (expectPort: number) =>
+export const createGetPortSyncFunctionString = (
+  expectPort: number,
+  host = defaultHost,
+) =>
   `
 (() => {
 const net = require('net');
 
-function getPort(expectPort) {
+function getPort(expectPort, host) {
   return new Promise((resolve, reject) => {
     const server = net.createServer();
     server.unref();
     server.on('error', reject);
-    server.listen(expectPort, () => {
+    server.listen(expectPort, host, () => {
       const { port } = server.address();
       server.close(() => {
         resolve(port);
@@ -46,7 +51,7 @@ async function getAvailablePort(expectPort) {
   let port = expectPort;
   while (true) {
     try {
-      const res = await getPort(port);
+      const res = await getPort(port, ${JSON.stringify(host)});
       return res;
     } catch (error) {
       port += Math.floor(Math.random() * 100 + 1);
@@ -58,13 +63,18 @@ getAvailablePort(${expectPort}).then(port => process.stdout.write(port.toString(
 })();
 `.trim();
 
-export function getPortSync(expectPort: number): number | never {
+export function getPortSync(
+  expectPort: number,
+  host = defaultHost,
+): number | never {
   const statement =
     os.EOL === '\n'
-      ? createGetPortSyncFunctionString(expectPort)
-      : createGetPortSyncFunctionString(expectPort).replace(/\n/g, '');
+      ? createGetPortSyncFunctionString(expectPort, host)
+      : createGetPortSyncFunctionString(expectPort, host).replace(/\n/g, '');
 
-  const port = execSync(`node -e "${statement}"`, { encoding: 'utf-8' });
+  const port = execFileSync(process.execPath, ['-e', statement], {
+    encoding: 'utf-8',
+  });
 
   return Number(port);
 }
@@ -73,7 +83,10 @@ export function createApp() {
   return connect();
 }
 
-export async function createServer(port: number): Promise<{
+export async function createServer(
+  port: number,
+  host = defaultHost,
+): Promise<{
   app: Thirdparty.connect.Server;
   server: http.Server;
   port: number;
@@ -104,7 +117,7 @@ export async function createServer(port: number): Promise<{
   };
 
   return new Promise<typeof res>((resolve) => {
-    server.listen(port, () => {
+    server.listen(port, host, () => {
       resolve(res);
     });
   });

--- a/packages/utils/tests/server.test.ts
+++ b/packages/utils/tests/server.test.ts
@@ -37,4 +37,17 @@ describe('test src/server.ts', () => {
       await close();
     }
   });
+
+  it('rejects when the requested port is already in use', async () => {
+    const { server, close } = await Server.createServer(0);
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      await expect(Server.createServer(port)).rejects.toMatchObject({
+        code: 'EADDRINUSE',
+      });
+    } finally {
+      await close();
+    }
+  });
 });

--- a/packages/utils/tests/server.test.ts
+++ b/packages/utils/tests/server.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from '@rstest/core';
+import type { AddressInfo } from 'net';
 import { Server } from '../src/build';
-import { getPortSync } from '../src/build/server';
+import {
+  createGetPortSyncFunctionString,
+  defaultHost,
+  getPortSync,
+} from '../src/build/server';
 
 describe('test src/server.ts', () => {
   it('getPort()', async () => {
@@ -17,5 +22,19 @@ describe('test src/server.ts', () => {
     const { close } = await Server.createServer(8262);
     expect(getPortSync(8262)).not.toEqual(8262);
     await close();
+  });
+
+  it('binds to localhost by default', async () => {
+    const { server, close } = await Server.createServer(0);
+
+    try {
+      const address = server.address() as AddressInfo;
+      expect(address.address).toEqual(defaultHost);
+      expect(createGetPortSyncFunctionString(3543)).toContain(
+        `getPort(port, ${JSON.stringify(defaultHost)})`,
+      );
+    } finally {
+      await close();
+    }
   });
 });


### PR DESCRIPTION
## Summary

### Changes:

- Bind the local report server to 127.0.0.1 by default and retry occupied ports safely.
- Restrict CORS to trusted local origins, while still allowing local cross-port bundle-diff access.
- Harden LoadDataByKey against invalid/prototype-style data keys.
- Port the router decorator registration compatibility needed by the v1.x toolchain.

## Related Links

<!--- Provide links of related issues or pages -->
