### PR TITLE
fix(sdk):  restrict report server exposure to v1.x

### DIFF
--- a/packages/sdk/src/sdk/server/apis/base.ts
+++ b/packages/sdk/src/sdk/server/apis/base.ts
@@ -1,6 +1,8 @@
 import { Data } from '@rsdoctor/utils/common';
 import { Manifest, SDK } from '@rsdoctor/types';
 
+const FORBIDDEN_DATA_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 export class BaseAPI implements Manifest.ManifestDataLoader {
   [key: string | symbol]: any;
   public readonly ctx!: SDK.ServerAPI.APIContext;
@@ -26,11 +28,27 @@ export class BaseAPI implements Manifest.ManifestDataLoader {
     const data = this.ctx.sdk.getStoreData();
 
     const sep = '.';
+    const keys = key.split(sep);
+    if (
+      keys.some((key) => FORBIDDEN_DATA_KEYS.has(key)) ||
+      !Object.prototype.hasOwnProperty.call(data, keys[0])
+    ) {
+      throw new Error(`Invalid data key: ${key}`);
+    }
 
     let res = data[key];
 
     if (key.includes(sep)) {
-      res = key.split(sep).reduce((t, k) => t[k], data);
+      res = keys.reduce((target, key) => {
+        if (
+          target === null ||
+          typeof target !== 'object' ||
+          !Object.prototype.hasOwnProperty.call(target, key)
+        ) {
+          throw new Error(`Invalid data key: ${keys.join(sep)}`);
+        }
+        return target[key];
+      }, data);
     }
 
     return res;

--- a/packages/sdk/src/sdk/server/apis/base.ts
+++ b/packages/sdk/src/sdk/server/apis/base.ts
@@ -1,7 +1,6 @@
 import { Data } from '@rsdoctor/utils/common';
 import { Manifest, SDK } from '@rsdoctor/types';
-
-const FORBIDDEN_DATA_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+import { getStoreDataByKey } from '../dataKey';
 
 export class BaseAPI implements Manifest.ManifestDataLoader {
   [key: string | symbol]: any;
@@ -9,7 +8,10 @@ export class BaseAPI implements Manifest.ManifestDataLoader {
 
   protected dataLoader: Data.APIDataLoader;
 
-  constructor(sdk: SDK.RsdoctorSDKInstance, server: SDK.RsdoctorServerInstance) {
+  constructor(
+    sdk: SDK.RsdoctorSDKInstance,
+    server: SDK.RsdoctorServerInstance,
+  ) {
     this.ctx = { sdk, server } as SDK.ServerAPI.APIContext;
     this.dataLoader = new Data.APIDataLoader(this);
   }
@@ -27,30 +29,6 @@ export class BaseAPI implements Manifest.ManifestDataLoader {
   public async loadData(key: Manifest.RsdoctorManifestObjectKeys) {
     const data = this.ctx.sdk.getStoreData();
 
-    const sep = '.';
-    const keys = key.split(sep);
-    if (
-      keys.some((key) => FORBIDDEN_DATA_KEYS.has(key)) ||
-      !Object.prototype.hasOwnProperty.call(data, keys[0])
-    ) {
-      throw new Error(`Invalid data key: ${key}`);
-    }
-
-    let res = data[key];
-
-    if (key.includes(sep)) {
-      res = keys.reduce((target, key) => {
-        if (
-          target === null ||
-          typeof target !== 'object' ||
-          !Object.prototype.hasOwnProperty.call(target, key)
-        ) {
-          throw new Error(`Invalid data key: ${keys.join(sep)}`);
-        }
-        return target[key];
-      }, data);
-    }
-
-    return res;
+    return getStoreDataByKey(data, key);
   }
 }

--- a/packages/sdk/src/sdk/server/dataKey.ts
+++ b/packages/sdk/src/sdk/server/dataKey.ts
@@ -1,0 +1,34 @@
+const FORBIDDEN_DATA_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function getStoreDataByKey(data: object, key: string) {
+  const sep = '.';
+  const keys = key.split(sep);
+  const root = data as Record<string, unknown>;
+
+  if (
+    keys.some((key) => FORBIDDEN_DATA_KEYS.has(key)) ||
+    !Object.prototype.hasOwnProperty.call(root, keys[0])
+  ) {
+    throw new Error(`Invalid data key: ${key}`);
+  }
+
+  let res = root[key];
+
+  if (key.includes(sep)) {
+    res = keys.reduce<unknown>((target, key) => {
+      if (
+        !isRecord(target) ||
+        !Object.prototype.hasOwnProperty.call(target, key)
+      ) {
+        throw new Error(`Invalid data key: ${keys.join(sep)}`);
+      }
+      return target[key];
+    }, root);
+  }
+
+  return res;
+}

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -4,7 +4,6 @@ import serve from 'sirv';
 import { Bundle, GlobalConfig } from '@rsdoctor/utils/common';
 import assert from 'assert';
 import bodyParser from 'body-parser';
-import cors from 'cors';
 import { PassThrough } from 'stream';
 import { Socket } from './socket';
 import { Router } from './router';
@@ -12,18 +11,23 @@ import * as APIs from './apis';
 import { chalk, logger } from '@rsdoctor/utils/logger';
 import { openBrowser } from '@/sdk/utils/openBrowser';
 import path from 'path';
-import { getLocalIpAddress } from './utils';
 import { Lodash } from '@rsdoctor/utils/common';
 import { createRequire } from 'module';
-import { ServerResponse } from 'http';
+import { IncomingMessage, ServerResponse } from 'http';
 
 const require = createRequire(import.meta.url);
 export * from './utils';
 
 /** Path for launch-editor: open file in editor from the UI (see https://github.com/yyx990803/launch-editor) */
 const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+const LISTEN_RETRY_LIMIT = 10;
 
 export type ISocketType = { port: number; socketUrl: string };
+
+function isAddressInUseError(error: unknown) {
+  return (error as { code?: string }).code === 'EADDRINUSE';
+}
 
 export class RsdoctorServer implements SDK.RsdoctorServerInstance {
   private _server!: Common.PromiseReturnType<typeof Server.createServer>;
@@ -60,8 +64,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
   }
 
   public get host(): string {
-    const host = getLocalIpAddress();
-    return host;
+    return Server.defaultHost;
   }
 
   public get origin(): string {
@@ -79,15 +82,77 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     return this._innerClientPath;
   }
 
+  private isLocalOrigin(origin: string) {
+    try {
+      const url = new URL(origin);
+      return (
+        (url.protocol === 'http:' || url.protocol === 'https:') &&
+        LOCAL_HOSTNAMES.has(url.hostname)
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  private setCorsHeaders(req: IncomingMessage, res: ServerResponse) {
+    const origin = req.headers.origin;
+    if (typeof origin !== 'string' || !this.isLocalOrigin(origin)) {
+      return false;
+    }
+
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    return true;
+  }
+
+  private createSecurityMiddleware(): Thirdparty.connect.NextHandleFunction {
+    return (req, res, next) => {
+      const isCorsAllowed = this.setCorsHeaders(req, res);
+      if (req.method?.toUpperCase() === 'OPTIONS') {
+        res.statusCode = isCorsAllowed ? 204 : 403;
+        res.end();
+        return;
+      }
+
+      next();
+    };
+  }
+
+  private async createInnerServer() {
+    let expectedPort = this.port;
+    let lastError: unknown;
+
+    for (let retry = 0; retry < LISTEN_RETRY_LIMIT; retry++) {
+      const port = Server.getPortSync(expectedPort, this.host);
+
+      try {
+        return {
+          port,
+          server: await Server.createServer(port, this.host),
+        };
+      } catch (error) {
+        if (!isAddressInUseError(error)) {
+          throw error;
+        }
+        lastError = error;
+        expectedPort = port + 1;
+      }
+    }
+
+    throw lastError;
+  }
+
   async bootstrap() {
     if (!this.disposed) {
       return;
     }
 
-    const port = Server.getPortSync(this.port);
+    const { port, server } = await this.createInnerServer();
     // rewrite port when the default port is unavailable
     this.port = port;
-    this._server = await Server.createServer(port);
+    this._server = server;
     this._socket = new Socket({
       sdk: this.sdk,
       server: this._server.server,
@@ -103,7 +168,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
 
     this.disposed = false;
 
-    this.app.use(cors());
+    this.app.use(this.createSecurityMiddleware());
     this.app.use(bodyParser.json({ limit: '500mb' }));
     const clientHtmlPath = this._innerClientPath
       ? this._innerClientPath
@@ -199,9 +264,6 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
       if (m === method) {
         try {
           const body = await cb(req, res, next);
-
-          res.setHeader('Access-Control-Allow-Origin', '*');
-          res.setHeader('Access-Control-Allow-Credentials', 'true');
           res.statusCode = 200;
 
           if (Buffer.isBuffer(body)) {
@@ -222,7 +284,6 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
         } catch (error) {
           res.statusCode = 500;
           res.end((error as Error).message);
-          return next(error);
         }
         return;
       }

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -13,14 +13,14 @@ import { openBrowser } from '@/sdk/utils/openBrowser';
 import path from 'path';
 import { Lodash } from '@rsdoctor/utils/common';
 import { createRequire } from 'module';
-import { IncomingMessage, ServerResponse } from 'http';
+import { ServerResponse } from 'http';
+import { setCorsHeaders } from './security';
 
 const require = createRequire(import.meta.url);
 export * from './utils';
 
 /** Path for launch-editor: open file in editor from the UI (see https://github.com/yyx990803/launch-editor) */
 const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
-const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
 const LISTEN_RETRY_LIMIT = 10;
 
 export type ISocketType = { port: number; socketUrl: string };
@@ -74,7 +74,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
   public get socketUrl(): ISocketType {
     return {
       port: this.port,
-      socketUrl: `ws://localhost:${this.port}`,
+      socketUrl: `ws://${this.host}:${this.port}`,
     };
   }
 
@@ -82,34 +82,9 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     return this._innerClientPath;
   }
 
-  private isLocalOrigin(origin: string) {
-    try {
-      const url = new URL(origin);
-      return (
-        (url.protocol === 'http:' || url.protocol === 'https:') &&
-        LOCAL_HOSTNAMES.has(url.hostname)
-      );
-    } catch {
-      return false;
-    }
-  }
-
-  private setCorsHeaders(req: IncomingMessage, res: ServerResponse) {
-    const origin = req.headers.origin;
-    if (typeof origin !== 'string' || !this.isLocalOrigin(origin)) {
-      return false;
-    }
-
-    res.setHeader('Access-Control-Allow-Origin', origin);
-    res.setHeader('Vary', 'Origin');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    return true;
-  }
-
   private createSecurityMiddleware(): Thirdparty.connect.NextHandleFunction {
     return (req, res, next) => {
-      const isCorsAllowed = this.setCorsHeaders(req, res);
+      const isCorsAllowed = setCorsHeaders(req, res);
       if (req.method?.toUpperCase() === 'OPTIONS') {
         res.statusCode = isCorsAllowed ? 204 : 403;
         res.end();
@@ -357,8 +332,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
 
     const needEncodeURI = args[0] === Client.RsdoctorClientRoutes.BundleDiff;
     const url = `http://${this.host}:${this.port}${relativeUrl}`;
-    const localhostUrl = `http://localhost:${this.port}${relativeUrl}`;
-    await openBrowser(localhostUrl, !needEncodeURI);
+    await openBrowser(url, !needEncodeURI);
     if (this._printServerUrl) {
       logger.info(
         `${chalk.green(`${this.sdk.name} compiler's`)} analyzer running on: ${chalk.cyan(url)}`,

--- a/packages/sdk/src/sdk/server/router.ts
+++ b/packages/sdk/src/sdk/server/router.ts
@@ -8,6 +8,24 @@ interface RouterOptions {
   server: SDK.RsdoctorServerInstance;
 }
 
+type APIConstructor = Common.Constructor<typeof BaseAPI>;
+
+type StandardMethodDecoratorContext = {
+  name: PropertyKey;
+  addInitializer(initializer: (this: unknown) => void): void;
+};
+
+function isStandardMethodDecoratorContext(
+  value: unknown,
+): value is StandardMethodDecoratorContext {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'name' in value &&
+    typeof (value as { addInitializer?: unknown }).addInitializer === 'function'
+  );
+}
+
 export class Router {
   static routes = {
     /**
@@ -17,33 +35,79 @@ export class Router {
     post: new Map<Function, Array<[apiKey: PropertyKey, pathname: string]>>(),
   };
 
+  private static addRoute(
+    method: keyof typeof Router.routes,
+    constructor: APIConstructor,
+    propertyKey: PropertyKey,
+    pathname: string,
+  ) {
+    const routes = Router.routes[method];
+    if (!routes.has(constructor)) {
+      routes.set(constructor, []);
+    }
+
+    const apiRoutes = routes.get(constructor)!;
+    if (
+      !apiRoutes.some(
+        ([registeredKey, registeredPathname]) =>
+          registeredKey === propertyKey && registeredPathname === pathname,
+      )
+    ) {
+      apiRoutes.push([propertyKey, pathname]);
+    }
+  }
+
   static get(pathname: string): MethodDecorator {
-    return (<T extends Common.Function>(
-      target: Common.Constructor<typeof BaseAPI>,
-      propertyKey: PropertyKey,
-      descriptor: TypedPropertyDescriptor<T>,
+    return ((
+      target: object,
+      contextOrKey: PropertyKey | StandardMethodDecoratorContext,
     ) => {
-      const routes = Router.routes.get;
-      if (!routes.has(target.constructor)) {
-        routes.set(target.constructor, []);
+      if (isStandardMethodDecoratorContext(contextOrKey)) {
+        contextOrKey.addInitializer(function (this: unknown) {
+          Router.addRoute(
+            'get',
+            (this as BaseAPI).constructor as APIConstructor,
+            contextOrKey.name,
+            pathname,
+          );
+        });
+        return target;
       }
-      routes.get(target.constructor)!.push([propertyKey, pathname]);
-      return descriptor;
+
+      Router.addRoute(
+        'get',
+        (target as { constructor: APIConstructor }).constructor,
+        contextOrKey,
+        pathname,
+      );
+      return;
     }) as MethodDecorator;
   }
 
   static post(pathname: string): MethodDecorator {
-    return (<T extends Common.Function>(
-      target: Common.Constructor<typeof BaseAPI>,
-      propertyKey: PropertyKey,
-      descriptor: TypedPropertyDescriptor<T>,
+    return ((
+      target: object,
+      contextOrKey: PropertyKey | StandardMethodDecoratorContext,
     ) => {
-      const routes = Router.routes.post;
-      if (!routes.has(target.constructor)) {
-        routes.set(target.constructor, []);
+      if (isStandardMethodDecoratorContext(contextOrKey)) {
+        contextOrKey.addInitializer(function (this: unknown) {
+          Router.addRoute(
+            'post',
+            (this as BaseAPI).constructor as APIConstructor,
+            contextOrKey.name,
+            pathname,
+          );
+        });
+        return target;
       }
-      routes.get(target.constructor)!.push([propertyKey, pathname]);
-      return descriptor;
+
+      Router.addRoute(
+        'post',
+        (target as { constructor: APIConstructor }).constructor,
+        contextOrKey,
+        pathname,
+      );
+      return;
     }) as MethodDecorator;
   }
 
@@ -51,25 +115,32 @@ export class Router {
 
   public async setup() {
     const { apis, sdk, server } = this.options;
+    const instances = new Map<APIConstructor, BaseAPI>();
 
     apis.forEach((API) => {
-      const obj = new API(sdk, server);
-      Router.routes.get.forEach((v, cons) => {
-        v.forEach(([key, pathname]) => {
-          if (cons === API) {
-            // api class match
-            server.get(pathname, this.wrapAPIFunction(obj, key));
-          }
-        });
-      });
+      if (typeof API === 'function' && !instances.has(API)) {
+        instances.set(API, new API(sdk, server));
+      }
+    });
 
-      Router.routes.post.forEach((v, cons) => {
-        v.forEach(([key, pathname]) => {
-          if (cons === API) {
-            // api class match
-            server.post(pathname, this.wrapAPIFunction(obj, key));
-          }
-        });
+    const getInstance = (API: APIConstructor) => {
+      if (!instances.has(API)) {
+        instances.set(API, new API(sdk, server));
+      }
+      return instances.get(API)!;
+    };
+
+    Router.routes.get.forEach((routes, API) => {
+      const obj = getInstance(API);
+      routes.forEach(([key, pathname]) => {
+        server.get(pathname, this.wrapAPIFunction(obj, key));
+      });
+    });
+
+    Router.routes.post.forEach((routes, API) => {
+      const obj = getInstance(API);
+      routes.forEach(([key, pathname]) => {
+        server.post(pathname, this.wrapAPIFunction(obj, key));
       });
     });
   }

--- a/packages/sdk/src/sdk/server/router.ts
+++ b/packages/sdk/src/sdk/server/router.ts
@@ -31,8 +31,14 @@ export class Router {
     /**
      * - `key` is the constructor of object which used to match the API class
      */
-    get: new Map<Function, Array<[apiKey: PropertyKey, pathname: string]>>(),
-    post: new Map<Function, Array<[apiKey: PropertyKey, pathname: string]>>(),
+    get: new Map<
+      APIConstructor,
+      Array<[apiKey: PropertyKey, pathname: string]>
+    >(),
+    post: new Map<
+      APIConstructor,
+      Array<[apiKey: PropertyKey, pathname: string]>
+    >(),
   };
 
   private static addRoute(

--- a/packages/sdk/src/sdk/server/security.ts
+++ b/packages/sdk/src/sdk/server/security.ts
@@ -1,0 +1,42 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
+export function isLocalOrigin(origin: string) {
+  try {
+    const url = new URL(origin);
+    return (
+      (url.protocol === 'http:' || url.protocol === 'https:') &&
+      LOCAL_HOSTNAMES.has(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isAllowedRequestOrigin(origin: string | string[] | undefined) {
+  if (origin === undefined) {
+    return true;
+  }
+
+  return typeof origin === 'string' && isLocalOrigin(origin);
+}
+
+export function getAllowedCorsOrigin(origin: string | string[] | undefined) {
+  return typeof origin === 'string' && isLocalOrigin(origin)
+    ? origin
+    : undefined;
+}
+
+export function setCorsHeaders(req: IncomingMessage, res: ServerResponse) {
+  const origin = getAllowedCorsOrigin(req.headers.origin);
+  if (!origin) {
+    return false;
+  }
+
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  return true;
+}

--- a/packages/sdk/src/sdk/server/socket/api.ts
+++ b/packages/sdk/src/sdk/server/socket/api.ts
@@ -1,5 +1,6 @@
 import { Data } from '@rsdoctor/utils/common';
 import { Manifest, SDK } from '@rsdoctor/types';
+import { getStoreDataByKey } from '../dataKey';
 
 interface SocketAPILoaderOptions {
   sdk: SDK.RsdoctorBuilderSDKInstance;
@@ -25,15 +26,7 @@ export class SocketAPILoader implements Manifest.ManifestDataLoader {
   public async loadData(key: string) {
     const data = this.options.sdk.getStoreData();
 
-    const sep = '.';
-
-    let res = data[key];
-
-    if (key.includes(sep)) {
-      res = key.split(sep).reduce((t, k) => t[k], data);
-    }
-
-    return res;
+    return getStoreDataByKey(data, key);
   }
 
   get loadAPIData() {

--- a/packages/sdk/src/sdk/server/socket/index.ts
+++ b/packages/sdk/src/sdk/server/socket/index.ts
@@ -7,6 +7,7 @@ import {
 } from 'socket.io';
 import { isDeepStrictEqual } from 'util';
 import { SocketAPILoader } from './api';
+import { isAllowedRequestOrigin } from '../security';
 
 interface SocketOptions {
   sdk: SDK.RsdoctorBuilderSDKInstance;
@@ -28,11 +29,35 @@ export class Socket {
   }
 
   public bootstrap() {
+    const { socketOptions } = this.options;
+    const corsOptions =
+      socketOptions?.cors &&
+      typeof socketOptions.cors === 'object' &&
+      !Array.isArray(socketOptions.cors)
+        ? socketOptions.cors
+        : {};
+
     this.io = new SocketServer(this.options.server, {
+      ...socketOptions,
       cors: {
-        origin: '*',
+        ...corsOptions,
+        origin: (origin, callback) => {
+          callback(null, isAllowedRequestOrigin(origin));
+        },
       },
-      ...this.options.socketOptions,
+      allowRequest: (req, callback) => {
+        if (!isAllowedRequestOrigin(req.headers.origin)) {
+          callback(null, false);
+          return;
+        }
+
+        if (socketOptions?.allowRequest) {
+          socketOptions.allowRequest(req, callback);
+          return;
+        }
+
+        callback(null, true);
+      },
     });
     this.io.on('connection', (socket) => {
       // setup event listeners for every socket which connected

--- a/packages/sdk/tests/server/apis/data.test.ts
+++ b/packages/sdk/tests/server/apis/data.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, rs } from '@rstest/core';
 import { SDK } from '@rsdoctor/types';
 import { setupSDK } from '../../utils';
+import { SocketAPILoader } from '../../../src/sdk/server/socket/api';
 
 rs.setConfig({ testTimeout: 50000 });
 
@@ -26,5 +27,23 @@ describe('test server/apis/data.ts', () => {
     } as never);
 
     expect(res.text).toBe('Invalid data key: __proto__.polluted');
+  });
+
+  it('rejects invalid socket data keys', async () => {
+    const loader = new SocketAPILoader({
+      sdk: {
+        getManifestData: () => ({}),
+        getStoreData: () => ({
+          envinfo: {
+            root: '/workspace',
+          },
+        }),
+      } as never,
+    });
+
+    await expect(loader.loadData('envinfo.root')).resolves.toBe('/workspace');
+    await expect(loader.loadData('__proto__.polluted')).rejects.toThrow(
+      'Invalid data key: __proto__.polluted',
+    );
   });
 });

--- a/packages/sdk/tests/server/apis/data.test.ts
+++ b/packages/sdk/tests/server/apis/data.test.ts
@@ -19,4 +19,12 @@ describe('test server/apis/data.ts', () => {
 
     spy.mockRestore();
   });
+
+  it('rejects invalid data keys', async () => {
+    const res = await target.post(SDK.ServerAPI.API.LoadDataByKey, {
+      key: '__proto__.polluted',
+    } as never);
+
+    expect(res.text).toBe('Invalid data key: __proto__.polluted');
+  });
 });

--- a/packages/sdk/tests/server/apis/index.test.ts
+++ b/packages/sdk/tests/server/apis/index.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from '@rstest/core';
 import { SDK } from '@rsdoctor/types';
 import { Router } from '../../../src/sdk/server/router';
-
-// make sure the decorators work.
-import '../../../src/sdk/server/apis';
+import * as APIs from '../../../src/sdk/server/apis';
 
 describe('ensure all of the apis implementation for server', () => {
   const apis = Object.values(SDK.ServerAPI.API);
+
+  Object.values(APIs).forEach((API) => {
+    if (typeof API === 'function') {
+      new API({} as never, {} as never);
+    }
+  });
 
   it(`ensure server`, async () => {
     const { get, post } = Router.routes;

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, rs } from '@rstest/core';
 import { Manifest, SDK } from '@rsdoctor/types';
 import { Manifest as ManifestShared } from '@rsdoctor/utils/common';
+import { request } from 'http';
 import { cwd, setupSDK } from '../../utils';
 import { getLocalIpAddress } from '../../../src/sdk/server/utils';
 
@@ -9,11 +10,66 @@ rs.setConfig({ testTimeout: 50000 });
 describe('test server/apis/project.ts', () => {
   const target = setupSDK();
 
+  function optionsWithOrigin(origin: string) {
+    return new Promise<{
+      statusCode: number;
+      allowOrigin: string | string[] | undefined;
+    }>((resolve, reject) => {
+      const url = new URL(
+        `${target.server.origin}${SDK.ServerAPI.API.Manifest}`,
+      );
+      const req = request(
+        {
+          hostname: url.hostname,
+          port: url.port,
+          path: url.pathname,
+          method: 'OPTIONS',
+          headers: { Origin: origin },
+        },
+        (res) => {
+          res.on('data', () => {});
+          res.on('close', () => {
+            resolve({
+              statusCode: res.statusCode || 0,
+              allowOrigin: res.headers['access-control-allow-origin'],
+            });
+          });
+        },
+      );
+
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
   it(`test api: ${SDK.ServerAPI.API.Env}`, async () => {
     const env = (await target.get(SDK.ServerAPI.API.Env)).toJSON();
 
     expect(env.ip).toEqual(getLocalIpAddress());
     expect(env.port).toEqual(target.server.port);
+  });
+
+  it('only allows local CORS preflight requests', async () => {
+    await expect(
+      optionsWithOrigin('https://example.com'),
+    ).resolves.toStrictEqual({
+      statusCode: 403,
+      allowOrigin: undefined,
+    });
+
+    await expect(
+      optionsWithOrigin(`http://127.0.0.1:${target.server.port}`),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: `http://127.0.0.1:${target.server.port}`,
+    });
+
+    await expect(
+      optionsWithOrigin(`http://127.0.0.1:${target.server.port + 1}`),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: `http://127.0.0.1:${target.server.port + 1}`,
+    });
   });
 
   it(`test api: ${SDK.ServerAPI.API.Manifest}`, async () => {

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -42,6 +42,36 @@ describe('test server/apis/project.ts', () => {
     });
   }
 
+  function socketHandshakeWithOrigin(origin: string) {
+    return new Promise<{
+      statusCode: number;
+      allowOrigin: string | string[] | undefined;
+    }>((resolve, reject) => {
+      const url = new URL(target.server.origin);
+      const req = request(
+        {
+          hostname: url.hostname,
+          port: url.port,
+          path: '/socket.io/?EIO=4&transport=polling',
+          method: 'GET',
+          headers: { Origin: origin },
+        },
+        (res) => {
+          res.on('data', () => {});
+          res.on('close', () => {
+            resolve({
+              statusCode: res.statusCode || 0,
+              allowOrigin: res.headers['access-control-allow-origin'],
+            });
+          });
+        },
+      );
+
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
   it(`test api: ${SDK.ServerAPI.API.Env}`, async () => {
     const env = (await target.get(SDK.ServerAPI.API.Env)).toJSON();
 
@@ -69,6 +99,35 @@ describe('test server/apis/project.ts', () => {
     ).resolves.toStrictEqual({
       statusCode: 204,
       allowOrigin: `http://127.0.0.1:${target.server.port + 1}`,
+    });
+  });
+
+  it('only allows local Socket.IO origins', async () => {
+    await expect(
+      socketHandshakeWithOrigin('https://example.com'),
+    ).resolves.toStrictEqual({
+      statusCode: 403,
+      allowOrigin: undefined,
+    });
+
+    await expect(
+      socketHandshakeWithOrigin(`http://127.0.0.1:${target.server.port}`),
+    ).resolves.toStrictEqual({
+      statusCode: 200,
+      allowOrigin: `http://127.0.0.1:${target.server.port}`,
+    });
+  });
+
+  it('uses the bound host for socket URLs', async () => {
+    const socket = (
+      target.server as unknown as {
+        socketUrl: { port: number; socketUrl: string };
+      }
+    ).socketUrl;
+
+    expect(socket).toStrictEqual({
+      port: target.server.port,
+      socketUrl: `ws://127.0.0.1:${target.server.port}`,
     });
   });
 

--- a/packages/utils/src/build/server.ts
+++ b/packages/utils/src/build/server.ts
@@ -2,12 +2,14 @@ import connect from 'connect';
 import http from 'http';
 import os from 'os';
 import gp from 'get-port';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { Thirdparty } from '@rsdoctor/types';
 import { random } from '../common/algorithm';
 
 // see https://neo4j.com/developer/kb/list-of-restricted-ports-in-browsers
 const RESTRICTED_PORTS = [3659, 4045, 6000, 6665, 6666, 6667, 6668, 6669];
+
+export const defaultHost = '127.0.0.1';
 
 function getRandomPort(min: number, max: number) {
   let port: number;
@@ -19,21 +21,24 @@ function getRandomPort(min: number, max: number) {
 
 export const defaultPort = getRandomPort(3000, 8999);
 
-export async function getPort(expectPort: number) {
-  return gp({ port: expectPort });
+export async function getPort(expectPort: number, host = defaultHost) {
+  return gp({ port: expectPort, host });
 }
 
-export const createGetPortSyncFunctionString = (expectPort: number) =>
+export const createGetPortSyncFunctionString = (
+  expectPort: number,
+  host = defaultHost,
+) =>
   `
 (() => {
 const net = require('net');
 
-function getPort(expectPort) {
+function getPort(expectPort, host) {
   return new Promise((resolve, reject) => {
     const server = net.createServer();
     server.unref();
     server.on('error', reject);
-    server.listen(expectPort, () => {
+    server.listen(expectPort, host, () => {
       const { port } = server.address();
       server.close(() => {
         resolve(port);
@@ -46,7 +51,7 @@ async function getAvailablePort(expectPort) {
   let port = expectPort;
   while (true) {
     try {
-      const res = await getPort(port);
+      const res = await getPort(port, ${JSON.stringify(host)});
       return res;
     } catch (error) {
       port += Math.floor(Math.random() * 100 + 1);
@@ -58,13 +63,18 @@ getAvailablePort(${expectPort}).then(port => process.stdout.write(port.toString(
 })();
 `.trim();
 
-export function getPortSync(expectPort: number): number | never {
+export function getPortSync(
+  expectPort: number,
+  host = defaultHost,
+): number | never {
   const statement =
     os.EOL === '\n'
-      ? createGetPortSyncFunctionString(expectPort)
-      : createGetPortSyncFunctionString(expectPort).replace(/\n/g, '');
+      ? createGetPortSyncFunctionString(expectPort, host)
+      : createGetPortSyncFunctionString(expectPort, host).replace(/\n/g, '');
 
-  const port = execSync(`node -e "${statement}"`, { encoding: 'utf-8' });
+  const port = execFileSync(process.execPath, ['-e', statement], {
+    encoding: 'utf-8',
+  });
 
   return Number(port);
 }
@@ -73,7 +83,10 @@ export function createApp() {
   return connect();
 }
 
-export async function createServer(port: number): Promise<{
+export async function createServer(
+  port: number,
+  host = defaultHost,
+): Promise<{
   app: Thirdparty.connect.Server;
   server: http.Server;
   port: number;
@@ -103,8 +116,13 @@ export async function createServer(port: number): Promise<{
     },
   };
 
-  return new Promise<typeof res>((resolve) => {
-    server.listen(port, () => {
+  return new Promise<typeof res>((resolve, reject) => {
+    const onError = (error: Error) => {
+      reject(error);
+    };
+    server.once('error', onError);
+    server.listen(port, host, () => {
+      server.off('error', onError);
       resolve(res);
     });
   });

--- a/packages/utils/tests/server.test.ts
+++ b/packages/utils/tests/server.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from '@rstest/core';
+import type { AddressInfo } from 'net';
 import { Server } from '../src/build';
-import { getPortSync } from '../src/build/server';
+import {
+  createGetPortSyncFunctionString,
+  defaultHost,
+  getPortSync,
+} from '../src/build/server';
 
 describe('test src/server.ts', () => {
   it('getPort()', async () => {
@@ -17,5 +22,32 @@ describe('test src/server.ts', () => {
     const { close } = await Server.createServer(8262);
     expect(getPortSync(8262)).not.toEqual(8262);
     await close();
+  });
+
+  it('binds to 127.0.0.1 by default', async () => {
+    const { server, close } = await Server.createServer(0);
+
+    try {
+      const address = server.address() as AddressInfo;
+      expect(address.address).toEqual(defaultHost);
+      expect(createGetPortSyncFunctionString(3543)).toContain(
+        `getPort(port, ${JSON.stringify(defaultHost)})`,
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it('rejects when the requested port is already in use', async () => {
+    const { server, close } = await Server.createServer(0);
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      await expect(Server.createServer(port)).rejects.toMatchObject({
+        code: 'EADDRINUSE',
+      });
+    } finally {
+      await close();
+    }
   });
 });


### PR DESCRIPTION
Backports the report server hardening from #1741 to `v1.x`.

Changes:
- Bind the local report server to `127.0.0.1` by default and retry occupied ports safely.
- Restrict CORS to trusted local origins, while still allowing local cross-port bundle-diff access.
- Harden `LoadDataByKey` against invalid/prototype-style data keys.
- Port the router decorator registration compatibility needed by the v1.x toolchain.

