### PR TITLE
fix(sdk): restrict report server exposure

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testMatch: ['/cases/**/**.test.ts'],
   timeout: 60000,
-  workers: process.env.CI ? 1 : undefined,
   use: {
     launchOptions: {
       args: ['--experimental-modules', '--es-module-specifier-resolution=node'],

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testMatch: ['/cases/**/**.test.ts'],
   timeout: 60000,
+  workers: process.env.CI ? 1 : undefined,
   use: {
     launchOptions: {
       args: ['--experimental-modules', '--es-module-specifier-resolution=node'],

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -21,8 +21,13 @@ export * from './utils';
 /** Path for launch-editor: open file in editor from the UI (see https://github.com/yyx990803/launch-editor) */
 const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
 const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+const LISTEN_RETRY_LIMIT = 10;
 
 export type ISocketType = { port: number; socketUrl: string };
+
+function isAddressInUseError(error: unknown) {
+  return (error as { code?: string }).code === 'EADDRINUSE';
+}
 
 export class RsdoctorServer implements SDK.RsdoctorServerInstance {
   private _server!: Common.PromiseReturnType<typeof Server.createServer>;
@@ -115,15 +120,39 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     };
   }
 
+  private async createInnerServer() {
+    let expectedPort = this.port;
+    let lastError: unknown;
+
+    for (let retry = 0; retry < LISTEN_RETRY_LIMIT; retry++) {
+      const port = Server.getPortSync(expectedPort, this.host);
+
+      try {
+        return {
+          port,
+          server: await Server.createServer(port, this.host),
+        };
+      } catch (error) {
+        if (!isAddressInUseError(error)) {
+          throw error;
+        }
+        lastError = error;
+        expectedPort = port + 1;
+      }
+    }
+
+    throw lastError;
+  }
+
   async bootstrap() {
     if (!this.disposed) {
       return;
     }
 
-    const port = Server.getPortSync(this.port, this.host);
+    const { port, server } = await this.createInnerServer();
     // rewrite port when the default port is unavailable
     this.port = port;
-    this._server = await Server.createServer(port, this.host);
+    this._server = server;
     this._socket = new Socket({
       sdk: this.sdk,
       server: this._server.server,

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -4,7 +4,6 @@ import serve from 'sirv';
 import { Bundle, GlobalConfig } from '@rsdoctor/utils/common';
 import assert from 'assert';
 import bodyParser from 'body-parser';
-import cors from 'cors';
 import { PassThrough } from 'stream';
 import { Socket } from './socket';
 import { Router } from './router';
@@ -12,16 +11,16 @@ import * as APIs from './apis';
 import { chalk, logger } from '@rsdoctor/utils/logger';
 import { openBrowser } from '@/sdk/utils/openBrowser';
 import path from 'path';
-import { getLocalIpAddress } from './utils';
 import { Lodash } from '@rsdoctor/utils/common';
 import { createRequire } from 'module';
-import { ServerResponse } from 'http';
+import { IncomingMessage, ServerResponse } from 'http';
 
 const require = createRequire(import.meta.url);
 export * from './utils';
 
 /** Path for launch-editor: open file in editor from the UI (see https://github.com/yyx990803/launch-editor) */
 const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
 
 export type ISocketType = { port: number; socketUrl: string };
 
@@ -60,8 +59,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
   }
 
   public get host(): string {
-    const host = getLocalIpAddress();
-    return host;
+    return Server.defaultHost;
   }
 
   public get origin(): string {
@@ -79,15 +77,53 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     return this._innerClientPath;
   }
 
+  private isLocalOrigin(origin: string) {
+    try {
+      const url = new URL(origin);
+      return (
+        (url.protocol === 'http:' || url.protocol === 'https:') &&
+        LOCAL_HOSTNAMES.has(url.hostname)
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  private setCorsHeaders(req: IncomingMessage, res: ServerResponse) {
+    const origin = req.headers.origin;
+    if (typeof origin !== 'string' || !this.isLocalOrigin(origin)) {
+      return false;
+    }
+
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    return true;
+  }
+
+  private createSecurityMiddleware(): Thirdparty.connect.NextHandleFunction {
+    return (req, res, next) => {
+      const isCorsAllowed = this.setCorsHeaders(req, res);
+      if (req.method?.toUpperCase() === 'OPTIONS') {
+        res.statusCode = isCorsAllowed ? 204 : 403;
+        res.end();
+        return;
+      }
+
+      next();
+    };
+  }
+
   async bootstrap() {
     if (!this.disposed) {
       return;
     }
 
-    const port = Server.getPortSync(this.port);
+    const port = Server.getPortSync(this.port, this.host);
     // rewrite port when the default port is unavailable
     this.port = port;
-    this._server = await Server.createServer(port);
+    this._server = await Server.createServer(port, this.host);
     this._socket = new Socket({
       sdk: this.sdk,
       server: this._server.server,
@@ -103,7 +139,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
 
     this.disposed = false;
 
-    this.app.use(cors());
+    this.app.use(this.createSecurityMiddleware());
     this.app.use(bodyParser.json({ limit: '500mb' }));
     const clientHtmlPath = this._innerClientPath
       ? this._innerClientPath
@@ -199,9 +235,6 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
       if (m === method) {
         try {
           const body = await cb(req, res, next);
-
-          res.setHeader('Access-Control-Allow-Origin', '*');
-          res.setHeader('Access-Control-Allow-Credentials', 'true');
           res.statusCode = 200;
 
           if (Buffer.isBuffer(body)) {

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, rs } from '@rstest/core';
 import { Manifest, SDK } from '@rsdoctor/types';
 import { Manifest as ManifestShared } from '@rsdoctor/utils/common';
+import { request } from 'http';
 import { cwd, setupSDK } from '../../utils';
 import { getLocalIpAddress } from '../../../src/sdk/server/utils';
 
@@ -9,11 +10,66 @@ rs.setConfig({ testTimeout: 50000 });
 describe('test server/apis/project.ts', () => {
   const target = setupSDK();
 
+  function optionsWithOrigin(origin: string) {
+    return new Promise<{
+      statusCode: number;
+      allowOrigin: string | string[] | undefined;
+    }>((resolve, reject) => {
+      const url = new URL(
+        `${target.server.origin}${SDK.ServerAPI.API.Manifest}`,
+      );
+      const req = request(
+        {
+          hostname: url.hostname,
+          port: url.port,
+          path: url.pathname,
+          method: 'OPTIONS',
+          headers: { Origin: origin },
+        },
+        (res) => {
+          res.on('data', () => {});
+          res.on('close', () => {
+            resolve({
+              statusCode: res.statusCode || 0,
+              allowOrigin: res.headers['access-control-allow-origin'],
+            });
+          });
+        },
+      );
+
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
   it(`test api: ${SDK.ServerAPI.API.Env}`, async () => {
     const env = (await target.get(SDK.ServerAPI.API.Env)).toJSON();
 
     expect(env.ip).toEqual(getLocalIpAddress());
     expect(env.port).toEqual(target.server.port);
+  });
+
+  it('only allows local CORS preflight requests', async () => {
+    await expect(
+      optionsWithOrigin('https://example.com'),
+    ).resolves.toStrictEqual({
+      statusCode: 403,
+      allowOrigin: undefined,
+    });
+
+    await expect(
+      optionsWithOrigin(`http://127.0.0.1:${target.server.port}`),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: `http://127.0.0.1:${target.server.port}`,
+    });
+
+    await expect(
+      optionsWithOrigin(`http://127.0.0.1:${target.server.port + 1}`),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: `http://127.0.0.1:${target.server.port + 1}`,
+    });
   });
 
   it(`test api: ${SDK.ServerAPI.API.Manifest}`, async () => {

--- a/packages/utils/src/build/server.ts
+++ b/packages/utils/src/build/server.ts
@@ -116,8 +116,13 @@ export async function createServer(
     },
   };
 
-  return new Promise<typeof res>((resolve) => {
+  return new Promise<typeof res>((resolve, reject) => {
+    const onError = (error: Error) => {
+      reject(error);
+    };
+    server.once('error', onError);
     server.listen(port, host, () => {
+      server.off('error', onError);
       resolve(res);
     });
   });

--- a/packages/utils/src/build/server.ts
+++ b/packages/utils/src/build/server.ts
@@ -2,12 +2,14 @@ import connect from 'connect';
 import http from 'http';
 import os from 'os';
 import gp from 'get-port';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { Thirdparty } from '@rsdoctor/types';
 import { random } from '../common/algorithm';
 
 // see https://neo4j.com/developer/kb/list-of-restricted-ports-in-browsers
 const RESTRICTED_PORTS = [3659, 4045, 6000, 6665, 6666, 6667, 6668, 6669];
+
+export const defaultHost = '127.0.0.1';
 
 function getRandomPort(min: number, max: number) {
   let port: number;
@@ -19,21 +21,24 @@ function getRandomPort(min: number, max: number) {
 
 export const defaultPort = getRandomPort(3000, 8999);
 
-export async function getPort(expectPort: number) {
-  return gp({ port: expectPort });
+export async function getPort(expectPort: number, host = defaultHost) {
+  return gp({ port: expectPort, host });
 }
 
-export const createGetPortSyncFunctionString = (expectPort: number) =>
+export const createGetPortSyncFunctionString = (
+  expectPort: number,
+  host = defaultHost,
+) =>
   `
 (() => {
 const net = require('net');
 
-function getPort(expectPort) {
+function getPort(expectPort, host) {
   return new Promise((resolve, reject) => {
     const server = net.createServer();
     server.unref();
     server.on('error', reject);
-    server.listen(expectPort, () => {
+    server.listen(expectPort, host, () => {
       const { port } = server.address();
       server.close(() => {
         resolve(port);
@@ -46,7 +51,7 @@ async function getAvailablePort(expectPort) {
   let port = expectPort;
   while (true) {
     try {
-      const res = await getPort(port);
+      const res = await getPort(port, ${JSON.stringify(host)});
       return res;
     } catch (error) {
       port += Math.floor(Math.random() * 100 + 1);
@@ -58,13 +63,18 @@ getAvailablePort(${expectPort}).then(port => process.stdout.write(port.toString(
 })();
 `.trim();
 
-export function getPortSync(expectPort: number): number | never {
+export function getPortSync(
+  expectPort: number,
+  host = defaultHost,
+): number | never {
   const statement =
     os.EOL === '\n'
-      ? createGetPortSyncFunctionString(expectPort)
-      : createGetPortSyncFunctionString(expectPort).replace(/\n/g, '');
+      ? createGetPortSyncFunctionString(expectPort, host)
+      : createGetPortSyncFunctionString(expectPort, host).replace(/\n/g, '');
 
-  const port = execSync(`node -e "${statement}"`, { encoding: 'utf-8' });
+  const port = execFileSync(process.execPath, ['-e', statement], {
+    encoding: 'utf-8',
+  });
 
   return Number(port);
 }
@@ -73,7 +83,10 @@ export function createApp() {
   return connect();
 }
 
-export async function createServer(port: number): Promise<{
+export async function createServer(
+  port: number,
+  host = defaultHost,
+): Promise<{
   app: Thirdparty.connect.Server;
   server: http.Server;
   port: number;
@@ -104,7 +117,7 @@ export async function createServer(port: number): Promise<{
   };
 
   return new Promise<typeof res>((resolve) => {
-    server.listen(port, () => {
+    server.listen(port, host, () => {
       resolve(res);
     });
   });

--- a/packages/utils/tests/server.test.ts
+++ b/packages/utils/tests/server.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from '@rstest/core';
+import type { AddressInfo } from 'net';
 import { Server } from '../src/build';
-import { getPortSync } from '../src/build/server';
+import {
+  createGetPortSyncFunctionString,
+  defaultHost,
+  getPortSync,
+} from '../src/build/server';
 
 describe('test src/server.ts', () => {
   it('getPort()', async () => {
@@ -17,5 +22,19 @@ describe('test src/server.ts', () => {
     const { close } = await Server.createServer(8262);
     expect(getPortSync(8262)).not.toEqual(8262);
     await close();
+  });
+
+  it('binds to 127.0.0.1 by default', async () => {
+    const { server, close } = await Server.createServer(0);
+
+    try {
+      const address = server.address() as AddressInfo;
+      expect(address.address).toEqual(defaultHost);
+      expect(createGetPortSyncFunctionString(3543)).toContain(
+        `getPort(port, ${JSON.stringify(defaultHost)})`,
+      );
+    } finally {
+      await close();
+    }
   });
 });

--- a/packages/utils/tests/server.test.ts
+++ b/packages/utils/tests/server.test.ts
@@ -37,4 +37,17 @@ describe('test src/server.ts', () => {
       await close();
     }
   });
+
+  it('rejects when the requested port is already in use', async () => {
+    const { server, close } = await Server.createServer(0);
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      await expect(Server.createServer(port)).rejects.toMatchObject({
+        code: 'EADDRINUSE',
+      });
+    } finally {
+      await close();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Bind the local report server to `127.0.0.1` by default to avoid exposing it on all network interfaces.
- Replace wildcard HTTP CORS with a local-origin allowlist for report server requests.
- Remove unconditional `Access-Control-Allow-Origin: *` headers from API responses.
- Retry occupied report server ports，otherwise, the port occupation will report an error.

## Related Links

<!--- Provide links of related issues or pages -->
