### PR TITLE
refactor(sdk): use cors middleware allowlist

### DIFF
--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -4,6 +4,7 @@ import serve from 'sirv';
 import { Bundle, GlobalConfig } from '@rsdoctor/utils/common';
 import assert from 'assert';
 import bodyParser from 'body-parser';
+import cors from 'cors';
 import { PassThrough } from 'stream';
 import { Socket } from './socket';
 import { Router } from './router';
@@ -13,14 +14,15 @@ import { openBrowser } from '@/sdk/utils/openBrowser';
 import path from 'path';
 import { Lodash } from '@rsdoctor/utils/common';
 import { createRequire } from 'module';
-import { IncomingMessage, ServerResponse } from 'http';
+import { ServerResponse } from 'http';
 
 const require = createRequire(import.meta.url);
 export * from './utils';
 
 /** Path for launch-editor: open file in editor from the UI (see https://github.com/yyx990803/launch-editor) */
 const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
-const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+const LOCAL_ORIGIN_REGEXP =
+  /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/;
 const LISTEN_RETRY_LIMIT = 10;
 
 export type ISocketType = { port: number; socketUrl: string };
@@ -82,44 +84,6 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     return this._innerClientPath;
   }
 
-  private isLocalOrigin(origin: string) {
-    try {
-      const url = new URL(origin);
-      return (
-        (url.protocol === 'http:' || url.protocol === 'https:') &&
-        LOCAL_HOSTNAMES.has(url.hostname)
-      );
-    } catch {
-      return false;
-    }
-  }
-
-  private setCorsHeaders(req: IncomingMessage, res: ServerResponse) {
-    const origin = req.headers.origin;
-    if (typeof origin !== 'string' || !this.isLocalOrigin(origin)) {
-      return false;
-    }
-
-    res.setHeader('Access-Control-Allow-Origin', origin);
-    res.setHeader('Vary', 'Origin');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    return true;
-  }
-
-  private createSecurityMiddleware(): Thirdparty.connect.NextHandleFunction {
-    return (req, res, next) => {
-      const isCorsAllowed = this.setCorsHeaders(req, res);
-      if (req.method?.toUpperCase() === 'OPTIONS') {
-        res.statusCode = isCorsAllowed ? 204 : 403;
-        res.end();
-        return;
-      }
-
-      next();
-    };
-  }
-
   private async createInnerServer() {
     let expectedPort = this.port;
     let lastError: unknown;
@@ -168,7 +132,13 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
 
     this.disposed = false;
 
-    this.app.use(this.createSecurityMiddleware());
+    this.app.use(
+      cors({
+        origin: LOCAL_ORIGIN_REGEXP,
+        methods: ['GET', 'POST', 'OPTIONS'],
+        allowedHeaders: ['Content-Type'],
+      }),
+    );
     this.app.use(bodyParser.json({ limit: '500mb' }));
     const clientHtmlPath = this._innerClientPath
       ? this._innerClientPath

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -49,11 +49,11 @@ describe('test server/apis/project.ts', () => {
     expect(env.port).toEqual(target.server.port);
   });
 
-  it('only allows local CORS preflight requests', async () => {
+  it('only sets CORS headers for local preflight requests', async () => {
     await expect(
       optionsWithOrigin('https://example.com'),
     ).resolves.toStrictEqual({
-      statusCode: 403,
+      statusCode: 204,
       allowOrigin: undefined,
     });
 


### PR DESCRIPTION
## Summary

- Replace custom report server CORS header handling with the existing `cors` middleware.
- Keep the local-origin allowlist behavior via a default local-origin regexp.
- Adjust the preflight test so non-local origins simply receive no CORS allow-origin header.

## Tests

- `pnpm exec rstest run packages/utils/tests/server.test.ts`
- `pnpm exec rstest run packages/sdk/tests/server/apis/project.test.ts` (fails locally before executing assertions because `@rsdoctor/client/dist/index.html` is missing)

Follow-up for #1744.