### PR TITLE
feat: report server options

### DIFF
--- a/packages/ai/src/server/socket.ts
+++ b/packages/ai/src/server/socket.ts
@@ -5,14 +5,17 @@ import fs from 'node:fs';
 
 const map: Record<string, Socket> = {};
 
+function redactSocketToken(url: string) {
+  return url.replace(/([?&]token=)[^&]+/, '$1<redacted>');
+}
+
 // 使用 logger.error 输出日志
 export const createSocket = (url: string): Socket => {
-  logger.error(map[url]);
   if (map[url]) return map[url];
   const socket = io(url, {});
-  logger.error('socket created', url);
+  logger.error('socket created', redactSocketToken(url));
   socket.on('connect', () => {
-    logger.error(`Socket Connect ${url}`);
+    logger.error(`Socket Connect ${redactSocketToken(url)}`);
   });
   map[url] = socket;
   return socket;
@@ -38,10 +41,24 @@ export function getPortFromArgs(): number {
   return 3000;
 }
 
+export function getTokenFromArgs(): string | undefined {
+  const args = process.argv.slice(2); // Skip the first two elements
+  const tokenIndex = args.indexOf('--token');
+  const compilerIndex = args.indexOf('--compiler');
+  if (tokenIndex !== -1 && args[tokenIndex + 1]) {
+    return args[tokenIndex + 1];
+  }
+
+  return getMcpToken(
+    compilerIndex !== -1 ? args[compilerIndex + 1] : undefined,
+  );
+}
+
 export const getWsUrl = async () => {
   const port = getPortFromArgs();
+  const token = getTokenFromArgs();
   logger.error(`Socket will start on port: ${port}`);
-  return `ws://localhost:${port}`;
+  return `ws://localhost:${port}${token ? `?token=${token}` : ''}`;
 };
 
 export const sendRequest = async (api: string, params = {}) => {
@@ -73,4 +90,23 @@ export const getMcpPort = (compiler?: string) => {
   }
 
   return mcpJson.port;
+};
+
+export const getMcpToken = (compiler?: string) => {
+  const mcpPortFilePath = GlobalConfig.getMcpConfigPath();
+
+  if (!fs.existsSync(mcpPortFilePath)) {
+    return undefined;
+  }
+
+  const mcpJson = JSON.parse(fs.readFileSync(mcpPortFilePath, 'utf8'));
+
+  if (compiler) {
+    const compilerToken = mcpJson.tokenList?.[compiler];
+    if (compilerToken) {
+      return compilerToken;
+    }
+  }
+
+  return mcpJson.token;
 };

--- a/packages/ai/src/server/socket.ts
+++ b/packages/ai/src/server/socket.ts
@@ -41,24 +41,10 @@ export function getPortFromArgs(): number {
   return 3000;
 }
 
-export function getTokenFromArgs(): string | undefined {
-  const args = process.argv.slice(2); // Skip the first two elements
-  const tokenIndex = args.indexOf('--token');
-  const compilerIndex = args.indexOf('--compiler');
-  if (tokenIndex !== -1 && args[tokenIndex + 1]) {
-    return args[tokenIndex + 1];
-  }
-
-  return getMcpToken(
-    compilerIndex !== -1 ? args[compilerIndex + 1] : undefined,
-  );
-}
-
 export const getWsUrl = async () => {
   const port = getPortFromArgs();
-  const token = getTokenFromArgs();
   logger.error(`Socket will start on port: ${port}`);
-  return `ws://localhost:${port}${token ? `?token=${token}` : ''}`;
+  return `ws://localhost:${port}`;
 };
 
 export const sendRequest = async (api: string, params = {}) => {
@@ -90,23 +76,4 @@ export const getMcpPort = (compiler?: string) => {
   }
 
   return mcpJson.port;
-};
-
-export const getMcpToken = (compiler?: string) => {
-  const mcpPortFilePath = GlobalConfig.getMcpConfigPath();
-
-  if (!fs.existsSync(mcpPortFilePath)) {
-    return undefined;
-  }
-
-  const mcpJson = JSON.parse(fs.readFileSync(mcpPortFilePath, 'utf8'));
-
-  if (compiler) {
-    const compilerToken = mcpJson.tokenList?.[compiler];
-    if (compilerToken) {
-      return compilerToken;
-    }
-  }
-
-  return mcpJson.token;
 };

--- a/packages/ai/src/server/socket.ts
+++ b/packages/ai/src/server/socket.ts
@@ -9,7 +9,7 @@ function redactSocketToken(url: string) {
   return url.replace(/([?&]token=)[^&]+/, '$1<redacted>');
 }
 
-// 使用 logger.error 输出日志
+// Use logger.error to output logs.
 export const createSocket = (url: string): Socket => {
   if (map[url]) return map[url];
   const socket = io(url, {});

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -87,7 +87,12 @@ example: ${bin} ${Commands.Analyze} --profile "${Constants.RsdoctorOutputManifes
       sdk.getManifestData = () => json;
 
       const manifestBuffer = Buffer.from(
-        JSON.stringify({ ...json, __LOCAL__SERVER__: true }),
+        JSON.stringify({
+          ...json,
+          __LOCAL__SERVER__: true,
+          __SOCKET__PORT__: sdk.server.socketUrl.port.toString(),
+          __SOCKET__URL__: sdk.server.socketUrl.socketUrl,
+        }),
       );
 
       sdk.server.proxy(SDK.ServerAPI.API.Manifest, 'GET', () => manifestBuffer);

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -70,7 +70,16 @@ example: ${bin} ${Commands.Analyze} --profile "${Constants.RsdoctorOutputManifes
 
       spinner.text = `start server`;
 
-      const sdk = new RsdoctorSDK({ name, root: cwd, port, type });
+      const sdk = new RsdoctorSDK({
+        name,
+        root: cwd,
+        type,
+        config: {
+          server: {
+            port,
+          },
+        },
+      });
 
       await sdk.bootstrap();
 

--- a/packages/cli/src/commands/stats-analyze.ts
+++ b/packages/cli/src/commands/stats-analyze.ts
@@ -11,8 +11,12 @@ import { TransUtils } from '@rsdoctor/graph';
 interface Options {
   profile: string;
   open?: boolean;
-  port?: number;
+  port?: number | string;
   type?: SDK.ToDataType;
+}
+
+export function coercePort(port?: number | string) {
+  return typeof port === 'undefined' ? undefined : Number(port);
 }
 
 export const statsAnalyze: Command<
@@ -32,7 +36,8 @@ export const statsAnalyze: Command<
       .option('--port <number>', 'port for Rsdoctor Server')
       .option('--type <mode>', 'Bundle analysis mode (normal or lite)');
   },
-  async action({ profile, open = true, type = SDK.ToDataType.Normal }) {
+  async action({ profile, open = true, port, type = SDK.ToDataType.Normal }) {
+    const serverPort = coercePort(port);
     const spinner = ora({ prefixText: cyan(`[${name}]`) }).start(
       `start to loading "${profile}"`,
     );
@@ -46,7 +51,11 @@ export const statsAnalyze: Command<
       name: 'stats-analyze',
       root: process.cwd(),
       type,
-      noServer: false,
+      config: {
+        server: {
+          port: serverPort,
+        },
+      },
     });
 
     await sdk.bootstrap();

--- a/packages/components/src/utils/data/local.ts
+++ b/packages/components/src/utils/data/local.ts
@@ -5,11 +5,6 @@ import type { Socket } from 'socket.io-client';
 import { BaseDataLoader } from './base';
 import { getSocket } from '../socket';
 
-function getSocketToken(socketUrl: string) {
-  const tokenMatch = /[?&]token=([^&]+)/.exec(socketUrl);
-  return tokenMatch ? decodeURIComponent(tokenMatch[1]) : '';
-}
-
 export class LocalServerDataLoader extends BaseDataLoader {
   protected events: Map<
     SDK.ServerAPI.API | SDK.ServerAPI.APIExtends,
@@ -134,6 +129,6 @@ export class LocalServerDataLoader extends BaseDataLoader {
   protected getSocket(): Socket {
     const socketPort = this.get('__SOCKET__PORT__') ?? '';
     const socketUrl = this.get('__SOCKET__URL__') ?? '';
-    return getSocket(socketPort, getSocketToken(socketUrl));
+    return getSocket(socketPort, socketUrl);
   }
 }

--- a/packages/components/src/utils/data/local.ts
+++ b/packages/components/src/utils/data/local.ts
@@ -1,8 +1,14 @@
 import { Manifest as ManifestShared } from '@rsdoctor/utils/common';
 import { Common, Manifest, SDK } from '@rsdoctor/types';
 import { get } from 'es-toolkit/compat';
+import type { Socket } from 'socket.io-client';
 import { BaseDataLoader } from './base';
 import { getSocket } from '../socket';
+
+function getSocketToken(socketUrl: string) {
+  const tokenMatch = /[?&]token=([^&]+)/.exec(socketUrl);
+  return tokenMatch ? decodeURIComponent(tokenMatch[1]) : '';
+}
 
 export class LocalServerDataLoader extends BaseDataLoader {
   protected events: Map<
@@ -31,7 +37,7 @@ export class LocalServerDataLoader extends BaseDataLoader {
       if (ManifestShared.isShardingData(res)) {
         if (!this.shardingDataMap.has(key)) {
           const task = new Promise((resolve) => {
-            getSocket().emit(
+            this.getSocket().emit(
               SDK.ServerAPI.API.LoadDataByKey,
               { key },
               (
@@ -60,19 +66,18 @@ export class LocalServerDataLoader extends BaseDataLoader {
 
   public async loadAPI<
     T extends SDK.ServerAPI.API,
-    B extends
-      SDK.ServerAPI.InferRequestBodyType<T> = SDK.ServerAPI.InferRequestBodyType<T>,
-    R extends
-      SDK.ServerAPI.InferResponseType<T> = SDK.ServerAPI.InferResponseType<T>,
+    B extends SDK.ServerAPI.InferRequestBodyType<T> =
+      SDK.ServerAPI.InferRequestBodyType<T>,
+    R extends SDK.ServerAPI.InferResponseType<T> =
+      SDK.ServerAPI.InferResponseType<T>,
   >(...args: B extends void ? [api: T] : [api: T, body: B]): Promise<R> {
     const [api, body] = args;
     // request limitation key
     const key = body ? `${api}_${JSON.stringify(body)}` : `${api}`;
-    const socketPort = this.get('__SOCKET__PORT__') ?? '';
 
     return this.limit(key, async () => {
       return new Promise((resolve) => {
-        getSocket(socketPort).emit(
+        this.getSocket().emit(
           api,
           body,
           (res: SDK.ServerAPI.SocketResponseType<T>) => {
@@ -116,13 +121,19 @@ export class LocalServerDataLoader extends BaseDataLoader {
     }
 
     this.events.get(api)!.add(fn);
-    getSocket().on(api as string, fn);
+    this.getSocket().on(api as string, fn);
   }
 
   public removeOnDataUpdate<
     T extends SDK.ServerAPI.API | SDK.ServerAPI.APIExtends,
   >(api: T, fn: (response: SDK.ServerAPI.SocketResponseType<T>) => void) {
-    getSocket().off(api as string, fn);
+    this.getSocket().off(api as string, fn);
     this.events.get(api)!.delete(fn);
+  }
+
+  protected getSocket(): Socket {
+    const socketPort = this.get('__SOCKET__PORT__') ?? '';
+    const socketUrl = this.get('__SOCKET__URL__') ?? '';
+    return getSocket(socketPort, getSocketToken(socketUrl));
   }
 }

--- a/packages/components/src/utils/socket.ts
+++ b/packages/components/src/utils/socket.ts
@@ -26,14 +26,17 @@ function ensureSocket(socketUrl: string = defaultSocketUrl) {
   return map.get(socketUrl)!;
 }
 
-export function getSocket(socketPort?: string, socketToken?: string): Socket {
-  const socketUrl = formatURL({
-    port: socketPort,
-    hostname: location.hostname,
-    protocol: location.protocol,
-    token: socketToken,
-  });
-  const socket = ensureSocket(socketPort ? socketUrl : defaultSocketUrl);
+export function getSocket(socketPort?: string, socketUrl?: string): Socket {
+  const resolvedSocketUrl =
+    socketUrl ||
+    formatURL({
+      port: socketPort,
+      hostname: location.hostname,
+      protocol: location.protocol,
+    });
+  const socket = ensureSocket(
+    socketPort || socketUrl ? resolvedSocketUrl : defaultSocketUrl,
+  );
   return socket;
 }
 
@@ -41,27 +44,22 @@ export function formatURL({
   port,
   protocol,
   hostname,
-  token,
 }: {
   port?: string;
   protocol: string;
   hostname: string;
-  token?: string;
 }) {
   if (typeof URL !== 'undefined') {
     const url = new URL('http://localhost');
     url.port = String(port);
     url.hostname = hostname;
     url.protocol = location.protocol.includes('https') ? 'wss' : 'ws';
-    if (token) {
-      url.searchParams.set('token', token);
-    }
     return ipv4Pattern.test(hostname) || hostname.includes('localhost')
       ? url.toString()
-      : `${protocol}//${hostname}${token ? `?token=${token}` : ''}`;
+      : `${protocol}//${hostname}`;
   }
 
   // compatible with IE11
   const colon = protocol.indexOf(':') === -1 ? ':' : '';
-  return `${protocol}${colon}//${hostname}:${port}${token ? `?token=${token}` : ''}`;
+  return `${protocol}${colon}//${hostname}:${port}`;
 }

--- a/packages/components/src/utils/socket.ts
+++ b/packages/components/src/utils/socket.ts
@@ -11,22 +11,27 @@ const defaultSocketUrl =
 const ipv4Pattern =
   /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
 
+function redactSocketToken(socketUrl: string) {
+  return socketUrl.replace(/([?&]token=)[^&]+/, '$1<redacted>');
+}
+
 function ensureSocket(socketUrl: string = defaultSocketUrl) {
   if (!map.has(socketUrl)) {
     const socket = io(socketUrl, {});
     socket.on('connect', () => {
-      console.log(`Socket Connect ${socketUrl}`);
+      console.log(`Socket Connect ${redactSocketToken(socketUrl)}`);
     });
     map.set(socketUrl, socket);
   }
   return map.get(socketUrl)!;
 }
 
-export function getSocket(socketPort?: string): Socket {
+export function getSocket(socketPort?: string, socketToken?: string): Socket {
   const socketUrl = formatURL({
     port: socketPort,
     hostname: location.hostname,
     protocol: location.protocol,
+    token: socketToken,
   });
   const socket = ensureSocket(socketPort ? socketUrl : defaultSocketUrl);
   return socket;
@@ -36,22 +41,27 @@ export function formatURL({
   port,
   protocol,
   hostname,
+  token,
 }: {
   port?: string;
   protocol: string;
   hostname: string;
+  token?: string;
 }) {
   if (typeof URL !== 'undefined') {
     const url = new URL('http://localhost');
     url.port = String(port);
     url.hostname = hostname;
     url.protocol = location.protocol.includes('https') ? 'wss' : 'ws';
+    if (token) {
+      url.searchParams.set('token', token);
+    }
     return ipv4Pattern.test(hostname) || hostname.includes('localhost')
       ? url.toString()
-      : `${protocol}//${hostname}`;
+      : `${protocol}//${hostname}${token ? `?token=${token}` : ''}`;
   }
 
   // compatible with IE11
   const colon = protocol.indexOf(':') === -1 ? ':' : '';
-  return `${protocol}${colon}//${hostname}:${port}`;
+  return `${protocol}${colon}//${hostname}:${port}${token ? `?token=${token}` : ''}`;
 }

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -102,6 +102,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     output = outputConfig,
     supports = getDefaultSupports(),
     port,
+    server: userServer = {},
     printLog = { serverUrls: true },
     mode = undefined,
     brief = undefined,
@@ -118,6 +119,14 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
   assert(typeof features === 'object' || Array.isArray(features));
   assert(typeof loaderInterceptorOptions === 'object');
   assert(typeof disableClientServer === 'boolean');
+  assert(typeof port === 'undefined' || typeof port === 'number');
+  assert(typeof userServer === 'object' && userServer !== null);
+  const server: SDK.RsdoctorServerConfig = {
+    ...userServer,
+  };
+  if (typeof server.port === 'undefined' && typeof port !== 'undefined') {
+    server.port = port;
+  }
   let finalMode: keyof typeof SDK.IMode =
     ('mode' in output && isValidMode(output.mode)
       ? output.mode === ('lite' as SDK.IMode.normal)
@@ -175,6 +184,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     innerClientPath,
     supports,
     port,
+    server,
     printLog,
   };
 

--- a/packages/core/tests/build/utils/config.test.ts
+++ b/packages/core/tests/build/utils/config.test.ts
@@ -318,6 +318,73 @@ describe('normalizeUserConfig', () => {
     });
   });
 
+  describe('server configuration', () => {
+    it('should preserve port and apply it to server.port', () => {
+      const result = normalizeUserConfig({
+        port: 9876,
+      });
+
+      expect(result.port).toBe(9876);
+      expect(result.server.port).toBe(9876);
+    });
+
+    it('should preserve server.port', () => {
+      const result = normalizeUserConfig({
+        server: {
+          port: 9876,
+        },
+      });
+
+      expect(result.server.port).toBe(9876);
+    });
+
+    it('should prefer server.port over port', () => {
+      const result = normalizeUserConfig({
+        port: 9876,
+        server: {
+          port: 9877,
+        },
+      });
+
+      expect(result.port).toBe(9876);
+      expect(result.server.port).toBe(9877);
+    });
+
+    it('should preserve server.cors options', () => {
+      const result = normalizeUserConfig({
+        server: {
+          cors: {
+            origin: 'https://example.com',
+            credentials: true,
+          },
+        },
+      });
+
+      expect(result.server.cors).toEqual({
+        origin: 'https://example.com',
+        credentials: true,
+      });
+    });
+
+    it('should preserve server.cors boolean values', () => {
+      expect(
+        normalizeUserConfig({
+          server: {
+            cors: false,
+          },
+        }).server.cors,
+      ).toBe(false);
+
+      expect(
+        normalizeUserConfig({
+          server: {
+            cors: true,
+          },
+        }).server.cors,
+      ).toBe(true);
+    });
+  });
+
   describe('output.reportCodeType', () => {
     it('should return NoCode when mode is brief regardless of reportCodeType', () => {
       const result = normalizeUserConfig({

--- a/packages/rspack-plugin/src/multiple.ts
+++ b/packages/rspack-plugin/src/multiple.ts
@@ -32,6 +32,7 @@ export class RsdoctorRspackMultiplePlugin<
       extraConfig: {
         innerClientPath: normallizedOptions.innerClientPath,
         printLog: normallizedOptions.printLog,
+        server: normallizedOptions.server,
         mode: normallizedOptions.output.mode
           ? normallizedOptions.output.mode
           : undefined,

--- a/packages/rspack-plugin/src/plugin.ts
+++ b/packages/rspack-plugin/src/plugin.ts
@@ -41,9 +41,9 @@ import { logger, time, timeEnd } from '@rsdoctor/utils/logger';
 // Static flag to ensure greet message is only printed once per process
 let hasGreeted = false;
 
-export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
-  implements RsdoctorRspackPluginInstance<Rules>
-{
+export class RsdoctorRspackPlugin<
+  Rules extends Linter.ExtendRuleData[],
+> implements RsdoctorRspackPluginInstance<Rules> {
   public readonly name = pluginTapName;
 
   public readonly sdk: SDK.RsdoctorBuilderSDKInstance | RsdoctorPrimarySDK;
@@ -68,7 +68,7 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
         },
       }),
     );
-    const { port, output, innerClientPath, printLog, sdkInstance } =
+    const { port, server, output, innerClientPath, printLog, sdkInstance } =
       this.options;
 
     this.sdk =
@@ -81,6 +81,7 @@ export class RsdoctorRspackPlugin<Rules extends Linter.ExtendRuleData[]>
         config: {
           innerClientPath,
           printLog,
+          server,
           mode: output.mode ? output.mode : undefined,
           brief:
             output.mode === SDK.IMode[SDK.IMode.brief]

--- a/packages/sdk/src/sdk/multiple/primary.ts
+++ b/packages/sdk/src/sdk/multiple/primary.ts
@@ -42,16 +42,24 @@ export class RsdoctorPrimarySDK
     extraConfig,
     type,
   }: RsdoctorSlaveSDKOptions) {
-    super({ name, root: controller.root });
+    super({
+      name,
+      root: controller.root,
+      config: extraConfig,
+    });
 
     const lastSdk = controller.getLastSdk();
-    const port = lastSdk ? lastSdk.server.port + 1 : this.server.port;
+    const port = lastSdk
+      ? lastSdk.server.port + 1
+      : (extraConfig?.server?.port ?? this.server.port);
 
     this.id = id++;
     this.stage = typeof stage === 'number' ? stage : 1;
     this.extraConfig = extraConfig;
     this.parent = controller;
-    this.server = new RsdoctorSlaveServer(this, port);
+    this.server = new RsdoctorSlaveServer(this, port, {
+      cors: extraConfig?.server?.cors,
+    });
     this.type = type;
     this.setName(name);
     this.clearSwitch();

--- a/packages/sdk/src/sdk/multiple/server.ts
+++ b/packages/sdk/src/sdk/multiple/server.ts
@@ -1,12 +1,16 @@
 import { Server } from '@rsdoctor/utils/build';
-import { RsdoctorServer } from '../server';
+import { RsdoctorServer, type RsdoctorServerOptions } from '../server';
 import type { RsdoctorPrimarySDK } from './primary';
 
 export class RsdoctorSlaveServer extends RsdoctorServer {
   protected sdk: RsdoctorPrimarySDK;
 
-  constructor(sdk: RsdoctorPrimarySDK, port = Server.defaultPort) {
-    super(sdk, port);
+  constructor(
+    sdk: RsdoctorPrimarySDK,
+    port = Server.defaultPort,
+    config?: RsdoctorServerOptions,
+  ) {
+    super(sdk, port, config);
     this.sdk = sdk;
   }
 

--- a/packages/sdk/src/sdk/sdk/index.ts
+++ b/packages/sdk/src/sdk/sdk/index.ts
@@ -60,11 +60,14 @@ export class RsdoctorSDK<
 
   constructor(options: T) {
     super(options);
+    const serverConfig = options.config?.server;
+    const port = serverConfig?.port ?? options.port;
     this.server = options.config?.noServer
-      ? new RsdoctorFakeServer(this, undefined)
-      : new RsdoctorServer(this, options.port, {
+      ? new RsdoctorFakeServer(this, port)
+      : new RsdoctorServer(this, port, {
           innerClientPath: options.config?.innerClientPath || '',
           printServerUrl: options.config?.printLog?.serverUrls,
+          cors: serverConfig?.cors,
         });
     this.type = Lodash.isNumber(options.type)
       ? options.type

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -16,7 +16,11 @@ import { Lodash } from '@rsdoctor/utils/common';
 import { createRequire } from 'module';
 import { ServerResponse } from 'http';
 import { randomBytes } from 'crypto';
-import { DEFAULT_ALLOWED_CORS_ORIGINS, isAllowedRequestHost } from './security';
+import {
+  DEFAULT_ALLOWED_CORS_ORIGINS,
+  isAllowedCorsRequest,
+  isAllowedRequestHost,
+} from './security';
 
 const require = createRequire(import.meta.url);
 export * from './utils';
@@ -26,12 +30,6 @@ const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
 const LISTEN_RETRY_LIMIT = 10;
 
 export type ISocketType = { port: number; socketUrl: string; token: string };
-
-export type RsdoctorServerOptions = {
-  innerClientPath?: string;
-  printServerUrl?: boolean;
-  cors?: SDK.RsdoctorServerConfig['cors'];
-};
 
 export type RsdoctorServerOptions = {
   innerClientPath?: string;
@@ -171,13 +169,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     });
     await this._socket.bootstrap();
 
-    (
-      GlobalConfig.writeMcpPort as (
-        port: number,
-        builderName?: string,
-        token?: string,
-      ) => void
-    )(this.port, this.sdk.name, this._socketToken);
+    GlobalConfig.writeMcpPort(this.port, this.sdk.name);
 
     logger.debug(
       `Successfully wrote mcp.json for ${chalk.cyan(this.sdk.name)} builder`,
@@ -195,10 +187,26 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
 
       next();
     });
+    if (
+      corsOptions !== false &&
+      corsOptions.origin === DEFAULT_ALLOWED_CORS_ORIGINS
+    ) {
+      this.app.use((req, res, next) => {
+        const host = req.headers.host || req.headers[':authority'];
+        if (!isAllowedCorsRequest(req.headers.origin, host)) {
+          res.statusCode = 403;
+          res.end();
+          return;
+        }
+
+        next();
+      });
+    }
     if (corsOptions !== false) {
       this.app.use(cors(corsOptions));
     }
     this.app.use(bodyParser.json({ limit: '500mb' }));
+    await this._router.setup();
 
     const clientHtmlPath = this._innerClientPath
       ? this._innerClientPath

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -15,11 +15,8 @@ import path from 'path';
 import { Lodash } from '@rsdoctor/utils/common';
 import { createRequire } from 'module';
 import { ServerResponse } from 'http';
-import {
-  DEFAULT_ALLOWED_CORS_ORIGINS,
-  isAllowedCorsRequest,
-  isAllowedRequestHost,
-} from './security';
+import { randomBytes } from 'crypto';
+import { DEFAULT_ALLOWED_CORS_ORIGINS, isAllowedRequestHost } from './security';
 
 const require = createRequire(import.meta.url);
 export * from './utils';
@@ -28,7 +25,13 @@ export * from './utils';
 const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
 const LISTEN_RETRY_LIMIT = 10;
 
-export type ISocketType = { port: number; socketUrl: string };
+export type ISocketType = { port: number; socketUrl: string; token: string };
+
+export type RsdoctorServerOptions = {
+  innerClientPath?: string;
+  printServerUrl?: boolean;
+  cors?: SDK.RsdoctorServerConfig['cors'];
+};
 
 export type RsdoctorServerOptions = {
   innerClientPath?: string;
@@ -56,6 +59,8 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
   private _printServerUrl: boolean;
 
   private _cors: SDK.RsdoctorServerConfig['cors'];
+
+  private _socketToken = randomBytes(16).toString('hex');
 
   constructor(
     protected sdk: SDK.RsdoctorBuilderSDKInstance,
@@ -88,7 +93,8 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
   public get socketUrl(): ISocketType {
     return {
       port: this.port,
-      socketUrl: `ws://localhost:${this.port}`,
+      socketUrl: `ws://localhost:${this.port}?token=${this._socketToken}`,
+      token: this._socketToken,
     };
   }
 
@@ -120,20 +126,25 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     throw lastError;
   }
 
-  private resolveCorsOptions():
-    | false
-    | SDK.RsdoctorServerCorsOptions
-    | undefined {
-    if (typeof this._cors === 'undefined') {
-      return undefined;
-    }
+  private resolveCorsOptions(): false | SDK.RsdoctorServerCorsOptions {
     if (this._cors === false) {
       return false;
     }
     if (this._cors === true) {
       return {};
     }
-    return this._cors;
+    if (typeof this._cors === 'undefined') {
+      return {
+        origin: DEFAULT_ALLOWED_CORS_ORIGINS,
+      };
+    }
+    return {
+      ...this._cors,
+      origin:
+        typeof this._cors.origin === 'undefined'
+          ? DEFAULT_ALLOWED_CORS_ORIGINS
+          : this._cors.origin,
+    };
   }
 
   async bootstrap() {
@@ -150,8 +161,9 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
       sdk: this.sdk,
       server: this._server.server,
       port: this.port,
+      token: this._socketToken,
       socketOptions:
-        corsOptions === false || typeof corsOptions === 'undefined'
+        corsOptions === false
           ? undefined
           : {
               cors: corsOptions,
@@ -159,7 +171,13 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     });
     await this._socket.bootstrap();
 
-    GlobalConfig.writeMcpPort(this.port, this.sdk.name);
+    (
+      GlobalConfig.writeMcpPort as (
+        port: number,
+        builderName?: string,
+        token?: string,
+      ) => void
+    )(this.port, this.sdk.name, this._socketToken);
 
     logger.debug(
       `Successfully wrote mcp.json for ${chalk.cyan(this.sdk.name)} builder`,
@@ -177,27 +195,10 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
 
       next();
     });
-    if (typeof corsOptions === 'undefined') {
-      this.app.use((req, res, next) => {
-        const host = req.headers.host || req.headers[':authority'];
-        if (!isAllowedCorsRequest(req.headers.origin, host)) {
-          res.statusCode = 403;
-          res.end();
-          return;
-        }
-
-        next();
-      });
-      this.app.use(
-        cors({
-          origin: DEFAULT_ALLOWED_CORS_ORIGINS,
-        }),
-      );
-    } else if (corsOptions !== false) {
+    if (corsOptions !== false) {
       this.app.use(cors(corsOptions));
     }
     this.app.use(bodyParser.json({ limit: '500mb' }));
-    await this._router.setup();
 
     const clientHtmlPath = this._innerClientPath
       ? this._innerClientPath

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -4,6 +4,7 @@ import serve from 'sirv';
 import { Bundle, GlobalConfig } from '@rsdoctor/utils/common';
 import assert from 'assert';
 import bodyParser from 'body-parser';
+import cors from 'cors';
 import { PassThrough } from 'stream';
 import { Socket } from './socket';
 import { Router } from './router';
@@ -14,7 +15,11 @@ import path from 'path';
 import { Lodash } from '@rsdoctor/utils/common';
 import { createRequire } from 'module';
 import { ServerResponse } from 'http';
-import { DEFAULT_ALLOWED_CORS_ORIGINS, isAllowedRequestHost } from './security';
+import {
+  DEFAULT_ALLOWED_CORS_ORIGINS,
+  isAllowedCorsRequest,
+  isAllowedRequestHost,
+} from './security';
 
 const require = createRequire(import.meta.url);
 export * from './utils';
@@ -24,6 +29,12 @@ const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
 const LISTEN_RETRY_LIMIT = 10;
 
 export type ISocketType = { port: number; socketUrl: string };
+
+export type RsdoctorServerOptions = {
+  innerClientPath?: string;
+  printServerUrl?: boolean;
+  cors?: SDK.RsdoctorServerConfig['cors'];
+};
 
 function isAddressInUseError(error: unknown) {
   return (error as { code?: string }).code === 'EADDRINUSE';
@@ -44,10 +55,12 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
 
   private _printServerUrl: boolean;
 
+  private _cors: SDK.RsdoctorServerConfig['cors'];
+
   constructor(
     protected sdk: SDK.RsdoctorBuilderSDKInstance,
     port = Server.defaultPort,
-    config?: { innerClientPath?: string; printServerUrl?: boolean },
+    config?: RsdoctorServerOptions,
   ) {
     assert(typeof port === 'number');
     // maybe the port will be rewrite in bootstrap()
@@ -57,6 +70,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     this._printServerUrl = Lodash.isUndefined(config?.printServerUrl)
       ? true
       : config?.printServerUrl;
+    this._cors = config?.cors;
   }
 
   public get app(): SDK.RsdoctorServerInstance['app'] {
@@ -106,12 +120,29 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     throw lastError;
   }
 
+  private resolveCorsOptions():
+    | false
+    | SDK.RsdoctorServerCorsOptions
+    | undefined {
+    if (typeof this._cors === 'undefined') {
+      return undefined;
+    }
+    if (this._cors === false) {
+      return false;
+    }
+    if (this._cors === true) {
+      return {};
+    }
+    return this._cors;
+  }
+
   async bootstrap() {
     if (!this.disposed) {
       return;
     }
 
     const { port, server } = await this.createInnerServer();
+    const corsOptions = this.resolveCorsOptions();
     // rewrite port when the default port is unavailable
     this.port = port;
     this._server = server;
@@ -119,6 +150,12 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
       sdk: this.sdk,
       server: this._server.server,
       port: this.port,
+      socketOptions:
+        corsOptions === false || typeof corsOptions === 'undefined'
+          ? undefined
+          : {
+              cors: corsOptions,
+            },
     });
     await this._socket.bootstrap();
 
@@ -129,7 +166,6 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     );
 
     this.disposed = false;
-    const { default: cors } = await import('cors');
 
     this.app.use((req, res, next) => {
       const host = req.headers.host || req.headers[':authority'];
@@ -141,12 +177,28 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
 
       next();
     });
-    this.app.use(
-      cors({
-        origin: DEFAULT_ALLOWED_CORS_ORIGINS,
-      }),
-    );
+    if (typeof corsOptions === 'undefined') {
+      this.app.use((req, res, next) => {
+        const host = req.headers.host || req.headers[':authority'];
+        if (!isAllowedCorsRequest(req.headers.origin, host)) {
+          res.statusCode = 403;
+          res.end();
+          return;
+        }
+
+        next();
+      });
+      this.app.use(
+        cors({
+          origin: DEFAULT_ALLOWED_CORS_ORIGINS,
+        }),
+      );
+    } else if (corsOptions !== false) {
+      this.app.use(cors(corsOptions));
+    }
     this.app.use(bodyParser.json({ limit: '500mb' }));
+    await this._router.setup();
+
     const clientHtmlPath = this._innerClientPath
       ? this._innerClientPath
       : require.resolve('@rsdoctor/client');
@@ -209,8 +261,6 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
         }
       },
     );
-
-    await this._router.setup();
 
     process.once('exit', () => this.dispose());
     process.once('SIGINT', () => this.dispose(0));

--- a/packages/sdk/src/sdk/server/security.ts
+++ b/packages/sdk/src/sdk/server/security.ts
@@ -15,6 +15,17 @@ export function isAllowedRequestOrigin(origin: string | string[] | undefined) {
   );
 }
 
+function getHostnameFromOrigin(origin: string) {
+  try {
+    const hostname = new URL(origin).hostname.toLowerCase();
+    return hostname.startsWith('[') && hostname.endsWith(']')
+      ? hostname.slice(1, -1)
+      : hostname;
+  } catch {
+    return '';
+  }
+}
+
 function isIpAddress(hostname: string) {
   return isIP(hostname) !== 0;
 }
@@ -35,4 +46,29 @@ export function isAllowedRequestHost(host: string | string[] | undefined) {
 
   const hostname = getHostnameFromHost(host).toLowerCase();
   return LOCAL_HOSTNAMES.test(hostname) || isIpAddress(hostname);
+}
+
+export function isAllowedCorsRequest(
+  origin: string | string[] | undefined,
+  host: string | string[] | undefined,
+) {
+  if (origin === undefined) {
+    return true;
+  }
+  if (
+    typeof origin !== 'string' ||
+    typeof host !== 'string' ||
+    !isAllowedRequestOrigin(origin)
+  ) {
+    return false;
+  }
+
+  const originHostname = getHostnameFromOrigin(origin);
+  const hostHostname = getHostnameFromHost(host).toLowerCase();
+
+  if (originHostname.endsWith('.localhost')) {
+    return originHostname === hostHostname;
+  }
+
+  return true;
 }

--- a/packages/sdk/src/sdk/server/socket/index.ts
+++ b/packages/sdk/src/sdk/server/socket/index.ts
@@ -7,60 +7,22 @@ import {
 } from 'socket.io';
 import { isDeepStrictEqual } from 'util';
 import { SocketAPILoader } from './api';
-import { isAllowedRequestHost, isAllowedRequestOrigin } from '../security';
+import { isAllowedRequestHost } from '../security';
 
 interface SocketOptions {
   sdk: SDK.RsdoctorBuilderSDKInstance;
   server: Server;
   port: number;
+  token: string;
   socketOptions?: Partial<SocketServerOptions>;
 }
 
-function isAllowedCorsOrigin(
-  origin: string | undefined,
-  allowedOrigin: SDK.RsdoctorServerCorsStaticOrigin | undefined,
-  defaultAllowed: boolean,
-): boolean {
-  if (origin === undefined) {
-    return true;
+function isAllowedSocketToken(url: string | undefined, token: string) {
+  if (!url) {
+    return false;
   }
 
-  if (typeof allowedOrigin === 'undefined') {
-    return defaultAllowed;
-  }
-
-  if (typeof allowedOrigin === 'boolean') {
-    return allowedOrigin;
-  }
-
-  if (typeof allowedOrigin === 'string') {
-    return allowedOrigin === '*' || allowedOrigin === origin;
-  }
-
-  if (Array.isArray(allowedOrigin)) {
-    return allowedOrigin.some((item) =>
-      isAllowedCorsOrigin(origin, item, defaultAllowed),
-    );
-  }
-
-  return allowedOrigin.test(origin);
-}
-
-function checkCorsOrigin(
-  origin: string | undefined,
-  corsOptions: SDK.RsdoctorServerCorsOptions | undefined,
-  callback: (allowed: boolean) => void,
-) {
-  const allowedOrigin = corsOptions?.origin;
-
-  if (typeof allowedOrigin === 'function') {
-    allowedOrigin(origin, (err, result) => {
-      callback(!err && isAllowedCorsOrigin(origin, result, false));
-    });
-    return;
-  }
-
-  callback(isAllowedCorsOrigin(origin, allowedOrigin, true));
+  return new URL(url, 'http://localhost').searchParams.get('token') === token;
 }
 
 export class Socket {
@@ -77,20 +39,15 @@ export class Socket {
 
   public bootstrap() {
     const { socketOptions } = this.options;
-    const hasCustomCorsOptions = typeof socketOptions?.cors !== 'undefined';
 
     this.io = new SocketServer(this.options.server, {
       ...socketOptions,
-      cors: hasCustomCorsOptions
-        ? socketOptions?.cors
-        : {
-            origin: (origin, callback) => {
-              callback(null, isAllowedRequestOrigin(origin));
-            },
-          },
       allowRequest: (req, callback) => {
         const host = req.headers.host || req.headers[':authority'];
-        if (!isAllowedRequestHost(host)) {
+        if (
+          !isAllowedRequestHost(host) ||
+          !isAllowedSocketToken(req.url, this.options.token)
+        ) {
           callback(null, false);
           return;
         }

--- a/packages/sdk/src/sdk/server/socket/index.ts
+++ b/packages/sdk/src/sdk/server/socket/index.ts
@@ -13,7 +13,54 @@ interface SocketOptions {
   sdk: SDK.RsdoctorBuilderSDKInstance;
   server: Server;
   port: number;
-  socketOptions?: SocketServerOptions;
+  socketOptions?: Partial<SocketServerOptions>;
+}
+
+function isAllowedCorsOrigin(
+  origin: string | undefined,
+  allowedOrigin: SDK.RsdoctorServerCorsStaticOrigin | undefined,
+  defaultAllowed: boolean,
+): boolean {
+  if (origin === undefined) {
+    return true;
+  }
+
+  if (typeof allowedOrigin === 'undefined') {
+    return defaultAllowed;
+  }
+
+  if (typeof allowedOrigin === 'boolean') {
+    return allowedOrigin;
+  }
+
+  if (typeof allowedOrigin === 'string') {
+    return allowedOrigin === '*' || allowedOrigin === origin;
+  }
+
+  if (Array.isArray(allowedOrigin)) {
+    return allowedOrigin.some((item) =>
+      isAllowedCorsOrigin(origin, item, defaultAllowed),
+    );
+  }
+
+  return allowedOrigin.test(origin);
+}
+
+function checkCorsOrigin(
+  origin: string | undefined,
+  corsOptions: SDK.RsdoctorServerCorsOptions | undefined,
+  callback: (allowed: boolean) => void,
+) {
+  const allowedOrigin = corsOptions?.origin;
+
+  if (typeof allowedOrigin === 'function') {
+    allowedOrigin(origin, (err, result) => {
+      callback(!err && isAllowedCorsOrigin(origin, result, false));
+    });
+    return;
+  }
+
+  callback(isAllowedCorsOrigin(origin, allowedOrigin, true));
 }
 
 export class Socket {
@@ -30,37 +77,52 @@ export class Socket {
 
   public bootstrap() {
     const { socketOptions } = this.options;
-    const corsOptions =
-      socketOptions?.cors &&
-      typeof socketOptions.cors === 'object' &&
-      !Array.isArray(socketOptions.cors)
-        ? socketOptions.cors
-        : {};
+    const hasCustomCorsOptions = typeof socketOptions?.cors !== 'undefined';
 
     this.io = new SocketServer(this.options.server, {
       ...socketOptions,
-      cors: {
-        ...corsOptions,
-        origin: (origin, callback) => {
-          callback(null, isAllowedRequestOrigin(origin));
-        },
-      },
+      cors: hasCustomCorsOptions
+        ? socketOptions?.cors
+        : {
+            origin: (origin, callback) => {
+              callback(null, isAllowedRequestOrigin(origin));
+            },
+          },
       allowRequest: (req, callback) => {
         const host = req.headers.host || req.headers[':authority'];
-        if (
-          !isAllowedRequestHost(host) ||
-          !isAllowedRequestOrigin(req.headers.origin)
-        ) {
+        if (!isAllowedRequestHost(host)) {
           callback(null, false);
           return;
         }
 
-        if (socketOptions?.allowRequest) {
-          socketOptions.allowRequest(req, callback);
-          return;
-        }
+        const origin = Array.isArray(req.headers.origin)
+          ? req.headers.origin[0]
+          : req.headers.origin;
+        const checkOrigin = hasCustomCorsOptions
+          ? (next: (allowed: boolean) => void) => {
+              checkCorsOrigin(
+                origin,
+                socketOptions?.cors as SDK.RsdoctorServerCorsOptions,
+                next,
+              );
+            }
+          : (next: (allowed: boolean) => void) => {
+              next(isAllowedRequestOrigin(origin));
+            };
 
-        callback(null, true);
+        checkOrigin((allowed) => {
+          if (!allowed) {
+            callback(null, false);
+            return;
+          }
+
+          if (socketOptions?.allowRequest) {
+            socketOptions.allowRequest(req, callback);
+            return;
+          }
+
+          callback(null, true);
+        });
       },
     });
     this.io.on('connection', (socket) => {

--- a/packages/sdk/src/sdk/server/socket/index.ts
+++ b/packages/sdk/src/sdk/server/socket/index.ts
@@ -52,34 +52,12 @@ export class Socket {
           return;
         }
 
-        const origin = Array.isArray(req.headers.origin)
-          ? req.headers.origin[0]
-          : req.headers.origin;
-        const checkOrigin = hasCustomCorsOptions
-          ? (next: (allowed: boolean) => void) => {
-              checkCorsOrigin(
-                origin,
-                socketOptions?.cors as SDK.RsdoctorServerCorsOptions,
-                next,
-              );
-            }
-          : (next: (allowed: boolean) => void) => {
-              next(isAllowedRequestOrigin(origin));
-            };
+        if (socketOptions?.allowRequest) {
+          socketOptions.allowRequest(req, callback);
+          return;
+        }
 
-        checkOrigin((allowed) => {
-          if (!allowed) {
-            callback(null, false);
-            return;
-          }
-
-          if (socketOptions?.allowRequest) {
-            socketOptions.allowRequest(req, callback);
-            return;
-          }
-
-          callback(null, true);
-        });
+        callback(null, true);
       },
     });
     this.io.on('connection', (socket) => {

--- a/packages/sdk/tests/sdk/core/atomic-write.test.ts
+++ b/packages/sdk/tests/sdk/core/atomic-write.test.ts
@@ -62,8 +62,12 @@ describe('atomic write manifest', () => {
           const sdk = new RsdoctorSDK({
             name: 'test',
             root: process.cwd(),
-            port,
-            config: { noServer: true },
+            config: {
+              noServer: true,
+              server: {
+                port,
+              },
+            },
           });
 
           try {

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -176,7 +176,7 @@ describe('test server/apis/project.ts', () => {
     await expect(
       optionsWithOrigin(partialCorsTarget, 'https://example.com'),
     ).resolves.toStrictEqual({
-      statusCode: 204,
+      statusCode: 403,
       allowOrigin: undefined,
     });
 

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -2,15 +2,26 @@ import { describe, it, expect, rs } from '@rstest/core';
 import { Manifest, SDK } from '@rsdoctor/types';
 import { Manifest as ManifestShared } from '@rsdoctor/utils/common';
 import { request } from 'http';
-import { cwd, setupSDK } from '../../utils';
+import { cwd, setupSDK, type MockSDKResponse } from '../../utils';
 import { getLocalIpAddress } from '../../../src/sdk/server/utils';
 
 rs.setConfig({ testTimeout: 50000 });
 
 describe('test server/apis/project.ts', () => {
   const target = setupSDK();
+  const customCorsTarget = setupSDK({
+    server: {
+      cors: {
+        origin: 'https://example.com',
+      },
+    },
+  });
 
-  function optionsWithOrigin(origin: string, host?: string) {
+  function optionsWithOrigin(
+    target: MockSDKResponse,
+    origin: string,
+    host?: string,
+  ) {
     return new Promise<{
       statusCode: number;
       allowOrigin: string | string[] | undefined;
@@ -78,35 +89,36 @@ describe('test server/apis/project.ts', () => {
 
   it('only allows local CORS preflight requests', async () => {
     await expect(
-      optionsWithOrigin('https://example.com'),
+      optionsWithOrigin(target, 'https://example.com'),
     ).resolves.toStrictEqual({
-      statusCode: 204,
+      statusCode: 403,
       allowOrigin: undefined,
     });
 
     await expect(
-      optionsWithOrigin(`http://127.0.0.1:${target.server.port}`),
+      optionsWithOrigin(target, `http://127.0.0.1:${target.server.port}`),
     ).resolves.toStrictEqual({
       statusCode: 204,
       allowOrigin: `http://127.0.0.1:${target.server.port}`,
     });
 
     await expect(
-      optionsWithOrigin(`http://127.0.0.1:${target.server.port + 1}`),
+      optionsWithOrigin(target, `http://127.0.0.1:${target.server.port + 1}`),
     ).resolves.toStrictEqual({
       statusCode: 204,
       allowOrigin: `http://127.0.0.1:${target.server.port + 1}`,
     });
 
     await expect(
-      optionsWithOrigin(`http://foo.localhost:${target.server.port}`),
+      optionsWithOrigin(target, `http://foo.localhost:${target.server.port}`),
     ).resolves.toStrictEqual({
-      statusCode: 204,
-      allowOrigin: `http://foo.localhost:${target.server.port}`,
+      statusCode: 403,
+      allowOrigin: undefined,
     });
 
     await expect(
       optionsWithOrigin(
+        target,
         `http://foo.localhost:${target.server.port}`,
         `foo.localhost:${target.server.port}`,
       ),
@@ -131,6 +143,25 @@ describe('test server/apis/project.ts', () => {
       requestWithHost('/__open-in-editor?file=/tmp/example.js', host),
     ).resolves.toStrictEqual({
       statusCode: 403,
+    });
+  });
+
+  it('supports custom server.cors options', async () => {
+    await expect(
+      optionsWithOrigin(customCorsTarget, 'https://example.com'),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: 'https://example.com',
+    });
+
+    await expect(
+      optionsWithOrigin(
+        customCorsTarget,
+        `http://127.0.0.1:${customCorsTarget.server.port}`,
+      ),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: 'https://example.com',
     });
   });
 

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -16,6 +16,13 @@ describe('test server/apis/project.ts', () => {
       },
     },
   });
+  const partialCorsTarget = setupSDK({
+    server: {
+      cors: {
+        credentials: true,
+      },
+    },
+  });
 
   function optionsWithOrigin(
     target: MockSDKResponse,
@@ -87,7 +94,7 @@ describe('test server/apis/project.ts', () => {
     expect(env.port).toEqual(target.server.port);
   });
 
-  it('only allows local CORS preflight requests', async () => {
+  it('uses local origins for default CORS preflight requests', async () => {
     await expect(
       optionsWithOrigin(target, 'https://example.com'),
     ).resolves.toStrictEqual({
@@ -162,6 +169,25 @@ describe('test server/apis/project.ts', () => {
     ).resolves.toStrictEqual({
       statusCode: 204,
       allowOrigin: 'https://example.com',
+    });
+  });
+
+  it('preserves default CORS origins for partial server.cors options', async () => {
+    await expect(
+      optionsWithOrigin(partialCorsTarget, 'https://example.com'),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: undefined,
+    });
+
+    await expect(
+      optionsWithOrigin(
+        partialCorsTarget,
+        `http://127.0.0.1:${partialCorsTarget.server.port}`,
+      ),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: `http://127.0.0.1:${partialCorsTarget.server.port}`,
     });
   });
 

--- a/packages/sdk/tests/server/security.test.ts
+++ b/packages/sdk/tests/server/security.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@rstest/core';
 import {
+  isAllowedCorsRequest,
   isAllowedRequestHost,
   isAllowedRequestOrigin,
 } from '../../src/sdk/server/security';
@@ -32,5 +33,23 @@ describe('test server/security.ts', () => {
     expect(isAllowedRequestHost('example.com:3000')).toBe(false);
     expect(isAllowedRequestHost('foo.localhost.evil.com:3000')).toBe(false);
     expect(isAllowedRequestHost(['localhost:3000'])).toBe(false);
+  });
+
+  it('allows CORS requests from matching local origins', () => {
+    expect(
+      isAllowedCorsRequest('http://127.0.0.1:3001', '127.0.0.1:3000'),
+    ).toBe(true);
+    expect(
+      isAllowedCorsRequest('http://foo.localhost:3001', 'foo.localhost:3000'),
+    ).toBe(true);
+  });
+
+  it('rejects CORS requests from non-local or mismatched origins', () => {
+    expect(isAllowedCorsRequest('https://example.com', '127.0.0.1:3000')).toBe(
+      false,
+    );
+    expect(
+      isAllowedCorsRequest('http://foo.localhost:3001', '127.0.0.1:3000'),
+    ).toBe(false);
   });
 });

--- a/packages/sdk/tests/server/socket.test.ts
+++ b/packages/sdk/tests/server/socket.test.ts
@@ -1,13 +1,24 @@
 import { describe, it, expect, rs } from '@rstest/core';
 import { request } from 'http';
-import { setupSDK } from '../utils';
+import { setupSDK, type MockSDKResponse } from '../utils';
 
 rs.setConfig({ testTimeout: 50000 });
 
 describe('test server/socket.ts', () => {
   const target = setupSDK();
+  const customCorsTarget = setupSDK({
+    server: {
+      cors: {
+        origin: 'https://example.com',
+      },
+    },
+  });
 
-  function requestSocketHandshake(origin?: string, host?: string) {
+  function requestSocketHandshake(
+    target: MockSDKResponse,
+    origin?: string,
+    host?: string,
+  ) {
     return new Promise<{
       statusCode: number;
       allowOrigin: string | string[] | undefined;
@@ -48,7 +59,7 @@ describe('test server/socket.ts', () => {
 
   it('rejects socket handshakes from non-local origins', async () => {
     await expect(
-      requestSocketHandshake('https://example.com'),
+      requestSocketHandshake(target, 'https://example.com'),
     ).resolves.toMatchObject({
       statusCode: 403,
       allowOrigin: undefined,
@@ -58,17 +69,40 @@ describe('test server/socket.ts', () => {
   it('allows socket handshakes from local origins', async () => {
     const origin = `http://foo.localhost:${target.server.port}`;
 
-    await expect(requestSocketHandshake(origin)).resolves.toMatchObject({
-      statusCode: 200,
-      allowOrigin: origin,
-    });
+    await expect(requestSocketHandshake(target, origin)).resolves.toMatchObject(
+      {
+        statusCode: 200,
+        allowOrigin: origin,
+      },
+    );
   });
 
   it('rejects socket handshakes with non-local Host headers', async () => {
     const origin = `http://foo.localhost:${target.server.port}`;
 
     await expect(
-      requestSocketHandshake(origin, `evil.example.com:${target.server.port}`),
+      requestSocketHandshake(
+        target,
+        origin,
+        `evil.example.com:${target.server.port}`,
+      ),
+    ).resolves.toMatchObject({
+      statusCode: 403,
+    });
+  });
+
+  it('allows socket handshakes from custom CORS origins', async () => {
+    await expect(
+      requestSocketHandshake(customCorsTarget, 'https://example.com'),
+    ).resolves.toMatchObject({
+      statusCode: 200,
+      allowOrigin: 'https://example.com',
+    });
+  });
+
+  it('rejects socket handshakes from disallowed custom CORS origins', async () => {
+    await expect(
+      requestSocketHandshake(customCorsTarget, 'https://evil.example.com'),
     ).resolves.toMatchObject({
       statusCode: 403,
     });

--- a/packages/sdk/tests/server/socket.test.ts
+++ b/packages/sdk/tests/server/socket.test.ts
@@ -13,11 +13,19 @@ describe('test server/socket.ts', () => {
       },
     },
   });
+  const partialCorsTarget = setupSDK({
+    server: {
+      cors: {
+        credentials: true,
+      },
+    },
+  });
 
   function requestSocketHandshake(
     target: MockSDKResponse,
     origin?: string,
     host?: string,
+    token = target.server.socketUrl.token,
   ) {
     return new Promise<{
       statusCode: number;
@@ -26,6 +34,9 @@ describe('test server/socket.ts', () => {
       const url = new URL(
         `${target.server.origin}/socket.io/?EIO=4&transport=polling`,
       );
+      if (token) {
+        url.searchParams.set('token', token);
+      }
       const headers =
         origin || host
           ? {
@@ -57,11 +68,21 @@ describe('test server/socket.ts', () => {
     });
   }
 
-  it('rejects socket handshakes from non-local origins', async () => {
+  it('rejects socket handshakes without tokens', async () => {
+    const origin = `http://127.0.0.1:${target.server.port}`;
+
+    await expect(
+      requestSocketHandshake(target, origin, undefined, ''),
+    ).resolves.toMatchObject({
+      statusCode: 403,
+    });
+  });
+
+  it('does not expose CORS headers for non-local socket origins', async () => {
     await expect(
       requestSocketHandshake(target, 'https://example.com'),
     ).resolves.toMatchObject({
-      statusCode: 403,
+      statusCode: 200,
       allowOrigin: undefined,
     });
   });
@@ -100,9 +121,41 @@ describe('test server/socket.ts', () => {
     });
   });
 
-  it('rejects socket handshakes from disallowed custom CORS origins', async () => {
+  it('uses the configured custom socket CORS origin header', async () => {
     await expect(
       requestSocketHandshake(customCorsTarget, 'https://evil.example.com'),
+    ).resolves.toMatchObject({
+      statusCode: 200,
+      allowOrigin: 'https://example.com',
+    });
+  });
+
+  it('preserves default CORS origins for partial socket CORS options', async () => {
+    await expect(
+      requestSocketHandshake(partialCorsTarget, 'https://example.com'),
+    ).resolves.toMatchObject({
+      statusCode: 200,
+      allowOrigin: undefined,
+    });
+
+    const origin = `http://127.0.0.1:${partialCorsTarget.server.port}`;
+
+    await expect(
+      requestSocketHandshake(partialCorsTarget, origin),
+    ).resolves.toMatchObject({
+      statusCode: 200,
+      allowOrigin: origin,
+    });
+  });
+
+  it('rejects socket handshakes with invalid tokens', async () => {
+    await expect(
+      requestSocketHandshake(
+        customCorsTarget,
+        'https://example.com',
+        undefined,
+        'invalid-token',
+      ),
     ).resolves.toMatchObject({
       statusCode: 403,
     });

--- a/packages/sdk/tests/utils.ts
+++ b/packages/sdk/tests/utils.ts
@@ -38,7 +38,17 @@ export async function createSDK(
   config?: SDK.SDKOptionsType,
 ): Promise<MockSDKResponse> {
   const port = await Server.getPort(getPreferredTestPort());
-  const sdk = new RsdoctorSDK({ name: 'test', root: cwd, port, config });
+  const sdk = new RsdoctorSDK({
+    name: 'test',
+    root: cwd,
+    config: {
+      ...config,
+      server: {
+        ...config?.server,
+        port: config?.server?.port ?? port,
+      },
+    },
+  });
 
   await sdk.bootstrap();
 

--- a/packages/types/src/plugin/plugin.ts
+++ b/packages/types/src/plugin/plugin.ts
@@ -37,17 +37,18 @@ export interface RsdoctorWebpackPluginFeatures {
 export interface RsdoctorPluginOptionsNormalized<
   Rules extends LinterType.ExtendRuleData[] = [],
 > extends Common.DeepRequired<
-    Omit<
-      RsdoctorWebpackPluginOptions<Rules>,
-      | 'sdkInstance'
-      | 'linter'
-      | 'output'
-      | 'supports'
-      | 'port'
-      | 'brief'
-      | 'mode'
-    >
-  > {
+  Omit<
+    RsdoctorWebpackPluginOptions<Rules>,
+    | 'sdkInstance'
+    | 'linter'
+    | 'output'
+    | 'supports'
+    | 'port'
+    | 'brief'
+    | 'mode'
+    | 'server'
+  >
+> {
   features: Common.DeepRequired<RsdoctorWebpackPluginFeatures>;
   linter: Required<LinterType.Options<Rules, InternalRules>>;
   sdkInstance?: SDK.RsdoctorBuilderSDKInstance;
@@ -58,6 +59,7 @@ export interface RsdoctorPluginOptionsNormalized<
     options: Config.BriefModeOptions | Config.NormalModeOptions;
   };
   port?: number;
+  server: SDK.RsdoctorServerConfig;
   supports: ISupport;
 }
 
@@ -152,6 +154,11 @@ export interface RsdoctorWebpackPluginOptions<
   port?: number;
 
   /**
+   * Configure the Rsdoctor report server.
+   */
+  server?: SDK.RsdoctorServerConfig;
+
+  /**
    * Options to control the log printing.
    */
   printLog?: SDK.IPrintLog;
@@ -185,8 +192,10 @@ export interface NormalModeOptions {
 }
 
 // Normal Mode Type
-interface NormalModeConfig
-  extends Omit<OutputBaseConfig, 'reportCodeType' | 'mode'> {
+interface NormalModeConfig extends Omit<
+  OutputBaseConfig,
+  'reportCodeType' | 'mode'
+> {
   mode?: 'normal';
   reportCodeType?: ReportCodeTypeByMode<'normal'>;
   options?: NormalModeOptions;
@@ -200,8 +209,10 @@ export interface BriefModeOptions {
   htmlOptions?: Config.BriefConfig;
 }
 
-export interface BriefModeConfig
-  extends Omit<OutputBaseConfig, 'reportCodeType' | 'mode'> {
+export interface BriefModeConfig extends Omit<
+  OutputBaseConfig,
+  'reportCodeType' | 'mode'
+> {
   mode?: 'brief';
   reportCodeType?: ReportCodeTypeByMode<'brief'>;
   options?: BriefModeOptions;

--- a/packages/types/src/sdk/instance.ts
+++ b/packages/types/src/sdk/instance.ts
@@ -121,6 +121,50 @@ export interface IPrintLog {
   serverUrls: boolean;
 }
 
+export type RsdoctorServerCorsStaticOrigin =
+  | boolean
+  | string
+  | RegExp
+  | Array<boolean | string | RegExp>;
+
+export type RsdoctorServerCorsOrigin =
+  | RsdoctorServerCorsStaticOrigin
+  | ((
+      requestOrigin: string | undefined,
+      callback: (
+        err: Error | null,
+        origin?: RsdoctorServerCorsStaticOrigin,
+      ) => void,
+    ) => void);
+
+export interface RsdoctorServerCorsOptions {
+  origin?: RsdoctorServerCorsOrigin;
+  methods?: string | string[];
+  allowedHeaders?: string | string[];
+  exposedHeaders?: string | string[];
+  credentials?: boolean;
+  maxAge?: number;
+  preflightContinue?: boolean;
+  optionsSuccessStatus?: number;
+}
+
+export interface RsdoctorServerConfig {
+  /**
+   * The port of the Rsdoctor report server.
+   */
+  port?: number;
+  /**
+   * Configure CORS for the Rsdoctor report server.
+   *
+   * - `false`: disable CORS middleware
+   * - `true`: use the cors middleware defaults
+   * - object: pass options to the cors middleware
+   *
+   * By default, Rsdoctor only allows local origins.
+   */
+  cors?: boolean | RsdoctorServerCorsOptions;
+}
+
 export type SDKOptionsType = {
   innerClientPath?: string;
   disableClientServer?: boolean;
@@ -129,4 +173,5 @@ export type SDKOptionsType = {
   mode?: keyof typeof IMode;
   brief?: BriefModeOptions;
   features?: { treeShaking?: boolean };
+  server?: RsdoctorServerConfig;
 };

--- a/packages/types/src/sdk/server/index.ts
+++ b/packages/types/src/sdk/server/index.ts
@@ -19,6 +19,11 @@ export interface RsdoctorServerInstance {
 
   readonly port: number;
   readonly origin: string;
+  readonly socketUrl: {
+    port: number;
+    socketUrl: string;
+    token: string;
+  };
 
   innerClientPath?: string;
 

--- a/packages/utils/src/common/global-config.ts
+++ b/packages/utils/src/common/global-config.ts
@@ -12,23 +12,13 @@ import { logger } from '../logger';
  *     builder1: portNumber,
  *     builder2: portNumber,
  *   },
- *   tokenList: {
- *     builder1: token,
- *     builder2: token,
- *   },
  *   port: portNumber, // The port of the last builder is used by default
- *   token: token // The token of the last builder is used by default
  * }
  *
  * @param {number} port - The port number to write.
  * @param {string} [builderName] - The name of the builder.
- * @param {string} [token] - The socket token to write.
  */
-export function writeMcpPort(
-  port: number,
-  builderName?: string,
-  token?: string,
-) {
+export function writeMcpPort(port: number, builderName?: string) {
   const homeDir = os.homedir();
   const rsdoctorDir = path.join(homeDir, '.cache/rsdoctor');
   const mcpPortFilePath = path.join(rsdoctorDir, 'mcp.json');
@@ -39,9 +29,7 @@ export function writeMcpPort(
 
   let mcpJson: {
     portList: Record<string, number>;
-    tokenList?: Record<string, string>;
     port: number;
-    token?: string;
   } = {
     portList: {},
     port: 0,
@@ -57,14 +45,9 @@ export function writeMcpPort(
 
   if (!mcpJson.portList) mcpJson.portList = {};
   mcpJson.portList[builderName || 'builder'] = port;
-  if (token) {
-    if (!mcpJson.tokenList) mcpJson.tokenList = {};
-    mcpJson.tokenList[builderName || 'builder'] = token;
-  }
 
   // Use the latest generated port.
   mcpJson.port = port;
-  mcpJson.token = token;
 
   fs.writeFileSync(mcpPortFilePath, JSON.stringify(mcpJson, null, 2), 'utf8');
 }

--- a/packages/utils/src/common/global-config.ts
+++ b/packages/utils/src/common/global-config.ts
@@ -12,13 +12,23 @@ import { logger } from '../logger';
  *     builder1: portNumber,
  *     builder2: portNumber,
  *   },
- *   port: portNumber // The port of the last builder is used by default
+ *   tokenList: {
+ *     builder1: token,
+ *     builder2: token,
+ *   },
+ *   port: portNumber, // The port of the last builder is used by default
+ *   token: token // The token of the last builder is used by default
  * }
  *
  * @param {number} port - The port number to write.
  * @param {string} [builderName] - The name of the builder.
+ * @param {string} [token] - The socket token to write.
  */
-export function writeMcpPort(port: number, builderName?: string) {
+export function writeMcpPort(
+  port: number,
+  builderName?: string,
+  token?: string,
+) {
   const homeDir = os.homedir();
   const rsdoctorDir = path.join(homeDir, '.cache/rsdoctor');
   const mcpPortFilePath = path.join(rsdoctorDir, 'mcp.json');
@@ -27,7 +37,12 @@ export function writeMcpPort(port: number, builderName?: string) {
     fs.mkdirSync(rsdoctorDir, { recursive: true });
   }
 
-  let mcpJson: { portList: Record<string, number>; port: number } = {
+  let mcpJson: {
+    portList: Record<string, number>;
+    tokenList?: Record<string, string>;
+    port: number;
+    token?: string;
+  } = {
     portList: {},
     port: 0,
   };
@@ -42,9 +57,14 @@ export function writeMcpPort(port: number, builderName?: string) {
 
   if (!mcpJson.portList) mcpJson.portList = {};
   mcpJson.portList[builderName || 'builder'] = port;
+  if (token) {
+    if (!mcpJson.tokenList) mcpJson.tokenList = {};
+    mcpJson.tokenList[builderName || 'builder'] = token;
+  }
 
   // Use the latest generated port.
   mcpJson.port = port;
+  mcpJson.token = token;
 
   fs.writeFileSync(mcpPortFilePath, JSON.stringify(mcpJson, null, 2), 'utf8');
 }

--- a/packages/webpack-plugin/src/multiple.ts
+++ b/packages/webpack-plugin/src/multiple.ts
@@ -32,6 +32,7 @@ export class RsdoctorWebpackMultiplePlugin<
       extraConfig: {
         innerClientPath: normallizedOptions.innerClientPath,
         printLog: normallizedOptions.printLog,
+        server: normallizedOptions.server,
         mode: normallizedOptions.output.mode
           ? normallizedOptions.output.mode
           : undefined,

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -29,9 +29,9 @@ import path from 'path';
 // Static flag to ensure greet message is only printed once per process
 let hasGreeted = false;
 
-export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
-  implements RsdoctorPluginInstance<Compiler, Rules>
-{
+export class RsdoctorWebpackPlugin<
+  Rules extends Linter.ExtendRuleData[],
+> implements RsdoctorPluginInstance<Compiler, Rules> {
   public readonly name = pluginTapName;
 
   public readonly options: Plugin.RsdoctorPluginOptionsNormalized<Rules>;
@@ -52,7 +52,7 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
 
   constructor(options?: Plugin.RsdoctorWebpackPluginOptions<Rules>) {
     this.options = normalizeUserConfig<Rules>(options);
-    const { port, output, innerClientPath, printLog, sdkInstance } =
+    const { port, server, output, innerClientPath, printLog, sdkInstance } =
       this.options;
 
     this.sdk =
@@ -65,6 +65,7 @@ export class RsdoctorWebpackPlugin<Rules extends Linter.ExtendRuleData[]>
         config: {
           innerClientPath: innerClientPath,
           printLog: printLog,
+          server,
           mode: output.mode,
           brief:
             output.mode === SDK.IMode[SDK.IMode.brief]


### PR DESCRIPTION
## Summary
This PR hardens the Rsdoctor report server access model and aligns the default CORS / socket behavior with Rsbuild-style local-only protection.</p><ul><li>Bind the report server to <code>127.0.0.1</code> by default instead of exposing it on all network interfaces.</li><li>Add Host header validation before serving report APIs and static report assets.</li><li>Replace the previous wildcard CORS behavior with local-origin defaults.</li><li>Preserve the default local-origin protection when users provide partial <code>server.cors</code> options, such as <code>{ credentials: true }</code>.</li><li>Add a socket token handshake similar to Rsbuild:<ul><li>the report server generates a random socket token;</li><li>the token is injected into the report manifest via <code>__SOCKET__URL__</code>;</li><li>the report UI connects with <code>?token=...</code>;</li><li>the socket server rejects handshakes with missing or invalid tokens.</li></ul></li><li>Keep socket token delivery inside the report UI runtime path. The token is not written to or read from <code>mcp.json</code>.</li></ul><p>CORS behavior:</p><div><div>
User config server.cors | Resolved corsOptions | HTTP CORS middleware
-- | -- | --
Not configured / undefined | { origin: DEFAULT_ALLOWED_CORS_ORIGINS } | Enabled
false | false | Disabled
true | {} | Enabled, equivalent to cors({})
{ credentials: true } | { credentials: true, origin: DEFAULT_ALLOWED_CORS_ORIGINS } | Enabled
{ origin: 'https://example.com' } | { origin: 'https://example.com' } | Enabled
{ origin: '*', credentials: true } | { origin: '*', credentials: true } | Enabled
{ origin: false } | { origin: false } | Enabled, but does not set Access-Control-Allow-Origin
{ origin: fn } | { origin: fn } | Enabled
{ origin: /regex/ } | { origin: /regex/ } | Enabled

</div></div><p>Default / partial CORS configs also keep the local-origin guard, so requests from non-local or mismatched local origins are rejected instead of silently falling back to wildcard CORS.</p></body></html>

## Related Links

<!--- Provide links of related issues or pages -->
