### PR TITLE
fix(agent-cli): backport publish pack guard

### DIFF
--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
+    "prepublishOnly": "pnpm run build",
     "test": "rstest run"
   },
   "devDependencies": {

--- a/packages/agent-cli/tests/pack.test.ts
+++ b/packages/agent-cli/tests/pack.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from '@rstest/core';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import packageJson from '../package.json';
+
+const packageRoot = path.resolve(__dirname, '..');
+
+describe('agent-cli pack', () => {
+  it('build emits the declaration entry referenced by package.json', () => {
+    execSync('pnpm run build', {
+      cwd: packageRoot,
+      stdio: 'pipe',
+    });
+
+    const typesEntry = packageJson.types;
+    expect(typeof typesEntry).toBe('string');
+
+    const typesPath = path.resolve(packageRoot, typesEntry);
+    expect(fs.existsSync(typesPath)).toBe(true);
+  });
+
+  it('includes declaration file in npm pack output', () => {
+    execSync('pnpm run build', {
+      cwd: packageRoot,
+      stdio: 'pipe',
+    });
+
+    const packOutput = execSync('npm pack --dry-run --json', {
+      cwd: packageRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const packedFiles = (JSON.parse(packOutput)[0]?.files ?? []).map(
+      (file: { path: string }) => file.path,
+    );
+
+    expect(packedFiles).toContain('dist/index.d.ts');
+  });
+});


### PR DESCRIPTION
## Summary

Backports the accepted agent-cli publish guard from #1748 to the `v1.x` release branch.

- add `prepublishOnly` so publishing runs the build first
- add a pack regression test that verifies the declared `types` file is emitted
- verify `npm pack --dry-run --json` includes `dist/index.d.ts`

## Why

`v1.x` is the release branch for rsdoctor 1.x, and the maintainer requested this sync after #1748 was merged on `main`.

## Validation

- `pnpm --filter @rsdoctor/agent-cli test` (33 tests passed)