### PR TITLE
fix(sdk): harden dev server access

### DIFF
--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -14,14 +14,13 @@ import path from 'path';
 import { Lodash } from '@rsdoctor/utils/common';
 import { createRequire } from 'module';
 import { ServerResponse } from 'http';
+import { DEFAULT_ALLOWED_CORS_ORIGINS, isAllowedRequestHost } from './security';
 
 const require = createRequire(import.meta.url);
 export * from './utils';
 
 /** Path for launch-editor: open file in editor from the UI (see https://github.com/yyx990803/launch-editor) */
 const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
-const DEFAULT_ALLOWED_CORS_ORIGINS =
-  /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/;
 const LISTEN_RETRY_LIMIT = 10;
 
 export type ISocketType = { port: number; socketUrl: string };
@@ -132,6 +131,16 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     this.disposed = false;
     const { default: cors } = await import('cors');
 
+    this.app.use((req, res, next) => {
+      const host = req.headers.host || req.headers[':authority'];
+      if (!isAllowedRequestHost(host)) {
+        res.statusCode = 403;
+        res.end();
+        return;
+      }
+
+      next();
+    });
     this.app.use(
       cors({
         origin: DEFAULT_ALLOWED_CORS_ORIGINS,

--- a/packages/sdk/src/sdk/server/security.ts
+++ b/packages/sdk/src/sdk/server/security.ts
@@ -1,0 +1,38 @@
+import { isIP } from 'node:net';
+
+export const DEFAULT_ALLOWED_CORS_ORIGINS =
+  /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/;
+
+const LOCAL_HOSTNAMES = /^(?:localhost|[^:]+\.localhost)$/;
+
+export function isAllowedRequestOrigin(origin: string | string[] | undefined) {
+  if (origin === undefined) {
+    return true;
+  }
+
+  return (
+    typeof origin === 'string' && DEFAULT_ALLOWED_CORS_ORIGINS.test(origin)
+  );
+}
+
+function isIpAddress(hostname: string) {
+  return isIP(hostname) !== 0;
+}
+
+function getHostnameFromHost(host: string) {
+  if (host.startsWith('[')) {
+    const endIndex = host.indexOf(']');
+    return endIndex === -1 ? '' : host.slice(1, endIndex);
+  }
+
+  return host.split(':')[0];
+}
+
+export function isAllowedRequestHost(host: string | string[] | undefined) {
+  if (typeof host !== 'string') {
+    return false;
+  }
+
+  const hostname = getHostnameFromHost(host).toLowerCase();
+  return LOCAL_HOSTNAMES.test(hostname) || isIpAddress(hostname);
+}

--- a/packages/sdk/src/sdk/server/socket/index.ts
+++ b/packages/sdk/src/sdk/server/socket/index.ts
@@ -7,6 +7,7 @@ import {
 } from 'socket.io';
 import { isDeepStrictEqual } from 'util';
 import { SocketAPILoader } from './api';
+import { isAllowedRequestHost, isAllowedRequestOrigin } from '../security';
 
 interface SocketOptions {
   sdk: SDK.RsdoctorBuilderSDKInstance;
@@ -28,11 +29,39 @@ export class Socket {
   }
 
   public bootstrap() {
+    const { socketOptions } = this.options;
+    const corsOptions =
+      socketOptions?.cors &&
+      typeof socketOptions.cors === 'object' &&
+      !Array.isArray(socketOptions.cors)
+        ? socketOptions.cors
+        : {};
+
     this.io = new SocketServer(this.options.server, {
+      ...socketOptions,
       cors: {
-        origin: '*',
+        ...corsOptions,
+        origin: (origin, callback) => {
+          callback(null, isAllowedRequestOrigin(origin));
+        },
       },
-      ...this.options.socketOptions,
+      allowRequest: (req, callback) => {
+        const host = req.headers.host || req.headers[':authority'];
+        if (
+          !isAllowedRequestHost(host) ||
+          !isAllowedRequestOrigin(req.headers.origin)
+        ) {
+          callback(null, false);
+          return;
+        }
+
+        if (socketOptions?.allowRequest) {
+          socketOptions.allowRequest(req, callback);
+          return;
+        }
+
+        callback(null, true);
+      },
     });
     this.io.on('connection', (socket) => {
       // setup event listeners for every socket which connected

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -10,7 +10,7 @@ rs.setConfig({ testTimeout: 50000 });
 describe('test server/apis/project.ts', () => {
   const target = setupSDK();
 
-  function optionsWithOrigin(origin: string) {
+  function optionsWithOrigin(origin: string, host?: string) {
     return new Promise<{
       statusCode: number;
       allowOrigin: string | string[] | undefined;
@@ -24,7 +24,10 @@ describe('test server/apis/project.ts', () => {
           port: url.port,
           path: url.pathname,
           method: 'OPTIONS',
-          headers: { Origin: origin },
+          headers: {
+            Origin: origin,
+            ...(host ? { Host: host } : {}),
+          },
         },
         (res) => {
           res.on('data', () => {});
@@ -33,6 +36,30 @@ describe('test server/apis/project.ts', () => {
               statusCode: res.statusCode || 0,
               allowOrigin: res.headers['access-control-allow-origin'],
             });
+          });
+        },
+      );
+
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
+  function requestWithHost(pathname: string, host: string) {
+    return new Promise<{ statusCode: number }>((resolve, reject) => {
+      const url = new URL(`${target.server.origin}${pathname}`);
+      const req = request(
+        {
+          hostname: url.hostname,
+          port: url.port,
+          path: `${url.pathname}${url.search}`,
+          method: 'GET',
+          headers: { Host: host },
+        },
+        (res) => {
+          res.on('data', () => {});
+          res.on('close', () => {
+            resolve({ statusCode: res.statusCode || 0 });
           });
         },
       );
@@ -76,6 +103,34 @@ describe('test server/apis/project.ts', () => {
     ).resolves.toStrictEqual({
       statusCode: 204,
       allowOrigin: `http://foo.localhost:${target.server.port}`,
+    });
+
+    await expect(
+      optionsWithOrigin(
+        `http://foo.localhost:${target.server.port}`,
+        `foo.localhost:${target.server.port}`,
+      ),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: `http://foo.localhost:${target.server.port}`,
+    });
+  });
+
+  it('rejects requests with non-local Host headers', async () => {
+    const host = `evil.example.com:${target.server.port}`;
+
+    await expect(requestWithHost('/', host)).resolves.toStrictEqual({
+      statusCode: 403,
+    });
+    await expect(
+      requestWithHost(SDK.ServerAPI.API.Manifest, host),
+    ).resolves.toStrictEqual({
+      statusCode: 403,
+    });
+    await expect(
+      requestWithHost('/__open-in-editor?file=/tmp/example.js', host),
+    ).resolves.toStrictEqual({
+      statusCode: 403,
     });
   });
 

--- a/packages/sdk/tests/server/security.test.ts
+++ b/packages/sdk/tests/server/security.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from '@rstest/core';
+import {
+  isAllowedRequestHost,
+  isAllowedRequestOrigin,
+} from '../../src/sdk/server/security';
+
+describe('test server/security.ts', () => {
+  it('allows local request origins', () => {
+    expect(isAllowedRequestOrigin(undefined)).toBe(true);
+    expect(isAllowedRequestOrigin('http://localhost:3000')).toBe(true);
+    expect(isAllowedRequestOrigin('https://foo.localhost:3000')).toBe(true);
+    expect(isAllowedRequestOrigin('http://127.0.0.1:3000')).toBe(true);
+    expect(isAllowedRequestOrigin('http://[::1]:3000')).toBe(true);
+  });
+
+  it('rejects non-local request origins', () => {
+    expect(isAllowedRequestOrigin('https://example.com')).toBe(false);
+    expect(isAllowedRequestOrigin('http://foo.localhost.evil.com')).toBe(false);
+    expect(isAllowedRequestOrigin(['http://localhost:3000'])).toBe(false);
+  });
+
+  it('allows local request hosts', () => {
+    expect(isAllowedRequestHost('localhost:3000')).toBe(true);
+    expect(isAllowedRequestHost('foo.localhost:3000')).toBe(true);
+    expect(isAllowedRequestHost('127.0.0.1:3000')).toBe(true);
+    expect(isAllowedRequestHost('[::1]:3000')).toBe(true);
+    expect(isAllowedRequestHost('192.168.1.10:3000')).toBe(true);
+  });
+
+  it('rejects non-local request hosts', () => {
+    expect(isAllowedRequestHost(undefined)).toBe(false);
+    expect(isAllowedRequestHost('example.com:3000')).toBe(false);
+    expect(isAllowedRequestHost('foo.localhost.evil.com:3000')).toBe(false);
+    expect(isAllowedRequestHost(['localhost:3000'])).toBe(false);
+  });
+});

--- a/packages/sdk/tests/server/socket.test.ts
+++ b/packages/sdk/tests/server/socket.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, rs } from '@rstest/core';
+import { request } from 'http';
+import { setupSDK } from '../utils';
+
+rs.setConfig({ testTimeout: 50000 });
+
+describe('test server/socket.ts', () => {
+  const target = setupSDK();
+
+  function requestSocketHandshake(origin?: string, host?: string) {
+    return new Promise<{
+      statusCode: number;
+      allowOrigin: string | string[] | undefined;
+    }>((resolve, reject) => {
+      const url = new URL(
+        `${target.server.origin}/socket.io/?EIO=4&transport=polling`,
+      );
+      const headers =
+        origin || host
+          ? {
+              ...(origin ? { Origin: origin } : {}),
+              ...(host ? { Host: host } : {}),
+            }
+          : undefined;
+      const req = request(
+        {
+          hostname: url.hostname,
+          port: url.port,
+          path: `${url.pathname}${url.search}`,
+          method: 'GET',
+          headers,
+        },
+        (res) => {
+          res.on('data', () => {});
+          res.on('close', () => {
+            resolve({
+              statusCode: res.statusCode || 0,
+              allowOrigin: res.headers['access-control-allow-origin'],
+            });
+          });
+        },
+      );
+
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
+  it('rejects socket handshakes from non-local origins', async () => {
+    await expect(
+      requestSocketHandshake('https://example.com'),
+    ).resolves.toMatchObject({
+      statusCode: 403,
+      allowOrigin: undefined,
+    });
+  });
+
+  it('allows socket handshakes from local origins', async () => {
+    const origin = `http://foo.localhost:${target.server.port}`;
+
+    await expect(requestSocketHandshake(origin)).resolves.toMatchObject({
+      statusCode: 200,
+      allowOrigin: origin,
+    });
+  });
+
+  it('rejects socket handshakes with non-local Host headers', async () => {
+    const origin = `http://foo.localhost:${target.server.port}`;
+
+    await expect(
+      requestSocketHandshake(origin, `evil.example.com:${target.server.port}`),
+    ).resolves.toMatchObject({
+      statusCode: 403,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Harden SDK dev server access by sharing local Origin/Host validation in a new `server/security` helper.
- Add HTTP Host validation before CORS/static/router middleware to reject non-local Host headers across `/`, `/api/*`, and `/__open-in-editor`.
- Restrict Socket.IO access by replacing `cors.origin: '*'` with an Origin callback and adding `allowRequest` checks for Host and Origin before accepting handshakes.
- Add regression tests for HTTP CORS, Host rejection, Socket.IO Origin/Host rejection, and local Host/Origin allowlist behavior.
## Related Links

<!--- Provide links of related issues or pages -->
