### PR TITLE
fix(sdk): sync report server hardening to main

### DIFF
--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -70,7 +70,16 @@ example: ${bin} ${Commands.Analyze} --profile "${Constants.RsdoctorOutputManifes
 
       spinner.text = `start server`;
 
-      const sdk = new RsdoctorSDK({ name, root: cwd, port, type });
+      const sdk = new RsdoctorSDK({
+        name,
+        root: cwd,
+        type,
+        config: {
+          server: {
+            port,
+          },
+        },
+      });
 
       await sdk.bootstrap();
 
@@ -78,7 +87,12 @@ example: ${bin} ${Commands.Analyze} --profile "${Constants.RsdoctorOutputManifes
       sdk.getManifestData = () => json;
 
       const manifestBuffer = Buffer.from(
-        JSON.stringify({ ...json, __LOCAL__SERVER__: true }),
+        JSON.stringify({
+          ...json,
+          __LOCAL__SERVER__: true,
+          __SOCKET__PORT__: sdk.server.socketUrl.port.toString(),
+          __SOCKET__URL__: sdk.server.socketUrl.socketUrl,
+        }),
       );
 
       sdk.server.proxy(SDK.ServerAPI.API.Manifest, 'GET', () => manifestBuffer);

--- a/packages/cli/src/commands/stats-analyze.test.ts
+++ b/packages/cli/src/commands/stats-analyze.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from '@rstest/core';
+import { coercePort } from './stats-analyze';
+
+describe('stats-analyze command', () => {
+  it('coercePort() preserves undefined', () => {
+    expect(coercePort()).toBeUndefined();
+  });
+
+  it('coercePort() converts valid port values to numbers', () => {
+    expect(coercePort(8888)).toBe(8888);
+    expect(coercePort('8888')).toBe(8888);
+  });
+
+  it('coercePort() rejects invalid port values', () => {
+    expect(() => coercePort('foo')).toThrow('Invalid port: foo');
+  });
+});

--- a/packages/cli/src/commands/stats-analyze.ts
+++ b/packages/cli/src/commands/stats-analyze.ts
@@ -11,8 +11,12 @@ import { TransUtils } from '@rsdoctor/graph';
 interface Options {
   profile: string;
   open?: boolean;
-  port?: number;
+  port?: number | string;
   type?: SDK.ToDataType;
+}
+
+export function coercePort(port?: number | string) {
+  return typeof port === 'undefined' ? undefined : Number(port);
 }
 
 export const statsAnalyze: Command<
@@ -32,7 +36,8 @@ export const statsAnalyze: Command<
       .option('--port <number>', 'port for Rsdoctor Server')
       .option('--type <mode>', 'Bundle analysis mode (normal or lite)');
   },
-  async action({ profile, open = true, type = SDK.ToDataType.Normal }) {
+  async action({ profile, open = true, port, type = SDK.ToDataType.Normal }) {
+    const serverPort = coercePort(port);
     const spinner = ora({ prefixText: cyan(`[${name}]`) }).start(
       `start to loading "${profile}"`,
     );
@@ -46,7 +51,11 @@ export const statsAnalyze: Command<
       name: 'stats-analyze',
       root: process.cwd(),
       type,
-      noServer: false,
+      config: {
+        server: {
+          port: serverPort,
+        },
+      },
     });
 
     await sdk.bootstrap();

--- a/packages/cli/src/commands/stats-analyze.ts
+++ b/packages/cli/src/commands/stats-analyze.ts
@@ -16,7 +16,16 @@ interface Options {
 }
 
 export function coercePort(port?: number | string) {
-  return typeof port === 'undefined' ? undefined : Number(port);
+  if (typeof port === 'undefined') {
+    return undefined;
+  }
+
+  const value = Number(port);
+  if (!Number.isFinite(value)) {
+    throw new Error(`Invalid port: ${port}`);
+  }
+
+  return value;
 }
 
 export const statsAnalyze: Command<

--- a/packages/components/src/utils/data/local.ts
+++ b/packages/components/src/utils/data/local.ts
@@ -70,6 +70,7 @@ export class LocalServerDataLoader extends BaseDataLoader {
     // request limitation key
     const key = body ? `${api}_${JSON.stringify(body)}` : `${api}`;
     const socketPort = this.get('__SOCKET__PORT__') ?? '';
+    const socketUrl = this.get('__SOCKET__URL__') ?? '';
 
     return this.limit(key, async () => {
       try {
@@ -77,6 +78,7 @@ export class LocalServerDataLoader extends BaseDataLoader {
           api,
           body as SDK.ServerAPI.InferRequestBodyType<T>,
           socketPort,
+          socketUrl,
         )) as R;
       } catch (err) {
         this.log(`loadAPI error: `, key);
@@ -121,7 +123,8 @@ export class LocalServerDataLoader extends BaseDataLoader {
 
     subscription.listeners.add(fn);
     const socketPort = this.get('__SOCKET__PORT__') ?? '';
-    subscribeServerAPI(api, normalizedBody, fn, socketPort);
+    const socketUrl = this.get('__SOCKET__URL__') ?? '';
+    subscribeServerAPI(api, normalizedBody, fn, socketPort, socketUrl);
   }
 
   public removeOnDataUpdate<
@@ -133,7 +136,8 @@ export class LocalServerDataLoader extends BaseDataLoader {
   ) {
     const key = `${api}::${JSON.stringify(body ?? null)}`;
     const socketPort = this.get('__SOCKET__PORT__') ?? '';
-    unsubscribeServerAPI(api, body, fn, socketPort);
+    const socketUrl = this.get('__SOCKET__URL__') ?? '';
+    unsubscribeServerAPI(api, body, fn, socketPort, socketUrl);
     this.events.get(key)?.listeners.delete(fn);
   }
 }

--- a/packages/components/src/utils/socket.ts
+++ b/packages/components/src/utils/socket.ts
@@ -63,7 +63,11 @@ function getDefaultSocketUrl() {
     : `${socketProtocol}://${location.host}`;
 }
 
-function getSocketUrl(socketPort?: string) {
+function getSocketUrl(socketPort?: string, socketUrl?: string) {
+  if (socketUrl) {
+    return socketUrl;
+  }
+
   if (typeof location === 'undefined') {
     return socketPort ? `ws://localhost:${socketPort}` : '';
   }
@@ -201,9 +205,14 @@ export function requestServerAPI<
     SDK.ServerAPI.InferRequestBodyType<T>,
   R extends SDK.ServerAPI.InferResponseType<T> =
     SDK.ServerAPI.InferResponseType<T>,
->(api: T, body: B | null | undefined, socketPort?: string): Promise<R> {
-  const socketUrl = getSocketUrl(socketPort);
-  if (!socketUrl) {
+>(
+  api: T,
+  body: B | null | undefined,
+  socketPort?: string,
+  socketUrl?: string,
+): Promise<R> {
+  const resolvedSocketUrl = getSocketUrl(socketPort, socketUrl);
+  if (!resolvedSocketUrl) {
     return Promise.reject(new Error('WebSocket URL is not available.'));
   }
 
@@ -211,7 +220,7 @@ export function requestServerAPI<
     return Promise.reject(new Error('WebSocket is not available.'));
   }
 
-  const client = getClient(socketUrl);
+  const client = getClient(resolvedSocketUrl);
   const id = `${Date.now()}-${++requestId}`;
 
   return new Promise<R>((resolve, reject) => {
@@ -235,8 +244,9 @@ export function subscribeServerAPI<T extends SocketAPI>(
   body: SDK.ServerAPI.InferRequestBodyType<T, null> | null,
   listener: SocketListener<T>,
   socketPort?: string,
+  socketUrl?: string,
 ) {
-  const client = getClient(getSocketUrl(socketPort));
+  const client = getClient(getSocketUrl(socketPort, socketUrl));
   const bodyValue = body ?? null;
   const key = getSubscriptionKey(api, bodyValue);
   if (!client.listeners.has(key)) {
@@ -253,7 +263,7 @@ export function subscribeServerAPI<T extends SocketAPI>(
   sendSubscription(client, subscription);
 
   return () => {
-    unsubscribeServerAPI(api, bodyValue, listener, socketPort);
+    unsubscribeServerAPI(api, bodyValue, listener, socketPort, socketUrl);
   };
 }
 
@@ -262,8 +272,9 @@ export function unsubscribeServerAPI<T extends SocketAPI>(
   body: SDK.ServerAPI.InferRequestBodyType<T, null> | null,
   listener: SocketListener<T>,
   socketPort?: string,
+  socketUrl?: string,
 ) {
-  const client = getClient(getSocketUrl(socketPort));
+  const client = getClient(getSocketUrl(socketPort, socketUrl));
   const key = getSubscriptionKey(api, body);
   const listeners = client.listeners.get(key);
   listeners?.delete(listener as SocketListener);

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -123,6 +123,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
   const server: SDK.RsdoctorServerConfig = {
     ...userServer,
   };
+  assert(typeof server.port === 'undefined' || typeof server.port === 'number');
   if (typeof server.port === 'undefined' && typeof port !== 'undefined') {
     server.port = port;
   }

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -101,6 +101,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     output = outputConfig,
     supports = getDefaultSupports(),
     port,
+    server: userServer = {},
     printLog = { serverUrls: true },
     mode = undefined,
     brief = undefined,
@@ -117,6 +118,14 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
   assert(typeof features === 'object' || Array.isArray(features));
   assert(typeof loaderInterceptorOptions === 'object');
   assert(typeof disableClientServer === 'boolean');
+  assert(typeof port === 'undefined' || typeof port === 'number');
+  assert(typeof userServer === 'object' && userServer !== null);
+  const server: SDK.RsdoctorServerConfig = {
+    ...userServer,
+  };
+  if (typeof server.port === 'undefined' && typeof port !== 'undefined') {
+    server.port = port;
+  }
   let finalMode: keyof typeof SDK.IMode =
     ('mode' in output && isValidMode(output.mode)
       ? output.mode === ('lite' as SDK.IMode.normal)
@@ -174,6 +183,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     innerClientPath,
     supports,
     port,
+    server,
     printLog,
   };
 

--- a/packages/core/tests/build/utils/config.test.ts
+++ b/packages/core/tests/build/utils/config.test.ts
@@ -318,6 +318,73 @@ describe('normalizeUserConfig', () => {
     });
   });
 
+  describe('server configuration', () => {
+    it('should preserve port and apply it to server.port', () => {
+      const result = normalizeUserConfig({
+        port: 9876,
+      });
+
+      expect(result.port).toBe(9876);
+      expect(result.server.port).toBe(9876);
+    });
+
+    it('should preserve server.port', () => {
+      const result = normalizeUserConfig({
+        server: {
+          port: 9876,
+        },
+      });
+
+      expect(result.server.port).toBe(9876);
+    });
+
+    it('should prefer server.port over port', () => {
+      const result = normalizeUserConfig({
+        port: 9876,
+        server: {
+          port: 9877,
+        },
+      });
+
+      expect(result.port).toBe(9876);
+      expect(result.server.port).toBe(9877);
+    });
+
+    it('should preserve server.cors options', () => {
+      const result = normalizeUserConfig({
+        server: {
+          cors: {
+            origin: 'https://example.com',
+            credentials: true,
+          },
+        },
+      });
+
+      expect(result.server.cors).toEqual({
+        origin: 'https://example.com',
+        credentials: true,
+      });
+    });
+
+    it('should preserve server.cors boolean values', () => {
+      expect(
+        normalizeUserConfig({
+          server: {
+            cors: false,
+          },
+        }).server.cors,
+      ).toBe(false);
+
+      expect(
+        normalizeUserConfig({
+          server: {
+            cors: true,
+          },
+        }).server.cors,
+      ).toBe(true);
+    });
+  });
+
   describe('output.reportCodeType', () => {
     it('should return NoCode when mode is brief regardless of reportCodeType', () => {
       const result = normalizeUserConfig({

--- a/packages/rspack-plugin/src/multiple.ts
+++ b/packages/rspack-plugin/src/multiple.ts
@@ -32,6 +32,7 @@ export class RsdoctorRspackMultiplePlugin<
       extraConfig: {
         innerClientPath: normallizedOptions.innerClientPath,
         printLog: normallizedOptions.printLog,
+        server: normallizedOptions.server,
         mode: normallizedOptions.output.mode
           ? normallizedOptions.output.mode
           : undefined,

--- a/packages/rspack-plugin/src/plugin.test.ts
+++ b/packages/rspack-plugin/src/plugin.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from '@rstest/core';
+import { RsdoctorRspackPlugin } from './plugin';
+
+describe('RsdoctorRspackPlugin', () => {
+  it('keeps the report server when the client server is disabled in CI', () => {
+    const originalCI = process.env.CI;
+    const originalRSTEST = process.env.RSTEST;
+
+    try {
+      process.env.CI = 'true';
+      delete process.env.RSTEST;
+
+      const plugin = new RsdoctorRspackPlugin();
+
+      expect(plugin.options.disableClientServer).toBe(true);
+      expect(plugin.sdk.server.constructor.name).toBe('RsdoctorServer');
+    } finally {
+      if (typeof originalCI === 'undefined') {
+        delete process.env.CI;
+      } else {
+        process.env.CI = originalCI;
+      }
+
+      if (typeof originalRSTEST === 'undefined') {
+        delete process.env.RSTEST;
+      } else {
+        process.env.RSTEST = originalRSTEST;
+      }
+    }
+  });
+});

--- a/packages/rspack-plugin/src/plugin.ts
+++ b/packages/rspack-plugin/src/plugin.ts
@@ -79,6 +79,7 @@ export class RsdoctorRspackPlugin<
         type: output.reportCodeType,
         config: {
           innerClientPath,
+          noServer: this.options.disableClientServer,
           printLog,
           server,
           mode: output.mode ? output.mode : undefined,

--- a/packages/rspack-plugin/src/plugin.ts
+++ b/packages/rspack-plugin/src/plugin.ts
@@ -79,7 +79,6 @@ export class RsdoctorRspackPlugin<
         type: output.reportCodeType,
         config: {
           innerClientPath,
-          noServer: this.options.disableClientServer,
           printLog,
           server,
           mode: output.mode ? output.mode : undefined,

--- a/packages/rspack-plugin/src/plugin.ts
+++ b/packages/rspack-plugin/src/plugin.ts
@@ -67,7 +67,7 @@ export class RsdoctorRspackPlugin<
         },
       }),
     );
-    const { port, output, innerClientPath, printLog, sdkInstance } =
+    const { port, server, output, innerClientPath, printLog, sdkInstance } =
       this.options;
 
     this.sdk =
@@ -80,6 +80,7 @@ export class RsdoctorRspackPlugin<
         config: {
           innerClientPath,
           printLog,
+          server,
           mode: output.mode ? output.mode : undefined,
           brief:
             output.mode === SDK.IMode[SDK.IMode.brief]

--- a/packages/rspack-plugin/tests/plugin.test.ts
+++ b/packages/rspack-plugin/tests/plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@rstest/core';
-import { RsdoctorRspackPlugin } from './plugin';
+import { RsdoctorRspackPlugin } from '../src/plugin';
 
 describe('RsdoctorRspackPlugin', () => {
   it('keeps the report server when the client server is disabled in CI', () => {

--- a/packages/sdk/src/sdk/multiple/primary.ts
+++ b/packages/sdk/src/sdk/multiple/primary.ts
@@ -42,16 +42,24 @@ export class RsdoctorPrimarySDK
     extraConfig,
     type,
   }: RsdoctorSlaveSDKOptions) {
-    super({ name, root: controller.root });
+    super({
+      name,
+      root: controller.root,
+      config: extraConfig,
+    });
 
     const lastSdk = controller.getLastSdk();
-    const port = lastSdk ? lastSdk.server.port + 1 : this.server.port;
+    const port = lastSdk
+      ? lastSdk.server.port + 1
+      : (extraConfig?.server?.port ?? this.server.port);
 
     this.id = id++;
     this.stage = typeof stage === 'number' ? stage : 1;
     this.extraConfig = extraConfig;
     this.parent = controller;
-    this.server = new RsdoctorSlaveServer(this, port);
+    this.server = new RsdoctorSlaveServer(this, port, {
+      cors: extraConfig?.server?.cors,
+    });
     this.type = type;
     this.setName(name);
     this.clearSwitch();

--- a/packages/sdk/src/sdk/multiple/server.ts
+++ b/packages/sdk/src/sdk/multiple/server.ts
@@ -1,12 +1,16 @@
 import { Server } from '@rsdoctor/utils/build';
-import { RsdoctorServer } from '../server';
+import { RsdoctorServer, type RsdoctorServerOptions } from '../server';
 import type { RsdoctorPrimarySDK } from './primary';
 
 export class RsdoctorSlaveServer extends RsdoctorServer {
   protected sdk: RsdoctorPrimarySDK;
 
-  constructor(sdk: RsdoctorPrimarySDK, port = Server.defaultPort) {
-    super(sdk, port);
+  constructor(
+    sdk: RsdoctorPrimarySDK,
+    port = Server.defaultPort,
+    config?: RsdoctorServerOptions,
+  ) {
+    super(sdk, port, config);
     this.sdk = sdk;
   }
 

--- a/packages/sdk/src/sdk/sdk/index.ts
+++ b/packages/sdk/src/sdk/sdk/index.ts
@@ -60,11 +60,14 @@ export class RsdoctorSDK<
 
   constructor(options: T) {
     super(options);
+    const serverConfig = options.config?.server;
+    const port = serverConfig?.port ?? options.port;
     this.server = options.config?.noServer
-      ? new RsdoctorFakeServer(this, undefined)
-      : new RsdoctorServer(this, options.port, {
+      ? new RsdoctorFakeServer(this, port)
+      : new RsdoctorServer(this, port, {
           innerClientPath: options.config?.innerClientPath || '',
           printServerUrl: options.config?.printLog?.serverUrls,
+          cors: serverConfig?.cors,
         });
     this.type = Lodash.isNumber(options.type)
       ? options.type

--- a/packages/sdk/src/sdk/server/fakeServer.ts
+++ b/packages/sdk/src/sdk/server/fakeServer.ts
@@ -11,5 +11,9 @@ export class RsdoctorFakeServer extends RsdoctorServer {
     this.sdk = sdk;
   }
 
+  async bootstrap() {}
+
   async openClientPage() {}
+
+  dispose = async () => {};
 }

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -13,14 +13,14 @@ import { openBrowser } from '@/sdk/utils/openBrowser';
 import path from 'path';
 import { Lodash } from '@rsdoctor/utils/common';
 import { createRequire } from 'module';
-import { IncomingMessage, ServerResponse } from 'http';
+import { ServerResponse } from 'http';
+import { DEFAULT_ALLOWED_CORS_ORIGINS, isAllowedRequestHost } from './security';
 
 const require = createRequire(import.meta.url);
 export * from './utils';
 
 /** Path for launch-editor: open file in editor from the UI (see https://github.com/yyx990803/launch-editor) */
 const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
-const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
 const LISTEN_RETRY_LIMIT = 10;
 
 export type ISocketType = { port: number; socketUrl: string };
@@ -82,44 +82,6 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     return this._innerClientPath;
   }
 
-  private isLocalOrigin(origin: string) {
-    try {
-      const url = new URL(origin);
-      return (
-        (url.protocol === 'http:' || url.protocol === 'https:') &&
-        LOCAL_HOSTNAMES.has(url.hostname)
-      );
-    } catch {
-      return false;
-    }
-  }
-
-  private setCorsHeaders(req: IncomingMessage, res: ServerResponse) {
-    const origin = req.headers.origin;
-    if (typeof origin !== 'string' || !this.isLocalOrigin(origin)) {
-      return false;
-    }
-
-    res.setHeader('Access-Control-Allow-Origin', origin);
-    res.setHeader('Vary', 'Origin');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    return true;
-  }
-
-  private createSecurityMiddleware(): Thirdparty.connect.NextHandleFunction {
-    return (req, res, next) => {
-      const isCorsAllowed = this.setCorsHeaders(req, res);
-      if (req.method?.toUpperCase() === 'OPTIONS') {
-        res.statusCode = isCorsAllowed ? 204 : 403;
-        res.end();
-        return;
-      }
-
-      next();
-    };
-  }
-
   private async createInnerServer() {
     let expectedPort = this.port;
     let lastError: unknown;
@@ -167,8 +129,23 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     );
 
     this.disposed = false;
+    const { default: cors } = await import('cors');
 
-    this.app.use(this.createSecurityMiddleware());
+    this.app.use((req, res, next) => {
+      const host = req.headers.host || req.headers[':authority'];
+      if (!isAllowedRequestHost(host)) {
+        res.statusCode = 403;
+        res.end();
+        return;
+      }
+
+      next();
+    });
+    this.app.use(
+      cors({
+        origin: DEFAULT_ALLOWED_CORS_ORIGINS,
+      }),
+    );
     this.app.use(bodyParser.json({ limit: '500mb' }));
     const clientHtmlPath = this._innerClientPath
       ? this._innerClientPath
@@ -386,12 +363,13 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     }
     this.disposed = true;
 
-    if (this._socket) {
-      this._socket.dispose();
-    }
-
     if (this._server) {
       await this._server.close();
+    }
+
+    // must close socket after server to avoid socket.io close error.
+    if (this._socket) {
+      this._socket.dispose();
     }
 
     if (exitCode !== undefined) {

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -4,7 +4,6 @@ import serve from 'sirv';
 import { Bundle, GlobalConfig } from '@rsdoctor/utils/common';
 import assert from 'assert';
 import bodyParser from 'body-parser';
-import cors from 'cors';
 import { PassThrough } from 'stream';
 import { Socket } from './socket';
 import { Router } from './router';
@@ -12,18 +11,23 @@ import * as APIs from './apis';
 import { chalk, logger } from '@rsdoctor/utils/logger';
 import { openBrowser } from '@/sdk/utils/openBrowser';
 import path from 'path';
-import { getLocalIpAddress } from './utils';
 import { Lodash } from '@rsdoctor/utils/common';
 import { createRequire } from 'module';
-import { ServerResponse } from 'http';
+import { IncomingMessage, ServerResponse } from 'http';
 
 const require = createRequire(import.meta.url);
 export * from './utils';
 
 /** Path for launch-editor: open file in editor from the UI (see https://github.com/yyx990803/launch-editor) */
 const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+const LISTEN_RETRY_LIMIT = 10;
 
 export type ISocketType = { port: number; socketUrl: string };
+
+function isAddressInUseError(error: unknown) {
+  return (error as { code?: string }).code === 'EADDRINUSE';
+}
 
 export class RsdoctorServer implements SDK.RsdoctorServerInstance {
   private _server!: Common.PromiseReturnType<typeof Server.createServer>;
@@ -60,8 +64,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
   }
 
   public get host(): string {
-    const host = getLocalIpAddress();
-    return host;
+    return Server.defaultHost;
   }
 
   public get origin(): string {
@@ -79,15 +82,77 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     return this._innerClientPath;
   }
 
+  private isLocalOrigin(origin: string) {
+    try {
+      const url = new URL(origin);
+      return (
+        (url.protocol === 'http:' || url.protocol === 'https:') &&
+        LOCAL_HOSTNAMES.has(url.hostname)
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  private setCorsHeaders(req: IncomingMessage, res: ServerResponse) {
+    const origin = req.headers.origin;
+    if (typeof origin !== 'string' || !this.isLocalOrigin(origin)) {
+      return false;
+    }
+
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    return true;
+  }
+
+  private createSecurityMiddleware(): Thirdparty.connect.NextHandleFunction {
+    return (req, res, next) => {
+      const isCorsAllowed = this.setCorsHeaders(req, res);
+      if (req.method?.toUpperCase() === 'OPTIONS') {
+        res.statusCode = isCorsAllowed ? 204 : 403;
+        res.end();
+        return;
+      }
+
+      next();
+    };
+  }
+
+  private async createInnerServer() {
+    let expectedPort = this.port;
+    let lastError: unknown;
+
+    for (let retry = 0; retry < LISTEN_RETRY_LIMIT; retry++) {
+      const port = Server.getPortSync(expectedPort, this.host);
+
+      try {
+        return {
+          port,
+          server: await Server.createServer(port, this.host),
+        };
+      } catch (error) {
+        if (!isAddressInUseError(error)) {
+          throw error;
+        }
+        lastError = error;
+        expectedPort = port + 1;
+      }
+    }
+
+    throw lastError;
+  }
+
   async bootstrap() {
     if (!this.disposed) {
       return;
     }
 
-    const port = Server.getPortSync(this.port);
+    const { port, server } = await this.createInnerServer();
     // rewrite port when the default port is unavailable
     this.port = port;
-    this._server = await Server.createServer(port);
+    this._server = server;
     this._socket = new Socket({
       sdk: this.sdk,
       server: this._server.server,
@@ -103,7 +168,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
 
     this.disposed = false;
 
-    this.app.use(cors());
+    this.app.use(this.createSecurityMiddleware());
     this.app.use(bodyParser.json({ limit: '500mb' }));
     const clientHtmlPath = this._innerClientPath
       ? this._innerClientPath
@@ -199,9 +264,6 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
       if (m === method) {
         try {
           const body = await cb(req, res, next);
-
-          res.setHeader('Access-Control-Allow-Origin', '*');
-          res.setHeader('Access-Control-Allow-Credentials', 'true');
           res.statusCode = 200;
 
           if (Buffer.isBuffer(body)) {

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -160,12 +160,6 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
       server: this._server.server,
       port: this.port,
       token: this._socketToken,
-      socketOptions:
-        corsOptions === false
-          ? undefined
-          : {
-              cors: corsOptions,
-            },
     });
     await this._socket.bootstrap();
 
@@ -426,7 +420,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
       await this._server.close();
     }
 
-    // must close socket after server to avoid socket.io close error.
+    // Close sockets after the HTTP server stops accepting new connections.
     if (this._socket) {
       this._socket.dispose();
     }

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -4,6 +4,7 @@ import serve from 'sirv';
 import { Bundle, GlobalConfig } from '@rsdoctor/utils/common';
 import assert from 'assert';
 import bodyParser from 'body-parser';
+import cors from 'cors';
 import { PassThrough } from 'stream';
 import { Socket } from './socket';
 import { Router } from './router';
@@ -14,7 +15,12 @@ import path from 'path';
 import { Lodash } from '@rsdoctor/utils/common';
 import { createRequire } from 'module';
 import { ServerResponse } from 'http';
-import { DEFAULT_ALLOWED_CORS_ORIGINS, isAllowedRequestHost } from './security';
+import { randomBytes } from 'crypto';
+import {
+  DEFAULT_ALLOWED_CORS_ORIGINS,
+  isAllowedCorsRequest,
+  isAllowedRequestHost,
+} from './security';
 
 const require = createRequire(import.meta.url);
 export * from './utils';
@@ -23,7 +29,13 @@ export * from './utils';
 const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
 const LISTEN_RETRY_LIMIT = 10;
 
-export type ISocketType = { port: number; socketUrl: string };
+export type ISocketType = { port: number; socketUrl: string; token: string };
+
+export type RsdoctorServerOptions = {
+  innerClientPath?: string;
+  printServerUrl?: boolean;
+  cors?: SDK.RsdoctorServerConfig['cors'];
+};
 
 function isAddressInUseError(error: unknown) {
   return (error as { code?: string }).code === 'EADDRINUSE';
@@ -44,10 +56,14 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
 
   private _printServerUrl: boolean;
 
+  private _cors: SDK.RsdoctorServerConfig['cors'];
+
+  private _socketToken = randomBytes(16).toString('hex');
+
   constructor(
     protected sdk: SDK.RsdoctorBuilderSDKInstance,
     port = Server.defaultPort,
-    config?: { innerClientPath?: string; printServerUrl?: boolean },
+    config?: RsdoctorServerOptions,
   ) {
     assert(typeof port === 'number');
     // maybe the port will be rewrite in bootstrap()
@@ -57,6 +73,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     this._printServerUrl = Lodash.isUndefined(config?.printServerUrl)
       ? true
       : config?.printServerUrl;
+    this._cors = config?.cors;
   }
 
   public get app(): SDK.RsdoctorServerInstance['app'] {
@@ -74,7 +91,8 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
   public get socketUrl(): ISocketType {
     return {
       port: this.port,
-      socketUrl: `ws://localhost:${this.port}`,
+      socketUrl: `ws://localhost:${this.port}?token=${this._socketToken}`,
+      token: this._socketToken,
     };
   }
 
@@ -106,12 +124,34 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     throw lastError;
   }
 
+  private resolveCorsOptions(): false | SDK.RsdoctorServerCorsOptions {
+    if (this._cors === false) {
+      return false;
+    }
+    if (this._cors === true) {
+      return {};
+    }
+    if (typeof this._cors === 'undefined') {
+      return {
+        origin: DEFAULT_ALLOWED_CORS_ORIGINS,
+      };
+    }
+    return {
+      ...this._cors,
+      origin:
+        typeof this._cors.origin === 'undefined'
+          ? DEFAULT_ALLOWED_CORS_ORIGINS
+          : this._cors.origin,
+    };
+  }
+
   async bootstrap() {
     if (!this.disposed) {
       return;
     }
 
     const { port, server } = await this.createInnerServer();
+    const corsOptions = this.resolveCorsOptions();
     // rewrite port when the default port is unavailable
     this.port = port;
     this._server = server;
@@ -119,6 +159,13 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
       sdk: this.sdk,
       server: this._server.server,
       port: this.port,
+      token: this._socketToken,
+      socketOptions:
+        corsOptions === false
+          ? undefined
+          : {
+              cors: corsOptions,
+            },
     });
     await this._socket.bootstrap();
 
@@ -129,7 +176,6 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     );
 
     this.disposed = false;
-    const { default: cors } = await import('cors');
 
     this.app.use((req, res, next) => {
       const host = req.headers.host || req.headers[':authority'];
@@ -141,12 +187,27 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
 
       next();
     });
-    this.app.use(
-      cors({
-        origin: DEFAULT_ALLOWED_CORS_ORIGINS,
-      }),
-    );
+    if (
+      corsOptions !== false &&
+      corsOptions.origin === DEFAULT_ALLOWED_CORS_ORIGINS
+    ) {
+      this.app.use((req, res, next) => {
+        const host = req.headers.host || req.headers[':authority'];
+        if (!isAllowedCorsRequest(req.headers.origin, host)) {
+          res.statusCode = 403;
+          res.end();
+          return;
+        }
+
+        next();
+      });
+    }
+    if (corsOptions !== false) {
+      this.app.use(cors(corsOptions));
+    }
     this.app.use(bodyParser.json({ limit: '500mb' }));
+    await this._router.setup();
+
     const clientHtmlPath = this._innerClientPath
       ? this._innerClientPath
       : require.resolve('@rsdoctor/client');
@@ -209,8 +270,6 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
         }
       },
     );
-
-    await this._router.setup();
 
     process.once('exit', () => this.dispose());
     process.once('SIGINT', () => this.dispose(0));

--- a/packages/sdk/src/sdk/server/security.ts
+++ b/packages/sdk/src/sdk/server/security.ts
@@ -1,0 +1,38 @@
+import { isIP } from 'node:net';
+
+export const DEFAULT_ALLOWED_CORS_ORIGINS =
+  /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/;
+
+const LOCAL_HOSTNAMES = /^(?:localhost|[^:]+\.localhost)$/;
+
+export function isAllowedRequestOrigin(origin: string | string[] | undefined) {
+  if (origin === undefined) {
+    return true;
+  }
+
+  return (
+    typeof origin === 'string' && DEFAULT_ALLOWED_CORS_ORIGINS.test(origin)
+  );
+}
+
+function isIpAddress(hostname: string) {
+  return isIP(hostname) !== 0;
+}
+
+function getHostnameFromHost(host: string) {
+  if (host.startsWith('[')) {
+    const endIndex = host.indexOf(']');
+    return endIndex === -1 ? '' : host.slice(1, endIndex);
+  }
+
+  return host.split(':')[0];
+}
+
+export function isAllowedRequestHost(host: string | string[] | undefined) {
+  if (typeof host !== 'string') {
+    return false;
+  }
+
+  const hostname = getHostnameFromHost(host).toLowerCase();
+  return LOCAL_HOSTNAMES.test(hostname) || isIpAddress(hostname);
+}

--- a/packages/sdk/src/sdk/server/security.ts
+++ b/packages/sdk/src/sdk/server/security.ts
@@ -15,6 +15,17 @@ export function isAllowedRequestOrigin(origin: string | string[] | undefined) {
   );
 }
 
+function getHostnameFromOrigin(origin: string) {
+  try {
+    const hostname = new URL(origin).hostname.toLowerCase();
+    return hostname.startsWith('[') && hostname.endsWith(']')
+      ? hostname.slice(1, -1)
+      : hostname;
+  } catch {
+    return '';
+  }
+}
+
 function isIpAddress(hostname: string) {
   return isIP(hostname) !== 0;
 }
@@ -35,4 +46,29 @@ export function isAllowedRequestHost(host: string | string[] | undefined) {
 
   const hostname = getHostnameFromHost(host).toLowerCase();
   return LOCAL_HOSTNAMES.test(hostname) || isIpAddress(hostname);
+}
+
+export function isAllowedCorsRequest(
+  origin: string | string[] | undefined,
+  host: string | string[] | undefined,
+) {
+  if (origin === undefined) {
+    return true;
+  }
+  if (
+    typeof origin !== 'string' ||
+    typeof host !== 'string' ||
+    !isAllowedRequestOrigin(origin)
+  ) {
+    return false;
+  }
+
+  const originHostname = getHostnameFromOrigin(origin);
+  const hostHostname = getHostnameFromHost(host).toLowerCase();
+
+  if (originHostname.endsWith('.localhost')) {
+    return originHostname === hostHostname;
+  }
+
+  return true;
 }

--- a/packages/sdk/src/sdk/server/socket/index.ts
+++ b/packages/sdk/src/sdk/server/socket/index.ts
@@ -7,13 +7,22 @@ import {
 } from 'socket.io';
 import { isDeepStrictEqual } from 'util';
 import { SocketAPILoader } from './api';
-import { isAllowedRequestHost, isAllowedRequestOrigin } from '../security';
+import { isAllowedRequestHost } from '../security';
 
 interface SocketOptions {
   sdk: SDK.RsdoctorBuilderSDKInstance;
   server: Server;
   port: number;
-  socketOptions?: SocketServerOptions;
+  token: string;
+  socketOptions?: Partial<SocketServerOptions>;
+}
+
+function isAllowedSocketToken(url: string | undefined, token: string) {
+  if (!url) {
+    return false;
+  }
+
+  return new URL(url, 'http://localhost').searchParams.get('token') === token;
 }
 
 export class Socket {
@@ -30,26 +39,14 @@ export class Socket {
 
   public bootstrap() {
     const { socketOptions } = this.options;
-    const corsOptions =
-      socketOptions?.cors &&
-      typeof socketOptions.cors === 'object' &&
-      !Array.isArray(socketOptions.cors)
-        ? socketOptions.cors
-        : {};
 
     this.io = new SocketServer(this.options.server, {
       ...socketOptions,
-      cors: {
-        ...corsOptions,
-        origin: (origin, callback) => {
-          callback(null, isAllowedRequestOrigin(origin));
-        },
-      },
       allowRequest: (req, callback) => {
         const host = req.headers.host || req.headers[':authority'];
         if (
           !isAllowedRequestHost(host) ||
-          !isAllowedRequestOrigin(req.headers.origin)
+          !isAllowedSocketToken(req.url, this.options.token)
         ) {
           callback(null, false);
           return;

--- a/packages/sdk/src/sdk/server/socket/index.ts
+++ b/packages/sdk/src/sdk/server/socket/index.ts
@@ -1,205 +1,102 @@
 import { Common, SDK } from '@rsdoctor/types';
 import type { Server } from 'http';
-import WebSocket, { WebSocketServer } from 'ws';
+import {
+  Server as SocketServer,
+  ServerOptions as SocketServerOptions,
+  Socket as SocketType,
+} from 'socket.io';
+import { isDeepStrictEqual } from 'util';
 import { SocketAPILoader } from './api';
+import { isAllowedRequestHost, isAllowedRequestOrigin } from '../security';
 
 interface SocketOptions {
   sdk: SDK.RsdoctorBuilderSDKInstance;
   server: Server;
   port: number;
+  socketOptions?: SocketServerOptions;
 }
 
-type Subscription = {
-  api: SDK.ServerAPI.API;
-  body: Common.PlainObject | null;
-};
-
-type SubscriptionRecord = Subscription & {
-  count: number;
-};
-
-type ClientMessage = {
-  type?: string;
-  id?: string;
-  api?: SDK.ServerAPI.API;
-  body?: Common.PlainObject | null;
-};
-
 export class Socket {
-  protected server?: WebSocketServer;
-
-  protected clients = new Set<WebSocket>();
+  protected io!: SocketServer;
 
   protected loader: SocketAPILoader;
 
-  protected map: Map<string, SubscriptionRecord> = new Map();
-
-  protected clientSubscriptions: Map<WebSocket, Set<string>> = new Map();
+  protected map: Map<SDK.ServerAPI.API, (Common.PlainObject | null)[]> =
+    new Map();
 
   constructor(protected options: SocketOptions) {
     this.loader = new SocketAPILoader({ sdk: options.sdk });
   }
 
   public bootstrap() {
-    this.server = new WebSocketServer({ server: this.options.server });
-    this.server.on('connection', (client) => {
-      this.attachClient(client);
+    const { socketOptions } = this.options;
+    const corsOptions =
+      socketOptions?.cors &&
+      typeof socketOptions.cors === 'object' &&
+      !Array.isArray(socketOptions.cors)
+        ? socketOptions.cors
+        : {};
+
+    this.io = new SocketServer(this.options.server, {
+      ...socketOptions,
+      cors: {
+        ...corsOptions,
+        origin: (origin, callback) => {
+          callback(null, isAllowedRequestOrigin(origin));
+        },
+      },
+      allowRequest: (req, callback) => {
+        const host = req.headers.host || req.headers[':authority'];
+        if (
+          !isAllowedRequestHost(host) ||
+          !isAllowedRequestOrigin(req.headers.origin)
+        ) {
+          callback(null, false);
+          return;
+        }
+
+        if (socketOptions?.allowRequest) {
+          socketOptions.allowRequest(req, callback);
+          return;
+        }
+
+        callback(null, true);
+      },
+    });
+    this.io.on('connection', (socket) => {
+      // setup event listeners for every socket which connected
+      this.setupSocket(socket);
     });
   }
 
-  public attachClient(client: WebSocket) {
-    this.clients.add(client);
+  protected setupSocket(socket: SocketType) {
+    // setup server api load request
+    Object.values(SDK.ServerAPI.API).forEach((api) => {
+      // server received the request for server api
+      // and the first argument is request body.
+      socket.on(api, async (body, callback) => {
+        // save to map for server side emit event to client.
+        this.saveRequestToMap(api, body);
 
-    if (typeof client.on === 'function') {
-      client.on('message', (message) => {
-        this.handleClientMessage(message.toString(), client);
+        // server will send the response for server api
+        callback(await this.getAPIResponse(api, body));
       });
-      client.on('close', () => {
-        this.clients.delete(client);
-        this.removeClientSubscriptions(client);
-      });
-    }
-  }
-
-  public async handleClientMessage(raw: string, client?: WebSocket) {
-    let message: ClientMessage;
-    try {
-      message = JSON.parse(raw) as ClientMessage;
-    } catch {
-      return;
-    }
-
-    if (
-      !message.api ||
-      !Object.values(SDK.ServerAPI.API).includes(message.api)
-    ) {
-      return;
-    }
-
-    if (message.type === 'request') {
-      await this.handleAPIRequestMessage(message, client);
-      return;
-    }
-
-    if (message.type === 'subscribe') {
-      this.saveRequestToMap(message.api, message.body ?? null, client);
-      return;
-    }
-
-    if (message.type === 'unsubscribe') {
-      this.removeRequestFromMap(message.api, message.body ?? null, client);
-    }
-  }
-
-  protected async handleAPIRequestMessage(
-    message: ClientMessage,
-    client?: WebSocket,
-  ) {
-    if (!message.id || !client || client.readyState !== WebSocket.OPEN) {
-      return;
-    }
-
-    try {
-      const response = await this.getAPIResponse(message.api!, message.body!);
-      client.send(
-        JSON.stringify({
-          type: 'response',
-          id: message.id,
-          payload: response.res,
-        }),
-      );
-    } catch (err) {
-      client.send(
-        JSON.stringify({
-          type: 'response',
-          id: message.id,
-          error: err instanceof Error ? err.message : String(err),
-        }),
-      );
-    }
-  }
-
-  public getSubscriptions(): Subscription[] {
-    return [...this.map.values()].map(({ api, body }) => ({ api, body }));
+    });
   }
 
   protected saveRequestToMap<T extends SDK.ServerAPI.API>(
     api: T,
     body: SDK.ServerAPI.InferRequestBodyType<T, null> | null = null,
-    client?: WebSocket,
   ) {
-    const key = this.getSubscriptionKey(api, body);
-    if (client) {
-      if (!this.clientSubscriptions.has(client)) {
-        this.clientSubscriptions.set(client, new Set());
-      }
-      const subscriptions = this.clientSubscriptions.get(client)!;
-      if (subscriptions.has(key)) {
-        return;
-      }
-      subscriptions.add(key);
+    if (!this.map.has(api)) {
+      this.map.set(api, []);
     }
 
-    const record = this.map.get(key);
-    if (record) {
-      record.count += 1;
-      return;
+    const list = this.map.get(api)!;
+
+    if (!list.some((e) => e === body || isDeepStrictEqual(e, body))) {
+      list.push(body);
     }
-
-    this.map.set(key, {
-      api,
-      body,
-      count: 1,
-    });
-  }
-
-  protected removeRequestFromMap<T extends SDK.ServerAPI.API>(
-    api: T,
-    body: SDK.ServerAPI.InferRequestBodyType<T, null> | null = null,
-    client?: WebSocket,
-  ) {
-    const key = this.getSubscriptionKey(api, body);
-    if (client) {
-      const subscriptions = this.clientSubscriptions.get(client);
-      if (!subscriptions?.has(key)) {
-        return;
-      }
-      subscriptions.delete(key);
-      if (subscriptions.size === 0) {
-        this.clientSubscriptions.delete(client);
-      }
-    }
-
-    this.removeSubscriptionKey(key);
-  }
-
-  protected removeClientSubscriptions(client: WebSocket) {
-    const subscriptions = this.clientSubscriptions.get(client);
-    if (!subscriptions) {
-      return;
-    }
-
-    subscriptions.forEach((key) => this.removeSubscriptionKey(key));
-    this.clientSubscriptions.delete(client);
-  }
-
-  protected removeSubscriptionKey(key: string) {
-    const record = this.map.get(key);
-    if (!record) {
-      return;
-    }
-
-    record.count -= 1;
-    if (record.count <= 0) {
-      this.map.delete(key);
-    }
-  }
-
-  protected getSubscriptionKey(
-    api: SDK.ServerAPI.API,
-    body: Common.PlainObject | null,
-  ) {
-    return `${api}:${JSON.stringify(body ?? null)}`;
   }
 
   protected async getAPIResponse<T extends SDK.ServerAPI.API>(
@@ -227,13 +124,15 @@ export class Socket {
     this.timer = setImmediate(async () => {
       const promises: Promise<void>[] = [];
 
-      this.map.forEach(({ api, body }) => {
-        promises.push(
-          (async () => {
-            const res = await this.getAPIResponse(api, body!);
-            this.sendAPIData(api, res);
-          })(),
-        );
+      this.map.forEach((bodies, api) => {
+        bodies.forEach((body) => {
+          promises.push(
+            (async () => {
+              const res = await this.getAPIResponse(api, body!);
+              this.io.emit(api, res);
+            })(),
+          );
+        });
       });
 
       await Promise.all(promises);
@@ -242,21 +141,13 @@ export class Socket {
 
   public sendAPIData<T extends SDK.ServerAPI.API | SDK.ServerAPI.APIExtends>(
     api: T,
-    payload: SDK.ServerAPI.SocketResponseType<T>,
+    msg: SDK.ServerAPI.SocketResponseType<T>,
   ) {
-    const message = JSON.stringify({ api, payload });
-    this.clients.forEach((client) => {
-      if (client.readyState === WebSocket.OPEN) {
-        client.send(message);
-      }
-    });
+    this.io.sockets.emit(api, msg);
   }
 
   public dispose() {
-    this.clients.forEach((client) => {
-      client.close();
-    });
-    this.clients.clear();
-    this.server?.close();
+    this.io.disconnectSockets();
+    this.io.close();
   }
 }

--- a/packages/sdk/src/sdk/server/socket/index.ts
+++ b/packages/sdk/src/sdk/server/socket/index.ts
@@ -1,11 +1,7 @@
 import { Common, SDK } from '@rsdoctor/types';
 import type { Server } from 'http';
-import {
-  Server as SocketServer,
-  ServerOptions as SocketServerOptions,
-  Socket as SocketType,
-} from 'socket.io';
-import { isDeepStrictEqual } from 'util';
+import WebSocket, { WebSocketServer } from 'ws';
+import type { VerifyClientCallbackSync } from 'ws';
 import { SocketAPILoader } from './api';
 import { isAllowedRequestHost } from '../security';
 
@@ -14,8 +10,23 @@ interface SocketOptions {
   server: Server;
   port: number;
   token: string;
-  socketOptions?: Partial<SocketServerOptions>;
 }
+
+type Subscription = {
+  api: SDK.ServerAPI.API;
+  body: Common.PlainObject | null;
+};
+
+type SubscriptionRecord = Subscription & {
+  count: number;
+};
+
+type ClientMessage = {
+  type?: string;
+  id?: string;
+  api?: SDK.ServerAPI.API;
+  body?: Common.PlainObject | null;
+};
 
 function isAllowedSocketToken(url: string | undefined, token: string) {
   if (!url) {
@@ -26,74 +37,189 @@ function isAllowedSocketToken(url: string | undefined, token: string) {
 }
 
 export class Socket {
-  protected io!: SocketServer;
+  protected server?: WebSocketServer;
+
+  protected clients = new Set<WebSocket>();
 
   protected loader: SocketAPILoader;
 
-  protected map: Map<SDK.ServerAPI.API, (Common.PlainObject | null)[]> =
-    new Map();
+  protected map: Map<string, SubscriptionRecord> = new Map();
+
+  protected clientSubscriptions: Map<WebSocket, Set<string>> = new Map();
 
   constructor(protected options: SocketOptions) {
     this.loader = new SocketAPILoader({ sdk: options.sdk });
   }
 
   public bootstrap() {
-    const { socketOptions } = this.options;
-
-    this.io = new SocketServer(this.options.server, {
-      ...socketOptions,
-      allowRequest: (req, callback) => {
+    this.server = new WebSocketServer({
+      server: this.options.server,
+      verifyClient: (({ req }) => {
         const host = req.headers.host || req.headers[':authority'];
-        if (
-          !isAllowedRequestHost(host) ||
-          !isAllowedSocketToken(req.url, this.options.token)
-        ) {
-          callback(null, false);
-          return;
-        }
-
-        if (socketOptions?.allowRequest) {
-          socketOptions.allowRequest(req, callback);
-          return;
-        }
-
-        callback(null, true);
-      },
+        return (
+          isAllowedRequestHost(host) &&
+          isAllowedSocketToken(req.url, this.options.token)
+        );
+      }) satisfies VerifyClientCallbackSync,
     });
-    this.io.on('connection', (socket) => {
-      // setup event listeners for every socket which connected
-      this.setupSocket(socket);
+    this.server.on('connection', (client) => {
+      this.attachClient(client);
     });
   }
 
-  protected setupSocket(socket: SocketType) {
-    // setup server api load request
-    Object.values(SDK.ServerAPI.API).forEach((api) => {
-      // server received the request for server api
-      // and the first argument is request body.
-      socket.on(api, async (body, callback) => {
-        // save to map for server side emit event to client.
-        this.saveRequestToMap(api, body);
+  public attachClient(client: WebSocket) {
+    this.clients.add(client);
 
-        // server will send the response for server api
-        callback(await this.getAPIResponse(api, body));
+    if (typeof client.on === 'function') {
+      client.on('message', (message) => {
+        this.handleClientMessage(message.toString(), client);
       });
-    });
+      client.on('close', () => {
+        this.clients.delete(client);
+        this.removeClientSubscriptions(client);
+      });
+    }
+  }
+
+  public async handleClientMessage(raw: string, client?: WebSocket) {
+    let message: ClientMessage;
+    try {
+      message = JSON.parse(raw) as ClientMessage;
+    } catch {
+      return;
+    }
+
+    if (
+      !message.api ||
+      !Object.values(SDK.ServerAPI.API).includes(message.api)
+    ) {
+      return;
+    }
+
+    if (message.type === 'request') {
+      await this.handleAPIRequestMessage(message, client);
+      return;
+    }
+
+    if (message.type === 'subscribe') {
+      this.saveRequestToMap(message.api, message.body ?? null, client);
+      return;
+    }
+
+    if (message.type === 'unsubscribe') {
+      this.removeRequestFromMap(message.api, message.body ?? null, client);
+    }
+  }
+
+  protected async handleAPIRequestMessage(
+    message: ClientMessage,
+    client?: WebSocket,
+  ) {
+    if (!message.id || !client || client.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    try {
+      const response = await this.getAPIResponse(message.api!, message.body!);
+      client.send(
+        JSON.stringify({
+          type: 'response',
+          id: message.id,
+          payload: response.res,
+        }),
+      );
+    } catch (err) {
+      client.send(
+        JSON.stringify({
+          type: 'response',
+          id: message.id,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    }
+  }
+
+  public getSubscriptions(): Subscription[] {
+    return [...this.map.values()].map(({ api, body }) => ({ api, body }));
   }
 
   protected saveRequestToMap<T extends SDK.ServerAPI.API>(
     api: T,
     body: SDK.ServerAPI.InferRequestBodyType<T, null> | null = null,
+    client?: WebSocket,
   ) {
-    if (!this.map.has(api)) {
-      this.map.set(api, []);
+    const key = this.getSubscriptionKey(api, body);
+    if (client) {
+      if (!this.clientSubscriptions.has(client)) {
+        this.clientSubscriptions.set(client, new Set());
+      }
+      const subscriptions = this.clientSubscriptions.get(client)!;
+      if (subscriptions.has(key)) {
+        return;
+      }
+      subscriptions.add(key);
     }
 
-    const list = this.map.get(api)!;
-
-    if (!list.some((e) => e === body || isDeepStrictEqual(e, body))) {
-      list.push(body);
+    const record = this.map.get(key);
+    if (record) {
+      record.count += 1;
+      return;
     }
+
+    this.map.set(key, {
+      api,
+      body,
+      count: 1,
+    });
+  }
+
+  protected removeRequestFromMap<T extends SDK.ServerAPI.API>(
+    api: T,
+    body: SDK.ServerAPI.InferRequestBodyType<T, null> | null = null,
+    client?: WebSocket,
+  ) {
+    const key = this.getSubscriptionKey(api, body);
+    if (client) {
+      const subscriptions = this.clientSubscriptions.get(client);
+      if (!subscriptions?.has(key)) {
+        return;
+      }
+      subscriptions.delete(key);
+      if (subscriptions.size === 0) {
+        this.clientSubscriptions.delete(client);
+      }
+    }
+
+    this.removeSubscriptionKey(key);
+  }
+
+  protected removeClientSubscriptions(client: WebSocket) {
+    const subscriptions = this.clientSubscriptions.get(client);
+    if (!subscriptions) {
+      return;
+    }
+
+    subscriptions.forEach((key) => this.removeSubscriptionKey(key));
+    this.clientSubscriptions.delete(client);
+  }
+
+  protected removeSubscriptionKey(key: string) {
+    const record = this.map.get(key);
+    if (!record) {
+      return;
+    }
+
+    record.count -= 1;
+    if (record.count <= 0) {
+      this.map.delete(key);
+    }
+  }
+
+  protected getSubscriptionKey(
+    api: SDK.ServerAPI.API,
+    body: Common.PlainObject | null,
+  ) {
+    return `${api}:${JSON.stringify(body ?? null)}`;
   }
 
   protected async getAPIResponse<T extends SDK.ServerAPI.API>(
@@ -121,15 +247,13 @@ export class Socket {
     this.timer = setImmediate(async () => {
       const promises: Promise<void>[] = [];
 
-      this.map.forEach((bodies, api) => {
-        bodies.forEach((body) => {
-          promises.push(
-            (async () => {
-              const res = await this.getAPIResponse(api, body!);
-              this.io.emit(api, res);
-            })(),
-          );
-        });
+      this.map.forEach(({ api, body }) => {
+        promises.push(
+          (async () => {
+            const res = await this.getAPIResponse(api, body!);
+            this.sendAPIData(api, res);
+          })(),
+        );
       });
 
       await Promise.all(promises);
@@ -138,13 +262,21 @@ export class Socket {
 
   public sendAPIData<T extends SDK.ServerAPI.API | SDK.ServerAPI.APIExtends>(
     api: T,
-    msg: SDK.ServerAPI.SocketResponseType<T>,
+    payload: SDK.ServerAPI.SocketResponseType<T>,
   ) {
-    this.io.sockets.emit(api, msg);
+    const message = JSON.stringify({ api, payload });
+    this.clients.forEach((client) => {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(message);
+      }
+    });
   }
 
   public dispose() {
-    this.io.disconnectSockets();
-    this.io.close();
+    this.clients.forEach((client) => {
+      client.close();
+    });
+    this.clients.clear();
+    this.server?.close();
   }
 }

--- a/packages/sdk/tests/sdk/core/atomic-write.test.ts
+++ b/packages/sdk/tests/sdk/core/atomic-write.test.ts
@@ -62,8 +62,12 @@ describe('atomic write manifest', () => {
           const sdk = new RsdoctorSDK({
             name: 'test',
             root: process.cwd(),
-            port,
-            config: { noServer: true },
+            config: {
+              noServer: true,
+              server: {
+                port,
+              },
+            },
           });
 
           try {

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -2,15 +2,33 @@ import { describe, it, expect, rs } from '@rstest/core';
 import { Manifest, SDK } from '@rsdoctor/types';
 import { Manifest as ManifestShared } from '@rsdoctor/utils/common';
 import { request } from 'http';
-import { cwd, setupSDK } from '../../utils';
+import { cwd, setupSDK, type MockSDKResponse } from '../../utils';
 import { getLocalIpAddress } from '../../../src/sdk/server/utils';
 
 rs.setConfig({ testTimeout: 50000 });
 
 describe('test server/apis/project.ts', () => {
   const target = setupSDK();
+  const customCorsTarget = setupSDK({
+    server: {
+      cors: {
+        origin: 'https://example.com',
+      },
+    },
+  });
+  const partialCorsTarget = setupSDK({
+    server: {
+      cors: {
+        credentials: true,
+      },
+    },
+  });
 
-  function optionsWithOrigin(origin: string, host?: string) {
+  function optionsWithOrigin(
+    target: MockSDKResponse,
+    origin: string,
+    host?: string,
+  ) {
     return new Promise<{
       statusCode: number;
       allowOrigin: string | string[] | undefined;
@@ -76,37 +94,38 @@ describe('test server/apis/project.ts', () => {
     expect(env.port).toEqual(target.server.port);
   });
 
-  it('only allows local CORS preflight requests', async () => {
+  it('uses local origins for default CORS preflight requests', async () => {
     await expect(
-      optionsWithOrigin('https://example.com'),
+      optionsWithOrigin(target, 'https://example.com'),
     ).resolves.toStrictEqual({
-      statusCode: 204,
+      statusCode: 403,
       allowOrigin: undefined,
     });
 
     await expect(
-      optionsWithOrigin(`http://127.0.0.1:${target.server.port}`),
+      optionsWithOrigin(target, `http://127.0.0.1:${target.server.port}`),
     ).resolves.toStrictEqual({
       statusCode: 204,
       allowOrigin: `http://127.0.0.1:${target.server.port}`,
     });
 
     await expect(
-      optionsWithOrigin(`http://127.0.0.1:${target.server.port + 1}`),
+      optionsWithOrigin(target, `http://127.0.0.1:${target.server.port + 1}`),
     ).resolves.toStrictEqual({
       statusCode: 204,
       allowOrigin: `http://127.0.0.1:${target.server.port + 1}`,
     });
 
     await expect(
-      optionsWithOrigin(`http://foo.localhost:${target.server.port}`),
+      optionsWithOrigin(target, `http://foo.localhost:${target.server.port}`),
     ).resolves.toStrictEqual({
-      statusCode: 204,
-      allowOrigin: `http://foo.localhost:${target.server.port}`,
+      statusCode: 403,
+      allowOrigin: undefined,
     });
 
     await expect(
       optionsWithOrigin(
+        target,
         `http://foo.localhost:${target.server.port}`,
         `foo.localhost:${target.server.port}`,
       ),
@@ -131,6 +150,44 @@ describe('test server/apis/project.ts', () => {
       requestWithHost('/__open-in-editor?file=/tmp/example.js', host),
     ).resolves.toStrictEqual({
       statusCode: 403,
+    });
+  });
+
+  it('supports custom server.cors options', async () => {
+    await expect(
+      optionsWithOrigin(customCorsTarget, 'https://example.com'),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: 'https://example.com',
+    });
+
+    await expect(
+      optionsWithOrigin(
+        customCorsTarget,
+        `http://127.0.0.1:${customCorsTarget.server.port}`,
+      ),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: 'https://example.com',
+    });
+  });
+
+  it('preserves default CORS origins for partial server.cors options', async () => {
+    await expect(
+      optionsWithOrigin(partialCorsTarget, 'https://example.com'),
+    ).resolves.toStrictEqual({
+      statusCode: 403,
+      allowOrigin: undefined,
+    });
+
+    await expect(
+      optionsWithOrigin(
+        partialCorsTarget,
+        `http://127.0.0.1:${partialCorsTarget.server.port}`,
+      ),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: `http://127.0.0.1:${partialCorsTarget.server.port}`,
     });
   });
 

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -192,9 +192,7 @@ describe('test server/apis/project.ts', () => {
   });
 
   it(`test api: ${SDK.ServerAPI.API.Manifest}`, async () => {
-    target.sdk.addClientRoutes([
-      Manifest.RsdoctorManifestClientRoutes.WebpackLoaders,
-    ]);
+    target.sdk.addClientRoutes([Manifest.RsdoctorManifestClientRoutes.Loaders]);
 
     const manifestStr = (
       await target.get(SDK.ServerAPI.API.Manifest)
@@ -204,7 +202,7 @@ describe('test server/apis/project.ts', () => {
     expect(manifest.data.root === cwd);
     expect(manifest.client.enableRoutes).toStrictEqual([
       Manifest.RsdoctorManifestClientRoutes.Overall,
-      Manifest.RsdoctorManifestClientRoutes.WebpackLoaders,
+      Manifest.RsdoctorManifestClientRoutes.Loaders,
     ]);
     expect(manifest.data.pid).toEqual(process.pid);
 

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, rs } from '@rstest/core';
 import { Manifest, SDK } from '@rsdoctor/types';
 import { Manifest as ManifestShared } from '@rsdoctor/utils/common';
+import { request } from 'http';
 import { cwd, setupSDK } from '../../utils';
 import { getLocalIpAddress } from '../../../src/sdk/server/utils';
 
@@ -9,11 +10,66 @@ rs.setConfig({ testTimeout: 50000 });
 describe('test server/apis/project.ts', () => {
   const target = setupSDK();
 
+  function optionsWithOrigin(origin: string) {
+    return new Promise<{
+      statusCode: number;
+      allowOrigin: string | string[] | undefined;
+    }>((resolve, reject) => {
+      const url = new URL(
+        `${target.server.origin}${SDK.ServerAPI.API.Manifest}`,
+      );
+      const req = request(
+        {
+          hostname: url.hostname,
+          port: url.port,
+          path: url.pathname,
+          method: 'OPTIONS',
+          headers: { Origin: origin },
+        },
+        (res) => {
+          res.on('data', () => {});
+          res.on('close', () => {
+            resolve({
+              statusCode: res.statusCode || 0,
+              allowOrigin: res.headers['access-control-allow-origin'],
+            });
+          });
+        },
+      );
+
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
   it(`test api: ${SDK.ServerAPI.API.Env}`, async () => {
     const env = (await target.get(SDK.ServerAPI.API.Env)).toJSON();
 
     expect(env.ip).toEqual(getLocalIpAddress());
     expect(env.port).toEqual(target.server.port);
+  });
+
+  it('only allows local CORS preflight requests', async () => {
+    await expect(
+      optionsWithOrigin('https://example.com'),
+    ).resolves.toStrictEqual({
+      statusCode: 403,
+      allowOrigin: undefined,
+    });
+
+    await expect(
+      optionsWithOrigin(`http://127.0.0.1:${target.server.port}`),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: `http://127.0.0.1:${target.server.port}`,
+    });
+
+    await expect(
+      optionsWithOrigin(`http://127.0.0.1:${target.server.port + 1}`),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: `http://127.0.0.1:${target.server.port + 1}`,
+    });
   });
 
   it(`test api: ${SDK.ServerAPI.API.Manifest}`, async () => {

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -10,7 +10,7 @@ rs.setConfig({ testTimeout: 50000 });
 describe('test server/apis/project.ts', () => {
   const target = setupSDK();
 
-  function optionsWithOrigin(origin: string) {
+  function optionsWithOrigin(origin: string, host?: string) {
     return new Promise<{
       statusCode: number;
       allowOrigin: string | string[] | undefined;
@@ -24,7 +24,10 @@ describe('test server/apis/project.ts', () => {
           port: url.port,
           path: url.pathname,
           method: 'OPTIONS',
-          headers: { Origin: origin },
+          headers: {
+            Origin: origin,
+            ...(host ? { Host: host } : {}),
+          },
         },
         (res) => {
           res.on('data', () => {});
@@ -33,6 +36,30 @@ describe('test server/apis/project.ts', () => {
               statusCode: res.statusCode || 0,
               allowOrigin: res.headers['access-control-allow-origin'],
             });
+          });
+        },
+      );
+
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
+  function requestWithHost(pathname: string, host: string) {
+    return new Promise<{ statusCode: number }>((resolve, reject) => {
+      const url = new URL(`${target.server.origin}${pathname}`);
+      const req = request(
+        {
+          hostname: url.hostname,
+          port: url.port,
+          path: `${url.pathname}${url.search}`,
+          method: 'GET',
+          headers: { Host: host },
+        },
+        (res) => {
+          res.on('data', () => {});
+          res.on('close', () => {
+            resolve({ statusCode: res.statusCode || 0 });
           });
         },
       );
@@ -53,7 +80,7 @@ describe('test server/apis/project.ts', () => {
     await expect(
       optionsWithOrigin('https://example.com'),
     ).resolves.toStrictEqual({
-      statusCode: 403,
+      statusCode: 204,
       allowOrigin: undefined,
     });
 
@@ -70,10 +97,47 @@ describe('test server/apis/project.ts', () => {
       statusCode: 204,
       allowOrigin: `http://127.0.0.1:${target.server.port + 1}`,
     });
+
+    await expect(
+      optionsWithOrigin(`http://foo.localhost:${target.server.port}`),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: `http://foo.localhost:${target.server.port}`,
+    });
+
+    await expect(
+      optionsWithOrigin(
+        `http://foo.localhost:${target.server.port}`,
+        `foo.localhost:${target.server.port}`,
+      ),
+    ).resolves.toStrictEqual({
+      statusCode: 204,
+      allowOrigin: `http://foo.localhost:${target.server.port}`,
+    });
+  });
+
+  it('rejects requests with non-local Host headers', async () => {
+    const host = `evil.example.com:${target.server.port}`;
+
+    await expect(requestWithHost('/', host)).resolves.toStrictEqual({
+      statusCode: 403,
+    });
+    await expect(
+      requestWithHost(SDK.ServerAPI.API.Manifest, host),
+    ).resolves.toStrictEqual({
+      statusCode: 403,
+    });
+    await expect(
+      requestWithHost('/__open-in-editor?file=/tmp/example.js', host),
+    ).resolves.toStrictEqual({
+      statusCode: 403,
+    });
   });
 
   it(`test api: ${SDK.ServerAPI.API.Manifest}`, async () => {
-    target.sdk.addClientRoutes([Manifest.RsdoctorManifestClientRoutes.Loaders]);
+    target.sdk.addClientRoutes([
+      Manifest.RsdoctorManifestClientRoutes.WebpackLoaders,
+    ]);
 
     const manifestStr = (
       await target.get(SDK.ServerAPI.API.Manifest)
@@ -83,7 +147,7 @@ describe('test server/apis/project.ts', () => {
     expect(manifest.data.root === cwd);
     expect(manifest.client.enableRoutes).toStrictEqual([
       Manifest.RsdoctorManifestClientRoutes.Overall,
-      Manifest.RsdoctorManifestClientRoutes.Loaders,
+      Manifest.RsdoctorManifestClientRoutes.WebpackLoaders,
     ]);
     expect(manifest.data.pid).toEqual(process.pid);
 

--- a/packages/sdk/tests/server/security.test.ts
+++ b/packages/sdk/tests/server/security.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from '@rstest/core';
+import {
+  isAllowedRequestHost,
+  isAllowedRequestOrigin,
+} from '../../src/sdk/server/security';
+
+describe('test server/security.ts', () => {
+  it('allows local request origins', () => {
+    expect(isAllowedRequestOrigin(undefined)).toBe(true);
+    expect(isAllowedRequestOrigin('http://localhost:3000')).toBe(true);
+    expect(isAllowedRequestOrigin('https://foo.localhost:3000')).toBe(true);
+    expect(isAllowedRequestOrigin('http://127.0.0.1:3000')).toBe(true);
+    expect(isAllowedRequestOrigin('http://[::1]:3000')).toBe(true);
+  });
+
+  it('rejects non-local request origins', () => {
+    expect(isAllowedRequestOrigin('https://example.com')).toBe(false);
+    expect(isAllowedRequestOrigin('http://foo.localhost.evil.com')).toBe(false);
+    expect(isAllowedRequestOrigin(['http://localhost:3000'])).toBe(false);
+  });
+
+  it('allows local request hosts', () => {
+    expect(isAllowedRequestHost('localhost:3000')).toBe(true);
+    expect(isAllowedRequestHost('foo.localhost:3000')).toBe(true);
+    expect(isAllowedRequestHost('127.0.0.1:3000')).toBe(true);
+    expect(isAllowedRequestHost('[::1]:3000')).toBe(true);
+    expect(isAllowedRequestHost('192.168.1.10:3000')).toBe(true);
+  });
+
+  it('rejects non-local request hosts', () => {
+    expect(isAllowedRequestHost(undefined)).toBe(false);
+    expect(isAllowedRequestHost('example.com:3000')).toBe(false);
+    expect(isAllowedRequestHost('foo.localhost.evil.com:3000')).toBe(false);
+    expect(isAllowedRequestHost(['localhost:3000'])).toBe(false);
+  });
+});

--- a/packages/sdk/tests/server/security.test.ts
+++ b/packages/sdk/tests/server/security.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@rstest/core';
 import {
+  isAllowedCorsRequest,
   isAllowedRequestHost,
   isAllowedRequestOrigin,
 } from '../../src/sdk/server/security';
@@ -32,5 +33,23 @@ describe('test server/security.ts', () => {
     expect(isAllowedRequestHost('example.com:3000')).toBe(false);
     expect(isAllowedRequestHost('foo.localhost.evil.com:3000')).toBe(false);
     expect(isAllowedRequestHost(['localhost:3000'])).toBe(false);
+  });
+
+  it('allows CORS requests from matching local origins', () => {
+    expect(
+      isAllowedCorsRequest('http://127.0.0.1:3001', '127.0.0.1:3000'),
+    ).toBe(true);
+    expect(
+      isAllowedCorsRequest('http://foo.localhost:3001', 'foo.localhost:3000'),
+    ).toBe(true);
+  });
+
+  it('rejects CORS requests from non-local or mismatched origins', () => {
+    expect(isAllowedCorsRequest('https://example.com', '127.0.0.1:3000')).toBe(
+      false,
+    );
+    expect(
+      isAllowedCorsRequest('http://foo.localhost:3001', '127.0.0.1:3000'),
+    ).toBe(false);
   });
 });

--- a/packages/sdk/tests/server/socket.test.ts
+++ b/packages/sdk/tests/server/socket.test.ts
@@ -1,13 +1,32 @@
 import { describe, it, expect, rs } from '@rstest/core';
 import { request } from 'http';
-import { setupSDK } from '../utils';
+import { setupSDK, type MockSDKResponse } from '../utils';
 
 rs.setConfig({ testTimeout: 50000 });
 
 describe('test server/socket.ts', () => {
   const target = setupSDK();
+  const customCorsTarget = setupSDK({
+    server: {
+      cors: {
+        origin: 'https://example.com',
+      },
+    },
+  });
+  const partialCorsTarget = setupSDK({
+    server: {
+      cors: {
+        credentials: true,
+      },
+    },
+  });
 
-  function requestSocketHandshake(origin?: string, host?: string) {
+  function requestSocketHandshake(
+    target: MockSDKResponse,
+    origin?: string,
+    host?: string,
+    token = target.server.socketUrl.token,
+  ) {
     return new Promise<{
       statusCode: number;
       allowOrigin: string | string[] | undefined;
@@ -15,6 +34,9 @@ describe('test server/socket.ts', () => {
       const url = new URL(
         `${target.server.origin}/socket.io/?EIO=4&transport=polling`,
       );
+      if (token) {
+        url.searchParams.set('token', token);
+      }
       const headers =
         origin || host
           ? {
@@ -46,11 +68,21 @@ describe('test server/socket.ts', () => {
     });
   }
 
-  it('rejects socket handshakes from non-local origins', async () => {
+  it('rejects socket handshakes without tokens', async () => {
+    const origin = `http://127.0.0.1:${target.server.port}`;
+
     await expect(
-      requestSocketHandshake('https://example.com'),
+      requestSocketHandshake(target, origin, undefined, ''),
     ).resolves.toMatchObject({
       statusCode: 403,
+    });
+  });
+
+  it('does not expose CORS headers for non-local socket origins', async () => {
+    await expect(
+      requestSocketHandshake(target, 'https://example.com'),
+    ).resolves.toMatchObject({
+      statusCode: 200,
       allowOrigin: undefined,
     });
   });
@@ -58,17 +90,72 @@ describe('test server/socket.ts', () => {
   it('allows socket handshakes from local origins', async () => {
     const origin = `http://foo.localhost:${target.server.port}`;
 
-    await expect(requestSocketHandshake(origin)).resolves.toMatchObject({
-      statusCode: 200,
-      allowOrigin: origin,
-    });
+    await expect(requestSocketHandshake(target, origin)).resolves.toMatchObject(
+      {
+        statusCode: 200,
+        allowOrigin: origin,
+      },
+    );
   });
 
   it('rejects socket handshakes with non-local Host headers', async () => {
     const origin = `http://foo.localhost:${target.server.port}`;
 
     await expect(
-      requestSocketHandshake(origin, `evil.example.com:${target.server.port}`),
+      requestSocketHandshake(
+        target,
+        origin,
+        `evil.example.com:${target.server.port}`,
+      ),
+    ).resolves.toMatchObject({
+      statusCode: 403,
+    });
+  });
+
+  it('allows socket handshakes from custom CORS origins', async () => {
+    await expect(
+      requestSocketHandshake(customCorsTarget, 'https://example.com'),
+    ).resolves.toMatchObject({
+      statusCode: 200,
+      allowOrigin: 'https://example.com',
+    });
+  });
+
+  it('uses the configured custom socket CORS origin header', async () => {
+    await expect(
+      requestSocketHandshake(customCorsTarget, 'https://evil.example.com'),
+    ).resolves.toMatchObject({
+      statusCode: 200,
+      allowOrigin: 'https://example.com',
+    });
+  });
+
+  it('preserves default CORS origins for partial socket CORS options', async () => {
+    await expect(
+      requestSocketHandshake(partialCorsTarget, 'https://example.com'),
+    ).resolves.toMatchObject({
+      statusCode: 200,
+      allowOrigin: undefined,
+    });
+
+    const origin = `http://127.0.0.1:${partialCorsTarget.server.port}`;
+
+    await expect(
+      requestSocketHandshake(partialCorsTarget, origin),
+    ).resolves.toMatchObject({
+      statusCode: 200,
+      allowOrigin: origin,
+    });
+  });
+
+  it('rejects socket handshakes with invalid tokens', async () => {
+    await expect(
+      requestSocketHandshake(
+        customCorsTarget,
+        'https://example.com',
+        undefined,
+        'invalid-token',
+      ),
     ).resolves.toMatchObject({
       statusCode: 403,
     });

--- a/packages/sdk/tests/server/socket.test.ts
+++ b/packages/sdk/tests/server/socket.test.ts
@@ -6,158 +6,76 @@ rs.setConfig({ testTimeout: 50000 });
 
 describe('test server/socket.ts', () => {
   const target = setupSDK();
-  const customCorsTarget = setupSDK({
-    server: {
-      cors: {
-        origin: 'https://example.com',
-      },
-    },
-  });
-  const partialCorsTarget = setupSDK({
-    server: {
-      cors: {
-        credentials: true,
-      },
-    },
-  });
 
   function requestSocketHandshake(
     target: MockSDKResponse,
-    origin?: string,
     host?: string,
     token = target.server.socketUrl.token,
   ) {
-    return new Promise<{
-      statusCode: number;
-      allowOrigin: string | string[] | undefined;
-    }>((resolve, reject) => {
-      const url = new URL(
-        `${target.server.origin}/socket.io/?EIO=4&transport=polling`,
-      );
+    return new Promise<{ statusCode: number }>((resolve, reject) => {
+      const url = new URL(target.server.socketUrl.socketUrl);
       if (token) {
         url.searchParams.set('token', token);
+      } else {
+        url.searchParams.delete('token');
       }
-      const headers =
-        origin || host
-          ? {
-              ...(origin ? { Origin: origin } : {}),
-              ...(host ? { Host: host } : {}),
-            }
-          : undefined;
-      const req = request(
-        {
-          hostname: url.hostname,
-          port: url.port,
-          path: `${url.pathname}${url.search}`,
-          method: 'GET',
-          headers,
-        },
-        (res) => {
-          res.on('data', () => {});
-          res.on('close', () => {
-            resolve({
-              statusCode: res.statusCode || 0,
-              allowOrigin: res.headers['access-control-allow-origin'],
-            });
-          });
-        },
-      );
 
+      const req = request({
+        hostname: '127.0.0.1',
+        port: target.server.port,
+        path: `${url.pathname}${url.search}`,
+        method: 'GET',
+        headers: {
+          Connection: 'Upgrade',
+          Upgrade: 'websocket',
+          'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+          'Sec-WebSocket-Version': '13',
+          ...(host ? { Host: host } : {}),
+        },
+      });
+
+      req.on('upgrade', (res, socket) => {
+        socket.destroy();
+        resolve({ statusCode: res.statusCode || 0 });
+      });
+      req.on('response', (res) => {
+        res.resume();
+        res.on('end', () => {
+          resolve({ statusCode: res.statusCode || 0 });
+        });
+      });
       req.on('error', reject);
       req.end();
     });
   }
 
   it('rejects socket handshakes without tokens', async () => {
-    const origin = `http://127.0.0.1:${target.server.port}`;
-
     await expect(
-      requestSocketHandshake(target, origin, undefined, ''),
-    ).resolves.toMatchObject({
-      statusCode: 403,
+      requestSocketHandshake(target, undefined, ''),
+    ).resolves.toStrictEqual({
+      statusCode: 401,
     });
   });
 
-  it('does not expose CORS headers for non-local socket origins', async () => {
-    await expect(
-      requestSocketHandshake(target, 'https://example.com'),
-    ).resolves.toMatchObject({
-      statusCode: 200,
-      allowOrigin: undefined,
+  it('allows socket handshakes with valid tokens', async () => {
+    await expect(requestSocketHandshake(target)).resolves.toStrictEqual({
+      statusCode: 101,
     });
-  });
-
-  it('allows socket handshakes from local origins', async () => {
-    const origin = `http://foo.localhost:${target.server.port}`;
-
-    await expect(requestSocketHandshake(target, origin)).resolves.toMatchObject(
-      {
-        statusCode: 200,
-        allowOrigin: origin,
-      },
-    );
   });
 
   it('rejects socket handshakes with non-local Host headers', async () => {
-    const origin = `http://foo.localhost:${target.server.port}`;
-
     await expect(
-      requestSocketHandshake(
-        target,
-        origin,
-        `evil.example.com:${target.server.port}`,
-      ),
-    ).resolves.toMatchObject({
-      statusCode: 403,
-    });
-  });
-
-  it('allows socket handshakes from custom CORS origins', async () => {
-    await expect(
-      requestSocketHandshake(customCorsTarget, 'https://example.com'),
-    ).resolves.toMatchObject({
-      statusCode: 200,
-      allowOrigin: 'https://example.com',
-    });
-  });
-
-  it('uses the configured custom socket CORS origin header', async () => {
-    await expect(
-      requestSocketHandshake(customCorsTarget, 'https://evil.example.com'),
-    ).resolves.toMatchObject({
-      statusCode: 200,
-      allowOrigin: 'https://example.com',
-    });
-  });
-
-  it('preserves default CORS origins for partial socket CORS options', async () => {
-    await expect(
-      requestSocketHandshake(partialCorsTarget, 'https://example.com'),
-    ).resolves.toMatchObject({
-      statusCode: 200,
-      allowOrigin: undefined,
-    });
-
-    const origin = `http://127.0.0.1:${partialCorsTarget.server.port}`;
-
-    await expect(
-      requestSocketHandshake(partialCorsTarget, origin),
-    ).resolves.toMatchObject({
-      statusCode: 200,
-      allowOrigin: origin,
+      requestSocketHandshake(target, `evil.example.com:${target.server.port}`),
+    ).resolves.toStrictEqual({
+      statusCode: 401,
     });
   });
 
   it('rejects socket handshakes with invalid tokens', async () => {
     await expect(
-      requestSocketHandshake(
-        customCorsTarget,
-        'https://example.com',
-        undefined,
-        'invalid-token',
-      ),
-    ).resolves.toMatchObject({
-      statusCode: 403,
+      requestSocketHandshake(target, undefined, 'invalid-token'),
+    ).resolves.toStrictEqual({
+      statusCode: 401,
     });
   });
 });

--- a/packages/sdk/tests/server/socket.test.ts
+++ b/packages/sdk/tests/server/socket.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, rs } from '@rstest/core';
+import { request } from 'http';
+import { setupSDK } from '../utils';
+
+rs.setConfig({ testTimeout: 50000 });
+
+describe('test server/socket.ts', () => {
+  const target = setupSDK();
+
+  function requestSocketHandshake(origin?: string, host?: string) {
+    return new Promise<{
+      statusCode: number;
+      allowOrigin: string | string[] | undefined;
+    }>((resolve, reject) => {
+      const url = new URL(
+        `${target.server.origin}/socket.io/?EIO=4&transport=polling`,
+      );
+      const headers =
+        origin || host
+          ? {
+              ...(origin ? { Origin: origin } : {}),
+              ...(host ? { Host: host } : {}),
+            }
+          : undefined;
+      const req = request(
+        {
+          hostname: url.hostname,
+          port: url.port,
+          path: `${url.pathname}${url.search}`,
+          method: 'GET',
+          headers,
+        },
+        (res) => {
+          res.on('data', () => {});
+          res.on('close', () => {
+            resolve({
+              statusCode: res.statusCode || 0,
+              allowOrigin: res.headers['access-control-allow-origin'],
+            });
+          });
+        },
+      );
+
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
+  it('rejects socket handshakes from non-local origins', async () => {
+    await expect(
+      requestSocketHandshake('https://example.com'),
+    ).resolves.toMatchObject({
+      statusCode: 403,
+      allowOrigin: undefined,
+    });
+  });
+
+  it('allows socket handshakes from local origins', async () => {
+    const origin = `http://foo.localhost:${target.server.port}`;
+
+    await expect(requestSocketHandshake(origin)).resolves.toMatchObject({
+      statusCode: 200,
+      allowOrigin: origin,
+    });
+  });
+
+  it('rejects socket handshakes with non-local Host headers', async () => {
+    const origin = `http://foo.localhost:${target.server.port}`;
+
+    await expect(
+      requestSocketHandshake(origin, `evil.example.com:${target.server.port}`),
+    ).resolves.toMatchObject({
+      statusCode: 403,
+    });
+  });
+});

--- a/packages/sdk/tests/utils.ts
+++ b/packages/sdk/tests/utils.ts
@@ -38,7 +38,17 @@ export async function createSDK(
   config?: SDK.SDKOptionsType,
 ): Promise<MockSDKResponse> {
   const port = await Server.getPort(getPreferredTestPort());
-  const sdk = new RsdoctorSDK({ name: 'test', root: cwd, port, config });
+  const sdk = new RsdoctorSDK({
+    name: 'test',
+    root: cwd,
+    config: {
+      ...config,
+      server: {
+        ...config?.server,
+        port: config?.server?.port ?? port,
+      },
+    },
+  });
 
   await sdk.bootstrap();
 

--- a/packages/types/src/plugin/plugin.ts
+++ b/packages/types/src/plugin/plugin.ts
@@ -147,8 +147,15 @@ export interface RsdoctorRspackPluginOptions<
 
   /**
    * The port of the Rsdoctor server.
+   *
+   * @deprecated Use `server.port` instead.
    */
   port?: number;
+
+  /**
+   * Options for the Rsdoctor report server.
+   */
+  server?: SDK.RsdoctorServerConfig;
 
   /**
    * Options to control the log printing.

--- a/packages/types/src/plugin/plugin.ts
+++ b/packages/types/src/plugin/plugin.ts
@@ -39,7 +39,14 @@ export interface RsdoctorPluginOptionsNormalized<
 > extends Common.DeepRequired<
   Omit<
     RsdoctorRspackPluginOptions<Rules>,
-    'sdkInstance' | 'linter' | 'output' | 'supports' | 'port' | 'brief' | 'mode'
+    | 'sdkInstance'
+    | 'linter'
+    | 'output'
+    | 'supports'
+    | 'port'
+    | 'brief'
+    | 'mode'
+    | 'server'
   >
 > {
   features: Common.DeepRequired<RsdoctorRspackPluginFeatures>;
@@ -52,6 +59,7 @@ export interface RsdoctorPluginOptionsNormalized<
     options: Config.BriefModeOptions | Config.NormalModeOptions;
   };
   port?: number;
+  server: SDK.RsdoctorServerConfig;
   supports: ISupport;
 }
 

--- a/packages/types/src/sdk/instance.ts
+++ b/packages/types/src/sdk/instance.ts
@@ -122,6 +122,50 @@ export interface IPrintLog {
   serverUrls: boolean;
 }
 
+export type RsdoctorServerCorsStaticOrigin =
+  | boolean
+  | string
+  | RegExp
+  | Array<boolean | string | RegExp>;
+
+export type RsdoctorServerCorsOrigin =
+  | RsdoctorServerCorsStaticOrigin
+  | ((
+      requestOrigin: string | undefined,
+      callback: (
+        err: Error | null,
+        origin?: RsdoctorServerCorsStaticOrigin,
+      ) => void,
+    ) => void);
+
+export interface RsdoctorServerCorsOptions {
+  origin?: RsdoctorServerCorsOrigin;
+  methods?: string | string[];
+  allowedHeaders?: string | string[];
+  exposedHeaders?: string | string[];
+  credentials?: boolean;
+  maxAge?: number;
+  preflightContinue?: boolean;
+  optionsSuccessStatus?: number;
+}
+
+export interface RsdoctorServerConfig {
+  /**
+   * The port of the Rsdoctor report server.
+   */
+  port?: number;
+  /**
+   * Configure CORS for the Rsdoctor report server.
+   *
+   * - `false`: disable CORS middleware
+   * - `true`: use the cors middleware defaults
+   * - object: pass options to the cors middleware
+   *
+   * By default, Rsdoctor only allows local origins.
+   */
+  cors?: boolean | RsdoctorServerCorsOptions;
+}
+
 export type SDKOptionsType = {
   innerClientPath?: string;
   disableClientServer?: boolean;
@@ -130,4 +174,5 @@ export type SDKOptionsType = {
   mode?: keyof typeof IMode;
   brief?: BriefModeOptions;
   features?: { treeShaking?: boolean };
+  server?: RsdoctorServerConfig;
 };

--- a/packages/types/src/sdk/server/index.ts
+++ b/packages/types/src/sdk/server/index.ts
@@ -19,6 +19,11 @@ export interface RsdoctorServerInstance {
 
   readonly port: number;
   readonly origin: string;
+  readonly socketUrl: {
+    port: number;
+    socketUrl: string;
+    token: string;
+  };
 
   innerClientPath?: string;
 

--- a/packages/utils/src/build/server.ts
+++ b/packages/utils/src/build/server.ts
@@ -2,12 +2,14 @@ import connect from 'connect';
 import http from 'http';
 import os from 'os';
 import gp from 'get-port';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { Thirdparty } from '@rsdoctor/types';
 import { random } from '../common/algorithm';
 
 // see https://neo4j.com/developer/kb/list-of-restricted-ports-in-browsers
 const RESTRICTED_PORTS = [3659, 4045, 6000, 6665, 6666, 6667, 6668, 6669];
+
+export const defaultHost = '127.0.0.1';
 
 function getRandomPort(min: number, max: number) {
   let port: number;
@@ -19,21 +21,24 @@ function getRandomPort(min: number, max: number) {
 
 export const defaultPort = getRandomPort(3000, 8999);
 
-export async function getPort(expectPort: number) {
-  return gp({ port: expectPort });
+export async function getPort(expectPort: number, host = defaultHost) {
+  return gp({ port: expectPort, host });
 }
 
-export const createGetPortSyncFunctionString = (expectPort: number) =>
+export const createGetPortSyncFunctionString = (
+  expectPort: number,
+  host = defaultHost,
+) =>
   `
 (() => {
 const net = require('net');
 
-function getPort(expectPort) {
+function getPort(expectPort, host) {
   return new Promise((resolve, reject) => {
     const server = net.createServer();
     server.unref();
     server.on('error', reject);
-    server.listen(expectPort, () => {
+    server.listen(expectPort, host, () => {
       const { port } = server.address();
       server.close(() => {
         resolve(port);
@@ -46,7 +51,7 @@ async function getAvailablePort(expectPort) {
   let port = expectPort;
   while (true) {
     try {
-      const res = await getPort(port);
+      const res = await getPort(port, ${JSON.stringify(host)});
       return res;
     } catch (error) {
       port += Math.floor(Math.random() * 100 + 1);
@@ -58,13 +63,18 @@ getAvailablePort(${expectPort}).then(port => process.stdout.write(port.toString(
 })();
 `.trim();
 
-export function getPortSync(expectPort: number): number | never {
+export function getPortSync(
+  expectPort: number,
+  host = defaultHost,
+): number | never {
   const statement =
     os.EOL === '\n'
-      ? createGetPortSyncFunctionString(expectPort)
-      : createGetPortSyncFunctionString(expectPort).replace(/\n/g, '');
+      ? createGetPortSyncFunctionString(expectPort, host)
+      : createGetPortSyncFunctionString(expectPort, host).replace(/\n/g, '');
 
-  const port = execSync(`node -e "${statement}"`, { encoding: 'utf-8' });
+  const port = execFileSync(process.execPath, ['-e', statement], {
+    encoding: 'utf-8',
+  });
 
   return Number(port);
 }
@@ -73,7 +83,10 @@ export function createApp() {
   return connect();
 }
 
-export async function createServer(port: number): Promise<{
+export async function createServer(
+  port: number,
+  host = defaultHost,
+): Promise<{
   app: Thirdparty.connect.Server;
   server: http.Server;
   port: number;
@@ -103,8 +116,13 @@ export async function createServer(port: number): Promise<{
     },
   };
 
-  return new Promise<typeof res>((resolve) => {
-    server.listen(port, () => {
+  return new Promise<typeof res>((resolve, reject) => {
+    const onError = (error: Error) => {
+      reject(error);
+    };
+    server.once('error', onError);
+    server.listen(port, host, () => {
+      server.off('error', onError);
       resolve(res);
     });
   });

--- a/packages/utils/src/common/global-config.ts
+++ b/packages/utils/src/common/global-config.ts
@@ -12,7 +12,7 @@ import { logger } from '../logger';
  *     builder1: portNumber,
  *     builder2: portNumber,
  *   },
- *   port: portNumber // The port of the last builder is used by default
+ *   port: portNumber, // The port of the last builder is used by default
  * }
  *
  * @param {number} port - The port number to write.
@@ -27,7 +27,10 @@ export function writeMcpPort(port: number, builderName?: string) {
     fs.mkdirSync(rsdoctorDir, { recursive: true });
   }
 
-  let mcpJson: { portList: Record<string, number>; port: number } = {
+  let mcpJson: {
+    portList: Record<string, number>;
+    port: number;
+  } = {
     portList: {},
     port: 0,
   };

--- a/packages/utils/tests/server.test.ts
+++ b/packages/utils/tests/server.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from '@rstest/core';
+import type { AddressInfo } from 'net';
 import { Server } from '../src/build';
-import { getPortSync } from '../src/build/server';
+import {
+  createGetPortSyncFunctionString,
+  defaultHost,
+  getPortSync,
+} from '../src/build/server';
 
 describe('test src/server.ts', () => {
   it('getPort()', async () => {
@@ -17,5 +22,32 @@ describe('test src/server.ts', () => {
     const { close } = await Server.createServer(8262);
     expect(getPortSync(8262)).not.toEqual(8262);
     await close();
+  });
+
+  it('binds to 127.0.0.1 by default', async () => {
+    const { server, close } = await Server.createServer(0);
+
+    try {
+      const address = server.address() as AddressInfo;
+      expect(address.address).toEqual(defaultHost);
+      expect(createGetPortSyncFunctionString(3543)).toContain(
+        `getPort(port, ${JSON.stringify(defaultHost)})`,
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it('rejects when the requested port is already in use', async () => {
+    const { server, close } = await Server.createServer(0);
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      await expect(Server.createServer(port)).rejects.toMatchObject({
+        code: 'EADDRINUSE',
+      });
+    } finally {
+      await close();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Sync #1744, #1757, and #1751 from `v1.x` to `main`.
- Bring over report server hardening: localhost binding, Host/CORS validation, default local CORS origins, partial `server.cors` default preservation, and socket token validation.
- Resolve `main` conflicts by preserving the current native WebSocket report UI client and passing the tokenized `__SOCKET__URL__` through that path.

### #1744 details：
This PR hardens the Rsdoctor report server access model and aligns the default CORS / socket behavior with Rsbuild-style local-only protection.</p><ul><li>Bind the report server to <code>127.0.0.1</code> by default instead of exposing it on all network interfaces.</li><li>Add Host header validation before serving report APIs and static report assets.</li><li>Replace the previous wildcard CORS behavior with local-origin defaults.</li><li>Preserve the default local-origin protection when users provide partial <code>server.cors</code> options, such as <code>{ credentials: true }</code>.</li><li>Add a socket token handshake similar to Rsbuild:<ul><li>the report server generates a random socket token;</li><li>the token is injected into the report manifest via <code>__SOCKET__URL__</code>;</li><li>the report UI connects with <code>?token=...</code>;</li><li>the socket server rejects handshakes with missing or invalid tokens.</li></ul></li><li>Keep socket token delivery inside the report UI runtime path. The token is not written to or read from <code>mcp.json</code>.</li></ul><p>CORS behavior:</p><div><div>
User config server.cors | Resolved corsOptions | HTTP CORS middleware
-- | -- | --
Not configured / undefined | { origin: DEFAULT_ALLOWED_CORS_ORIGINS } | Enabled
false | false | Disabled
true | {} | Enabled, equivalent to cors({})
{ credentials: true } | { credentials: true, origin: DEFAULT_ALLOWED_CORS_ORIGINS } | Enabled
{ origin: 'https://example.com' } | { origin: 'https://example.com' } | Enabled
{ origin: '*', credentials: true } | { origin: '*', credentials: true } | Enabled
{ origin: false } | { origin: false } | Enabled, but does not set Access-Control-Allow-Origin
{ origin: fn } | { origin: fn } | Enabled
{ origin: /regex/ } | { origin: /regex/ } | Enabled

</div></div><p>Default / partial CORS configs also keep the local-origin guard, so requests from non-local or mismatched local origins are rejected instead of silently falling back to wildcard CORS.</p></body></html>

## Related Links

- https://github.com/web-infra-dev/rsdoctor/pull/1744
- https://github.com/web-infra-dev/rsdoctor/pull/1757
- https://github.com/web-infra-dev/rsdoctor/pull/1751