### PR TITLE
docs: add server cors option docs

### DIFF
--- a/packages/document/docs/en/config/options/_meta.json
+++ b/packages/document/docs/en/config/options/_meta.json
@@ -6,6 +6,7 @@
   "features",
   "output",
   "port",
+  "server",
   "supports",
   "brief",
   "mode",

--- a/packages/document/docs/en/config/options/options.mdx
+++ b/packages/document/docs/en/config/options/options.mdx
@@ -77,6 +77,7 @@ This `Options` object is the configuration for [RsdoctorRspackPlugin](#rsdoctorr
 - [features](./features.mdx) - **Feature Toggle Configuration**: Control various analysis features of Rsdoctor, such as loader analysis, bundle analysis, rule checking, etc.
 - [output](./output.mdx) - **Output Related Configuration**: Control report output format, directory and other options, including mode, options, reportCodeType, etc.
 - [port](./port.mdx) - **Service Port Configuration**: Set the port number for the Rsdoctor development server, used for report preview during local development.
+- [server](./server.mdx) - **Report Server Configuration**: Configure the Rsdoctor report server, including `server.port` and `server.cors`.
 - [supports](./supports.mdx) - **Feature Support Configuration**: Enable compatibility support for specific build tools, such as BannerPlugin, etc.
 - [brief](./brief.mdx) - **Brief Mode Configuration**: Control the generation of brief mode reports, including HTML filename and whether to generate JSON data files.
 - [mode](./mode.mdx) - **Build Report Data Output Mode**: Select the output mode for reports, supporting normal (normal mode) and brief (brief mode).
@@ -108,6 +109,8 @@ interface RsdoctorWebpackPluginOptions<
   supports?: ISupport;
 
   port?: number;
+
+  server?: SDK.RsdoctorServerConfig;
 
   /**
    * @deprecated Use `output.options.htmlOptions` instead

--- a/packages/document/docs/en/config/options/server.mdx
+++ b/packages/document/docs/en/config/options/server.mdx
@@ -1,0 +1,124 @@
+# server
+
+- **Type:** `RsdoctorServerConfig`
+- **Optional:** `true`
+- **Default:** `{}`
+
+Configure the Rsdoctor report server.
+
+## port
+
+- **Type:** `number`
+- **Optional:** `true`
+- **Default:** `random(3000, 8999)`
+
+Configure the port for the Rsdoctor report server.
+
+If `server.port` is not set, Rsdoctor uses the top-level [`port`](./port.mdx) option. If both options are set, `server.port` takes priority.
+
+```js
+new RsdoctorRspackPlugin({
+  server: {
+    port: 3001,
+  },
+});
+```
+
+## cors
+
+- **Type:** `boolean | RsdoctorServerCorsOptions`
+- **Optional:** `true`
+- **Default:** Allows local origins only.
+
+Configure CORS response headers for the Rsdoctor report server.
+
+By default, Rsdoctor allows local origins only:
+
+- `http://localhost` and `https://localhost`
+- `localhost` subdomains, such as `http://foo.localhost`
+- `http://127.0.0.1` and `https://127.0.0.1`
+- `http://[::1]` and `https://[::1]`
+
+All default local origins can include any port.
+
+### Values
+
+- `false`: Disable the CORS middleware.
+- `true`: Use the defaults from the `cors` package.
+- `object`: Pass options to the `cors` middleware. If `origin` is omitted, Rsdoctor keeps the default local-origin policy. If `origin` is set, it replaces the default local-origin policy.
+
+Rsdoctor still validates local request hosts separately. The `cors` option only controls CORS middleware behavior and response headers.
+
+### Examples
+
+Allow a custom origin:
+
+```js
+new RsdoctorRspackPlugin({
+  server: {
+    cors: {
+      origin: 'https://example.com',
+      credentials: true,
+    },
+  },
+});
+```
+
+Keep the default local-origin policy and add other CORS options:
+
+```js
+new RsdoctorRspackPlugin({
+  server: {
+    cors: {
+      credentials: true,
+      methods: ['GET', 'POST', 'OPTIONS'],
+    },
+  },
+});
+```
+
+Use the `cors` package defaults:
+
+```js
+new RsdoctorRspackPlugin({
+  server: {
+    cors: true,
+  },
+});
+```
+
+### Type definitions
+
+```ts
+interface RsdoctorServerConfig {
+  port?: number;
+  cors?: boolean | RsdoctorServerCorsOptions;
+}
+
+type RsdoctorServerCorsStaticOrigin =
+  | boolean
+  | string
+  | RegExp
+  | Array<boolean | string | RegExp>;
+
+type RsdoctorServerCorsOrigin =
+  | RsdoctorServerCorsStaticOrigin
+  | ((
+      requestOrigin: string | undefined,
+      callback: (
+        err: Error | null,
+        origin?: RsdoctorServerCorsStaticOrigin,
+      ) => void,
+    ) => void);
+
+interface RsdoctorServerCorsOptions {
+  origin?: RsdoctorServerCorsOrigin;
+  methods?: string | string[];
+  allowedHeaders?: string | string[];
+  exposedHeaders?: string | string[];
+  credentials?: boolean;
+  maxAge?: number;
+  preflightContinue?: boolean;
+  optionsSuccessStatus?: number;
+}
+```

--- a/packages/document/docs/zh/config/options/_meta.json
+++ b/packages/document/docs/zh/config/options/_meta.json
@@ -6,6 +6,7 @@
   "features",
   "output",
   "port",
+  "server",
   "supports",
   "brief",
   "mode",

--- a/packages/document/docs/zh/config/options/options.mdx
+++ b/packages/document/docs/zh/config/options/options.mdx
@@ -77,6 +77,7 @@ new RsdoctorWebpackPlugin({
 - [features](./features.mdx) - **特性开关配置**：控制 Rsdoctor 的各项分析功能，如 loader 分析、bundle 分析、规则检查等
 - [output](./output.mdx) - **输出相关配置**：控制报告的输出格式、目录等选项，包括 mode、options、reportCodeType 等
 - [port](./port.mdx) - **服务端口配置**：设置 Rsdoctor 开发服务器的端口号，用于本地开发时的报告预览
+- [server](./server.mdx) - **报告服务配置**：配置 Rsdoctor 报告服务，包括 `server.port` 和 `server.cors`
 - [supports](./supports.mdx) - **特性支持配置**：启用特定构建工具的兼容性支持，如 BannerPlugin 等
 - [brief](./brief.mdx) - **Brief 模式的配置**：控制简要模式报告的生成，包括 HTML 文件名和是否生成 JSON 数据文件
 - [mode](./mode.mdx) - **构建报告数据输出模式**：选择报告的输出模式，支持 normal（普通模式）和 brief（简要模式）
@@ -107,6 +108,8 @@ interface RsdoctorWebpackPluginOptions<
   supports?: ISupport;
 
   port?: number;
+
+  server?: SDK.RsdoctorServerConfig;
 
   /**
    * @deprecated 使用 `output.options.htmlOptions` 代替

--- a/packages/document/docs/zh/config/options/server.mdx
+++ b/packages/document/docs/zh/config/options/server.mdx
@@ -1,0 +1,124 @@
+# server
+
+- **类型：** `RsdoctorServerConfig`
+- **可选：** `true`
+- **默认值：** `{}`
+
+配置 Rsdoctor 报告服务。
+
+## port
+
+- **类型：** `number`
+- **可选：** `true`
+- **默认值：** `random(3000, 8999)`
+
+配置 Rsdoctor 报告服务的端口。
+
+如果没有配置 `server.port`，Rsdoctor 会使用顶层 [`port`](./port.mdx) 配置。如果两个配置同时存在，`server.port` 优先级更高。
+
+```js
+new RsdoctorRspackPlugin({
+  server: {
+    port: 3001,
+  },
+});
+```
+
+## cors
+
+- **类型：** `boolean | RsdoctorServerCorsOptions`
+- **可选：** `true`
+- **默认值：** 只允许本地来源。
+
+配置 Rsdoctor 报告服务的 CORS 响应头。
+
+默认情况下，Rsdoctor 只允许以下本地来源：
+
+- `http://localhost` 和 `https://localhost`
+- `localhost` 子域名，例如 `http://foo.localhost`
+- `http://127.0.0.1` 和 `https://127.0.0.1`
+- `http://[::1]` 和 `https://[::1]`
+
+以上默认本地来源都可以携带任意端口。
+
+### 可选值
+
+- `false`：关闭 CORS 中间件。
+- `true`：使用 `cors` 包的默认配置。
+- `object`：传递给 `cors` 中间件的配置对象。如果没有配置 `origin`，Rsdoctor 会保留默认的本地来源策略。如果配置了 `origin`，它会替换默认的本地来源策略。
+
+Rsdoctor 仍然会单独校验本地请求 Host。`cors` 配置只控制 CORS 中间件行为和响应头。
+
+### 示例
+
+允许一个自定义来源：
+
+```js
+new RsdoctorRspackPlugin({
+  server: {
+    cors: {
+      origin: 'https://example.com',
+      credentials: true,
+    },
+  },
+});
+```
+
+保留默认本地来源策略，并添加其他 CORS 选项：
+
+```js
+new RsdoctorRspackPlugin({
+  server: {
+    cors: {
+      credentials: true,
+      methods: ['GET', 'POST', 'OPTIONS'],
+    },
+  },
+});
+```
+
+使用 `cors` 包的默认配置：
+
+```js
+new RsdoctorRspackPlugin({
+  server: {
+    cors: true,
+  },
+});
+```
+
+### 类型定义
+
+```ts
+interface RsdoctorServerConfig {
+  port?: number;
+  cors?: boolean | RsdoctorServerCorsOptions;
+}
+
+type RsdoctorServerCorsStaticOrigin =
+  | boolean
+  | string
+  | RegExp
+  | Array<boolean | string | RegExp>;
+
+type RsdoctorServerCorsOrigin =
+  | RsdoctorServerCorsStaticOrigin
+  | ((
+      requestOrigin: string | undefined,
+      callback: (
+        err: Error | null,
+        origin?: RsdoctorServerCorsStaticOrigin,
+      ) => void,
+    ) => void);
+
+interface RsdoctorServerCorsOptions {
+  origin?: RsdoctorServerCorsOrigin;
+  methods?: string | string[];
+  allowedHeaders?: string | string[];
+  exposedHeaders?: string | string[];
+  credentials?: boolean;
+  maxAge?: number;
+  preflightContinue?: boolean;
+  optionsSuccessStatus?: number;
+}
+```


### PR DESCRIPTION
## Summary

Backport #1761 to `v1.x` to add documentation for the `server` options, including `server.port` and `server.cors`, in both English and Chinese docs.

## Related Links

#1761