### PR TITLE
fix(core): merge user-supplied supports onto defaults so asset gzipSize is populated (v1.x)

### DIFF
--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -100,13 +100,14 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     sdkInstance,
     innerClientPath = '',
     output = outputConfig,
-    supports = getDefaultSupports(),
+    supports: userSupports = {},
     port,
     server: userServer = {},
     printLog = { serverUrls: true },
     mode = undefined,
     brief = undefined,
   } = normalizedConfig;
+  const supports = { ...getDefaultSupports(), ...userSupports };
   // If process.env.RSTEST is set to true, disableClientServer should be false
   // Otherwise, if process.env.CI is set, disableClientServer should be true
   const disableClientServer =


### PR DESCRIPTION
## Summary

Fix asset-level gzip sizes being dropped when callers pass supports: {} — the destructuring default never fires for an empty object, leaving supports.gzip undefined and silently skipping gzip computation; merge defaults onto the user object instead.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/7861#issuecomment-4806598744