### PR TITLE
fix(shared): use relative types imports internally

### DIFF
--- a/packages/shared/src/common/alerts.ts
+++ b/packages/shared/src/common/alerts.ts
@@ -1,4 +1,4 @@
-import { Rule, SDK } from '@rsdoctor/shared/types';
+import { Rule, SDK } from '../types';
 import path from 'path-browserify';
 
 const { relative } = path;

--- a/packages/shared/src/common/bundle.ts
+++ b/packages/shared/src/common/bundle.ts
@@ -1,4 +1,4 @@
-import { Client } from '@rsdoctor/shared/types';
+import { Client } from '../types';
 
 const sep = ',';
 

--- a/packages/shared/src/common/data/index.ts
+++ b/packages/shared/src/common/data/index.ts
@@ -1,4 +1,4 @@
-import { Rule, SDK, Manifest, Constants } from '@rsdoctor/shared/types';
+import { Rule, SDK, Manifest, Constants } from '../../types';
 import path from 'path-browserify';
 
 import * as Loader from '../loader';

--- a/packages/shared/src/common/graph/assets.ts
+++ b/packages/shared/src/common/graph/assets.ts
@@ -1,4 +1,4 @@
-import { Client, Constants, SDK } from '@rsdoctor/shared/types';
+import { Client, Constants, SDK } from '../../types';
 import { getChunksByAsset } from './chunk';
 import { getModulesByAsset } from './modules';
 

--- a/packages/shared/src/common/graph/bundle-diff.ts
+++ b/packages/shared/src/common/graph/bundle-diff.ts
@@ -1,4 +1,4 @@
-import { Client, SDK } from '@rsdoctor/shared/types';
+import { Client, SDK } from '../../types';
 import { getAssetsDiffResult, diffSize } from './assets';
 
 /**

--- a/packages/shared/src/common/graph/chunk.ts
+++ b/packages/shared/src/common/graph/chunk.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../types';
 
 export function getChunkIdsByAsset(asset: SDK.AssetData): string[] {
   if (asset.chunks) {

--- a/packages/shared/src/common/graph/dependency.ts
+++ b/packages/shared/src/common/graph/dependency.ts
@@ -1,4 +1,4 @@
-import { Rule, SDK } from '@rsdoctor/shared/types';
+import { Rule, SDK } from '../../types';
 
 export function getDependencyByPackageData(
   dep: Rule.DependencyWithPackageData,

--- a/packages/shared/src/common/graph/entrypoints.ts
+++ b/packages/shared/src/common/graph/entrypoints.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../types';
 
 export function getEntryPoints(
   entrypoints: SDK.EntryPointData[],

--- a/packages/shared/src/common/graph/modules.ts
+++ b/packages/shared/src/common/graph/modules.ts
@@ -1,4 +1,4 @@
-import { Rule, SDK } from '@rsdoctor/shared/types';
+import { Rule, SDK } from '../../types';
 import { getChunksByChunkIds, getChunkIdsByAsset } from './chunk';
 import {
   getDependenciesByModule,

--- a/packages/shared/src/common/loader.ts
+++ b/packages/shared/src/common/loader.ts
@@ -1,6 +1,6 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../types';
 import { mergeIntervals } from './algorithm';
-import { Plugin } from '@rsdoctor/shared/types';
+import { Plugin } from '../types';
 
 export function findLoaderTotalTiming(
   loaders: Pick<SDK.LoaderTransformData, 'startAt' | 'endAt'>[],

--- a/packages/shared/src/common/loader.ts
+++ b/packages/shared/src/common/loader.ts
@@ -1,6 +1,5 @@
-import { SDK } from '../types';
+import { Plugin, SDK } from '../types';
 import { mergeIntervals } from './algorithm';
-import { Plugin } from '../types';
 
 export function findLoaderTotalTiming(
   loaders: Pick<SDK.LoaderTransformData, 'startAt' | 'endAt'>[],

--- a/packages/shared/src/common/manifest.ts
+++ b/packages/shared/src/common/manifest.ts
@@ -1,4 +1,4 @@
-import { Manifest } from '@rsdoctor/shared/types';
+import { Manifest } from '../types';
 import { decompressText } from './algorithm';
 import { isRemoteUrl } from './url';
 

--- a/packages/shared/src/common/package.ts
+++ b/packages/shared/src/common/package.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../types';
 import { compact, isEmpty, last } from './lodash';
 
 /**

--- a/packages/shared/src/common/plugin.ts
+++ b/packages/shared/src/common/plugin.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../types';
 
 export function getPluginHooks(plugin: SDK.PluginData) {
   return Object.keys(plugin);

--- a/packages/shared/src/common/resolver.ts
+++ b/packages/shared/src/common/resolver.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../types';
 import { mergeIntervals } from './algorithm';
 
 export function isResolveSuccessData(

--- a/packages/shared/src/common/rspack.ts
+++ b/packages/shared/src/common/rspack.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../types';
 
 export const RspackLoaderInternalPropertyName = '__l__';
 

--- a/packages/shared/src/graph/graph/chunk-graph/asset.ts
+++ b/packages/shared/src/graph/graph/chunk-graph/asset.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../../types';
 import { gzipSync } from 'node:zlib';
 let id = 1;
 

--- a/packages/shared/src/graph/graph/chunk-graph/chunk.ts
+++ b/packages/shared/src/graph/graph/chunk-graph/chunk.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../../types';
 
 export class Chunk implements SDK.ChunkInstance {
   readonly id: string;

--- a/packages/shared/src/graph/graph/chunk-graph/entrypoint.ts
+++ b/packages/shared/src/graph/graph/chunk-graph/entrypoint.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../../types';
 
 let id = 1;
 export class EntryPoint implements SDK.EntryPointInstance {

--- a/packages/shared/src/graph/graph/chunk-graph/graph.ts
+++ b/packages/shared/src/graph/graph/chunk-graph/graph.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../../types';
 
 export class ChunkGraph implements SDK.ChunkGraphInstance {
   private _assetMap: Map<number, SDK.AssetInstance> = new Map();

--- a/packages/shared/src/graph/graph/module-graph/dependency.ts
+++ b/packages/shared/src/graph/graph/module-graph/dependency.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../../types';
 
 let id = 1;
 

--- a/packages/shared/src/graph/graph/module-graph/graph.ts
+++ b/packages/shared/src/graph/graph/module-graph/graph.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../../types';
 import { Dependency } from './dependency';
 import { Module } from './module';
 import { Statement } from './statement';

--- a/packages/shared/src/graph/graph/module-graph/module.ts
+++ b/packages/shared/src/graph/graph/module-graph/module.ts
@@ -1,4 +1,4 @@
-import { SDK, Plugin } from '@rsdoctor/shared/types';
+import { SDK, Plugin } from '../../../types';
 import path from 'path-browserify';
 import { isNumber } from 'es-toolkit/compat';
 import type { SourceMapConsumer } from 'source-map';

--- a/packages/shared/src/graph/graph/module-graph/statement.ts
+++ b/packages/shared/src/graph/graph/module-graph/statement.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../../types';
 import { isSameRange } from './utils';
 
 export class Statement implements SDK.StatementInstance {

--- a/packages/shared/src/graph/graph/module-graph/tree-shaking/export.ts
+++ b/packages/shared/src/graph/graph/module-graph/tree-shaking/export.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../../../types';
 
 let id = 1;
 

--- a/packages/shared/src/graph/graph/module-graph/tree-shaking/module.ts
+++ b/packages/shared/src/graph/graph/module-graph/tree-shaking/module.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../../../types';
 import { ExportInfo } from './export';
 import { SideEffect } from './sideEffect';
 import { Variable } from './variable';

--- a/packages/shared/src/graph/graph/module-graph/tree-shaking/sideEffect.ts
+++ b/packages/shared/src/graph/graph/module-graph/tree-shaking/sideEffect.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../../../types';
 
 let id = 1;
 

--- a/packages/shared/src/graph/graph/module-graph/tree-shaking/types.ts
+++ b/packages/shared/src/graph/graph/module-graph/tree-shaking/types.ts
@@ -1,4 +1,4 @@
-import type { SDK } from '@rsdoctor/shared/types';
+import type { SDK } from '../../../../types';
 
 export type ExportData = SDK.ExportData;
 export type ModuleGraphModuleData = SDK.ModuleGraphModuleData;

--- a/packages/shared/src/graph/graph/module-graph/tree-shaking/variable.ts
+++ b/packages/shared/src/graph/graph/module-graph/tree-shaking/variable.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../../../types';
 import { ExportInfo } from './export';
 
 let id = 1;

--- a/packages/shared/src/graph/graph/module-graph/types.ts
+++ b/packages/shared/src/graph/graph/module-graph/types.ts
@@ -1,4 +1,4 @@
-import type { SDK } from '@rsdoctor/shared/types';
+import type { SDK } from '../../../types';
 
 export type ModuleBuildMeta = SDK.ModuleBuildMeta;
 export type ModuleSize = SDK.ModuleSize;

--- a/packages/shared/src/graph/graph/module-graph/utils.ts
+++ b/packages/shared/src/graph/graph/module-graph/utils.ts
@@ -1,4 +1,4 @@
-import type { SDK } from '@rsdoctor/shared/types';
+import type { SDK } from '../../../types';
 import { isNil, isUndefined, last } from 'es-toolkit/compat';
 
 export function isSamePosition(

--- a/packages/shared/src/graph/graph/package-graph/dependency.ts
+++ b/packages/shared/src/graph/graph/package-graph/dependency.ts
@@ -1,4 +1,4 @@
-import type { SDK } from '@rsdoctor/shared/types';
+import type { SDK } from '../../../types';
 
 let id = 1;
 

--- a/packages/shared/src/graph/graph/package-graph/graph.ts
+++ b/packages/shared/src/graph/graph/package-graph/graph.ts
@@ -1,6 +1,6 @@
 import { unionBy } from 'es-toolkit/compat';
 import path from 'path-browserify';
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../../types';
 import { Package } from './package';
 import { PackageDependency } from './dependency';
 import { readPackageJson } from './utils';

--- a/packages/shared/src/graph/graph/package-graph/package.ts
+++ b/packages/shared/src/graph/graph/package-graph/package.ts
@@ -1,4 +1,4 @@
-import type { SDK } from '@rsdoctor/shared/types';
+import type { SDK } from '../../../types';
 import path from 'path-browserify';
 import { isPackagePath } from './utils';
 

--- a/packages/shared/src/graph/graph/package-graph/types.ts
+++ b/packages/shared/src/graph/graph/package-graph/types.ts
@@ -1,4 +1,4 @@
-import type { SDK } from '@rsdoctor/shared/types';
+import type { SDK } from '../../../types';
 
 export type PackageData = SDK.PackageData;
 export type PackageJSONData = SDK.PackageJSONData;

--- a/packages/shared/src/graph/graph/package-graph/utils.ts
+++ b/packages/shared/src/graph/graph/package-graph/utils.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../../types';
 import { compact, isEmpty, last } from 'es-toolkit/compat';
 import path from 'path-browserify';
 

--- a/packages/shared/src/graph/transform/chunks/assetsContent.ts
+++ b/packages/shared/src/graph/transform/chunks/assetsContent.ts
@@ -1,4 +1,4 @@
-import { SDK, Plugin } from '@rsdoctor/shared/types';
+import { SDK, Plugin } from '../../../types';
 
 const COMPRESSIBLE_REGEX =
   /\.(?:js|css|html|json|svg|txt|xml|xhtml|wasm|manifest)$/i;

--- a/packages/shared/src/graph/transform/chunks/assetsModules.ts
+++ b/packages/shared/src/graph/transform/chunks/assetsModules.ts
@@ -1,5 +1,5 @@
 import path from 'path-browserify';
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../../types';
 import { isEmpty, pick } from 'es-toolkit/compat';
 import { gzipSync } from 'node:zlib';
 import { ParseBundle } from '../../types/transform';

--- a/packages/shared/src/graph/transform/chunks/chunkTransform.ts
+++ b/packages/shared/src/graph/transform/chunks/chunkTransform.ts
@@ -1,5 +1,5 @@
 import { Asset, Chunk, ChunkGraph, EntryPoint } from '../../graph';
-import { Plugin } from '@rsdoctor/shared/types';
+import { Plugin } from '../../../types';
 
 const FILTER_ASSETS_TYPE = 'assets by status';
 

--- a/packages/shared/src/graph/transform/module-graph/compatible.ts
+++ b/packages/shared/src/graph/transform/module-graph/compatible.ts
@@ -1,4 +1,4 @@
-import { Plugin, SDK } from '@rsdoctor/shared/types';
+import { Plugin, SDK } from '../../../types';
 
 /**
  * Reverse decode the location (loc) information.

--- a/packages/shared/src/graph/transform/module-graph/transform.ts
+++ b/packages/shared/src/graph/transform/module-graph/transform.ts
@@ -1,4 +1,4 @@
-import { SDK, Plugin } from '@rsdoctor/shared/types';
+import { SDK, Plugin } from '../../../types';
 import path from 'path-browserify';
 import { Statement, ModuleGraph, Module } from '../../graph';
 import { isImportDependency, getImportKind } from './utils';

--- a/packages/shared/src/graph/transform/module-graph/utils.ts
+++ b/packages/shared/src/graph/transform/module-graph/utils.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../../types';
 
 function isStyleExt(path: string) {
   return /\.(c|le|sa|sc)ss(\?.*)?$/.test(path);

--- a/packages/shared/src/graph/transform/trans-utils/transStats.ts
+++ b/packages/shared/src/graph/transform/trans-utils/transStats.ts
@@ -1,4 +1,4 @@
-import { Plugin, SDK } from '@rsdoctor/shared/types';
+import { Plugin, SDK } from '../../../types';
 import { Chunks, ModuleGraphTrans } from '..';
 
 /**

--- a/packages/shared/src/graph/types/transform.ts
+++ b/packages/shared/src/graph/types/transform.ts
@@ -1,4 +1,4 @@
-import { SDK } from '@rsdoctor/shared/types';
+import { SDK } from '../../types';
 
 export type ParseBundle = (
   assetFile: string,

--- a/packages/shared/tests/published-types.test.ts
+++ b/packages/shared/tests/published-types.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from '@rstest/core';
+import { execFileSync, type ExecFileSyncOptions } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(testDir, '../../..');
+const sharedRoot = path.resolve(repoRoot, 'packages/shared');
+const sharedPackageJsonPath = path.resolve(sharedRoot, 'package.json');
+const tscPath = require.resolve('typescript/lib/tsc');
+
+function runTsc(args: string[], options: ExecFileSyncOptions) {
+  try {
+    execFileSync(process.execPath, [tscPath, ...args], options);
+  } catch (error) {
+    const result = error as {
+      stdout?: Buffer | string;
+      stderr?: Buffer | string;
+    };
+
+    throw new Error(
+      ['tsc failed.', result.stdout?.toString(), result.stderr?.toString()]
+        .filter(Boolean)
+        .join('\n'),
+    );
+  }
+}
+
+function linkDependency(
+  consumerNodeModules: string,
+  packageName: string,
+  packageRoot: string,
+) {
+  const segments = packageName.split('/');
+  const target = path.join(consumerNodeModules, ...segments);
+
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.symlinkSync(packageRoot, target, 'junction');
+}
+
+function installSharedDependencies(consumerNodeModules: string) {
+  const sharedPackageJson = JSON.parse(
+    fs.readFileSync(sharedPackageJsonPath, 'utf-8'),
+  ) as {
+    dependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+  };
+  const packages = [
+    ...Object.keys(sharedPackageJson.dependencies ?? {}),
+    ...Object.keys(sharedPackageJson.peerDependencies ?? {}),
+  ];
+
+  for (const packageName of packages) {
+    const dependencyPackageJsonPath = require.resolve(
+      `${packageName}/package.json`,
+      {
+        paths: [sharedRoot],
+      },
+    );
+
+    linkDependency(
+      consumerNodeModules,
+      packageName,
+      path.dirname(dependencyPackageJsonPath),
+    );
+  }
+}
+
+function installSharedPackage(consumerNodeModules: string) {
+  const packageRoot = path.join(consumerNodeModules, '@rsdoctor/shared');
+
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.copyFileSync(
+    sharedPackageJsonPath,
+    path.join(packageRoot, 'package.json'),
+  );
+  fs.cpSync(path.join(sharedRoot, 'dist'), path.join(packageRoot, 'dist'), {
+    recursive: true,
+  });
+}
+
+describe('@rsdoctor/shared published declarations', () => {
+  it('resolves exported types in a consumer without extra dependencies', () => {
+    const consumerRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'rsdoctor-shared-types-consumer-'),
+    );
+
+    try {
+      const consumerNodeModules = path.join(consumerRoot, 'node_modules');
+
+      fs.mkdirSync(consumerNodeModules, { recursive: true });
+      installSharedPackage(consumerNodeModules);
+      installSharedDependencies(consumerNodeModules);
+      fs.writeFileSync(
+        path.join(consumerRoot, 'index.ts'),
+        "import type { SDK } from '@rsdoctor/shared/types';\n\nconst moduleData = {} as SDK.ModuleData;\nvoid moduleData;\n",
+      );
+      fs.writeFileSync(
+        path.join(consumerRoot, 'package.json'),
+        JSON.stringify({ type: 'module' }, null, 2),
+      );
+      fs.writeFileSync(
+        path.join(consumerRoot, 'tsconfig.json'),
+        JSON.stringify(
+          {
+            compilerOptions: {
+              module: 'Node16',
+              moduleResolution: 'Node16',
+              noEmit: true,
+              strict: true,
+              target: 'ES2022',
+            },
+            include: ['index.ts'],
+          },
+          null,
+          2,
+        ),
+      );
+
+      expect(() =>
+        runTsc(['-p', consumerRoot], {
+          cwd: consumerRoot,
+          encoding: 'utf-8',
+          stdio: 'pipe',
+        }),
+      ).not.toThrow();
+    } finally {
+      fs.rmSync(consumerRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
This pull request updates import paths throughout the `packages/shared/src/common` and `packages/shared/src/graph` directories to use relative imports for shared types, rather than importing from the `@rsdoctor/shared/types` package. This change improves modularity and maintainability by making the codebase less dependent on external package resolution and more robust to changes in project structure.

**Refactoring: Use of relative imports for shared types**

* Updated all imports of `Rule`, `SDK`, `Manifest`, `Constants`, `Client`, and `Plugin` in files under `packages/shared/src/common/` to use relative paths to the local `types` module instead of the external `@rsdoctor/shared/types` package. 

* Similarly, updated all imports of `SDK` in files under `packages/shared/src/graph/graph/` and its subdirectories to use relative imports from `../../../types`.

No functional or logic changes were made; this is a structural update to improve code organization and reduce reliance on external type package resolution.
## Related Links

https://github.com/web-infra-dev/rsdoctor/issues/1710#issuecomment-4851572164

<!--- Provide links of related issues or pages -->
