### PR TITLE
fix(components): backport bundle size asset lookup guard

### DIFF
--- a/packages/components/src/pages/BundleSize/components/asset-path.test.ts
+++ b/packages/components/src/pages/BundleSize/components/asset-path.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from '@rstest/core';
+import {
+  createAssetPathMap,
+  normalizeAssetPath,
+  resolveAssetFileTitleTarget,
+} from './asset-path';
+
+describe('BundleSize asset path helpers', () => {
+  it('normalizes Windows path separators', () => {
+    expect(normalizeAssetPath('static\\js\\main.js')).toBe('static/js/main.js');
+  });
+
+  it('resolves assets using normalized tree file paths', () => {
+    const asset = {
+      path: 'static\\js\\main.js',
+      size: 1024,
+    };
+    const assetsMap = createAssetPathMap([asset]);
+
+    expect(
+      resolveAssetFileTitleTarget(assetsMap, 'static/js/main.js', 'main.js'),
+    ).toBe(asset);
+  });
+
+  it('falls back to basename when the asset lookup misses', () => {
+    const assetsMap = createAssetPathMap([{ path: 'static/js/main.js' }]);
+
+    expect(
+      resolveAssetFileTitleTarget(assetsMap, 'static/css/main.css', 'main.css'),
+    ).toBe('main.css');
+  });
+});

--- a/packages/components/src/pages/BundleSize/components/asset-path.ts
+++ b/packages/components/src/pages/BundleSize/components/asset-path.ts
@@ -1,0 +1,11 @@
+export const normalizeAssetPath = (assetPath: string) =>
+  assetPath.replace(/\\/g, '/');
+
+export const createAssetPathMap = <T extends { path: string }>(assets: T[]) =>
+  new Map(assets.map((asset) => [normalizeAssetPath(asset.path), asset]));
+
+export const resolveAssetFileTitleTarget = <T extends { path: string }>(
+  assetsMap: Map<string, T>,
+  file: string,
+  basename: string,
+) => assetsMap.get(normalizeAssetPath(file)) ?? basename;

--- a/packages/components/src/pages/BundleSize/components/tree-graph.tsx
+++ b/packages/components/src/pages/BundleSize/components/tree-graph.tsx
@@ -23,6 +23,7 @@ import { ServerAPIProvider } from '../../../components/Manifest';
 import { Size } from '../../../constants';
 import { createFileStructures, formatSize, useI18n } from '../../../utils';
 import { AssetDetail } from './asset';
+import { createAssetPathMap, resolveAssetFileTitleTarget } from './asset-path';
 import styles from './index.module.scss';
 import './index.sass';
 import { SearchModal } from './search-modal';
@@ -133,11 +134,20 @@ export const TreeGraph = memo(
       });
     }, [summary.all.total.files]);
 
+    const assetsMap = useMemo(() => {
+      return createAssetPathMap(filteredAssets);
+    }, [filteredAssets]);
+
     const assetsStructures = useMemo(() => {
       const res = createFileStructures({
         files: filteredAssets.map((e) => e.path).filter(Boolean),
         fileTitle(file, basename) {
-          const target = filteredAssets.find((e) => e.path === file)!;
+          const target = resolveAssetFileTitleTarget(assetsMap, file, basename);
+
+          if (typeof target === 'string') {
+            return target;
+          }
+
           const { size, initial, path, content } = target;
 
           return (
@@ -173,7 +183,7 @@ export const TreeGraph = memo(
         },
       });
       return res;
-    }, [filteredAssets]);
+    }, [assetsMap, filteredAssets, showCode]);
 
     const onSearch = (value: string) => {
       setAssetName(value);


### PR DESCRIPTION
## Summary

Backport #1780 to `v1.x`. This guards Bundle Size asset tree rendering when an asset lookup misses, normalizes asset paths before lookup, and falls back to the basename instead of crashing the Bundle Size page.

Validation:
- `corepack pnpm exec nx build @rsdoctor/components`
- `corepack pnpm --filter @rsdoctor/components run test -- packages/components/src/pages/BundleSize/components/asset-path.test.ts`

## Related Links

- Backports #1780
- Fixes #1556

<!--- Provide links of related issues or pages -->