### PR TITLE
fix(components): backport custom bundle alert rules

### DIFF
--- a/packages/components/src/components/Alerts/bundle-alert.tsx
+++ b/packages/components/src/components/Alerts/bundle-alert.tsx
@@ -1,4 +1,5 @@
 import { Tabs, Empty, Tag } from 'antd';
+import { useState } from 'react';
 
 import { Card } from '../Card';
 import { ECMAVersionCheck } from '../Alert/ecma-version-check';
@@ -7,12 +8,11 @@ import { AlertCollapse } from './collapse';
 import { CommonList } from './list';
 import { ViewMode } from '../../constants';
 
-import { AlertProps } from '../Alert/types';
-
+import type { AlertProps } from '../Alert/types';
+import type { CSSProperties } from 'react';
 import type { Rule } from '@rsdoctor/types';
 
 import styles from './bundle-alert.module.scss';
-import { CSSProperties, useState } from 'react';
 import { CrossChunksAlertCollapse } from './collapse-cross-chunks';
 import { ModuleMixedChunksAlertCollapse } from './collapse-module-mixed-chunks';
 import { SideEffectsOnlyImportsAlertCollapse } from './collapse-side-effects-only-imports';
@@ -29,88 +29,89 @@ interface BundleAlertProps {
   extraCom?: React.JSX.Element | undefined;
 }
 
+const BUILTIN_RULE_TABS = [
+  {
+    key: 'E1001',
+    label: 'Duplicate Packages',
+  },
+  {
+    key: 'E1002',
+    label: 'Cross Chunks Package',
+  },
+  {
+    key: 'E1003',
+    label: 'Loader Performance Optimization',
+  },
+  {
+    key: 'E1004',
+    label: 'ECMA Version Check',
+  },
+  {
+    key: 'E1005',
+    label: 'Default Import Check',
+  },
+  {
+    key: 'E1006',
+    label: 'Module Mixed Chunks',
+  },
+  {
+    key: 'E1007',
+    label: 'Tree Shaking Side Effects Only',
+  },
+  {
+    key: 'E1008',
+    label: 'CJS Require Cannot Tree-Shake',
+  },
+  {
+    key: 'E1009',
+    label: 'ESM Import Resolved to CJS',
+  },
+];
+
 export const BundleAlert: React.FC<BundleAlertProps> = ({
   title,
   dataSource,
   extraData,
 }) => {
-  const firstKeyWithData =
-    [
-      'E1001',
-      'E1002',
-      'E1003',
-      'E1004',
-      'E1005',
-      'E1006',
-      'E1007',
-      'E1008',
-      'E1009',
-    ].find((code) => dataSource.some((d) => d.code === code)) ?? 'E1001';
-  const [activeKey, setActiveKey] = useState(firstKeyWithData);
   const tabData: Array<{
     key: string;
     label: string;
     data: Array<Rule.RuleStoreDataItem>;
-  }> = [
-    {
-      key: 'E1001',
-      label: 'Duplicate Packages',
-      data: [],
-    },
-    {
-      key: 'E1002',
-      label: 'Cross Chunks Package',
-      data: [],
-    },
-    {
-      key: 'E1003',
-      label: 'Loader Performance Optimization',
-      data: [],
-    },
-    {
-      key: 'E1004',
-      label: 'ECMA Version Check',
-      data: [],
-    },
-    {
-      key: 'E1005',
-      label: 'Default Import Check',
-      data: [],
-    },
-    {
-      key: 'E1006',
-      label: 'Module Mixed Chunks',
-      data: [],
-    },
-    {
-      key: 'E1007',
-      label: 'Tree Shaking Side Effects Only',
-      data: [],
-    },
-    {
-      key: 'E1008',
-      label: 'CJS Require Cannot Tree-Shake',
-      data: [],
-    },
-    {
-      key: 'E1009',
-      label: 'ESM Import Resolved to CJS',
-      data: [],
-    },
-  ];
+    tag: string;
+  }> = BUILTIN_RULE_TABS.map((tab) => ({ ...tab, data: [], tag: tab.key }));
+  const customRulesData: Array<Rule.RuleStoreDataItem> = [];
 
   dataSource.forEach((data) => {
-    const target = tabData.find((td) => td.key === data.code)?.data;
-    target?.push(data);
+    const target = tabData.find((td) => td.key === data.code);
+    if (target) {
+      target.data.push(data);
+    } else {
+      customRulesData.push(data);
+    }
   });
+
+  if (customRulesData.length) {
+    tabData.push({
+      key: 'CUSTOM_RULES',
+      label: 'Custom Rules',
+      data: customRulesData,
+      tag: 'Custom',
+    });
+  }
 
   tabData.sort(
     (a, b) => (b.data.length > 0 ? 1 : 0) - (a.data.length > 0 ? 1 : 0),
   );
 
+  const defaultActiveKey = tabData[0]?.key ?? 'E1001';
+  const [activeKey, setActiveKey] = useState(defaultActiveKey);
+  const resolvedActiveKey = tabData.some((tab) => tab.key === activeKey)
+    ? activeKey
+    : defaultActiveKey;
+
   const tabItems = tabData.map((td) => {
     const tagStyle =
-      activeKey === td.key
+      resolvedActiveKey === td.key
         ? ({
             border: '1px solid #91D5FF',
             backgroundColor: '#E6F7FF',
@@ -118,7 +119,7 @@ export const BundleAlert: React.FC<BundleAlertProps> = ({
         : {};
 
     const tagTextStyle =
-      activeKey === td.key
+      resolvedActiveKey === td.key
         ? {
             color: '#1890FF',
           }
@@ -139,7 +140,7 @@ export const BundleAlert: React.FC<BundleAlertProps> = ({
             <Tag
               style={{ fontFamily: 'Menlo', borderRadius: '2px', ...tagStyle }}
             >
-              <span style={{ ...tagTextStyle }}>{td.key}</span>
+              <span style={{ ...tagTextStyle }}>{td.tag}</span>
             </Tag>
           </div>
         }
@@ -197,6 +198,9 @@ export const BundleAlert: React.FC<BundleAlertProps> = ({
           <EsmResolvedToCjsAlertCollapse data={td.data} extraData={extraData} />
         );
         break;
+      case 'CUSTOM_RULES':
+        children = <CommonList data={td.data} showCode />;
+        break;
       default:
         children = null;
         break;
@@ -226,7 +230,7 @@ export const BundleAlert: React.FC<BundleAlertProps> = ({
                   borderRadius: '2px',
                 }}
               >
-                {td.key}
+                {td.tag}
               </Tag>
               <span>{td.label}</span>
             </>
@@ -261,7 +265,7 @@ export const BundleAlert: React.FC<BundleAlertProps> = ({
             onChange={setActiveKey}
             tabBarGutter={10}
             type="card"
-            defaultActiveKey={tabData[0]?.key ?? 'E1001'}
+            activeKey={resolvedActiveKey}
             items={tabItems}
           />
         )}

--- a/packages/components/src/components/Alerts/bundle-alert.tsx
+++ b/packages/components/src/components/Alerts/bundle-alert.tsx
@@ -1,5 +1,5 @@
 import { Tabs, Empty, Tag } from 'antd';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Card } from '../Card';
 import { ECMAVersionCheck } from '../Alert/ecma-version-check';
@@ -105,9 +105,15 @@ export const BundleAlert: React.FC<BundleAlertProps> = ({
 
   const defaultActiveKey = tabData[0]?.key ?? 'E1001';
   const [activeKey, setActiveKey] = useState(defaultActiveKey);
-  const resolvedActiveKey = tabData.some((tab) => tab.key === activeKey)
-    ? activeKey
-    : defaultActiveKey;
+  const activeTab = tabData.find((tab) => tab.key === activeKey);
+  const resolvedActiveKey =
+    activeTab && (activeTab.data.length > 0 || dataSource.length === 0)
+      ? activeKey
+      : defaultActiveKey;
+
+  useEffect(() => {
+    setActiveKey(defaultActiveKey);
+  }, [defaultActiveKey]);
 
   const tabItems = tabData.map((td) => {
     const tagStyle =

--- a/packages/components/src/components/Alerts/list.module.scss
+++ b/packages/components/src/components/Alerts/list.module.scss
@@ -5,3 +5,11 @@
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+.code {
+  margin-bottom: 4px;
+  color: #1890ff;
+  font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
+  font-size: 13px;
+  font-weight: 600;
+}

--- a/packages/components/src/components/Alerts/list.tsx
+++ b/packages/components/src/components/Alerts/list.tsx
@@ -7,8 +7,11 @@ import type { Rule } from '@rsdoctor/types';
 
 import styles from './list.module.scss';
 
-export const CommonList = (props: { data: Array<Rule.RuleStoreDataItem> }) => {
-  const { data } = props;
+export const CommonList = (props: {
+  data: Array<Rule.RuleStoreDataItem>;
+  showCode?: boolean;
+}) => {
+  const { data, showCode } = props;
   return data.map((d) => {
     const { code, link, description } = d;
     const navigate = useRuleIndexNavigate(code, link);
@@ -19,10 +22,13 @@ export const CommonList = (props: { data: Array<Rule.RuleStoreDataItem> }) => {
           background: '#fff',
         }}
         description={
-          <div className={styles.description}>{description || ''}</div>
+          <div className={styles.description}>
+            {showCode ? <div className={styles.code}>{code}</div> : null}
+            <div>{description || ''}</div>
+          </div>
         }
         icon={
-          <Button onClick={() => navigate} type="link">
+          <Button onClick={navigate} type="link">
             more
           </Button>
         }


### PR DESCRIPTION
## Summary

Backport #1781 to `v1.x`. This keeps custom bundle alert rule codes visible by grouping unknown codes under a `Custom Rules` tab and rendering them through the common alert list.

Validation:
- `corepack pnpm exec nx build @rsdoctor/components`

## Related Links

- Backports #1781
- Fixes #1368

<!--- Provide links of related issues or pages -->