### PR TITLE
feat(components): backport js-only bundle asset filters

### DIFF
--- a/packages/components/src/components/Charts/TreeMap.tsx
+++ b/packages/components/src/components/Charts/TreeMap.tsx
@@ -24,6 +24,7 @@ import { ServerAPIProvider } from 'src/components/Manifest';
 import { ModuleAnalyzeComponent } from '../../pages/ModuleAnalyze';
 import Styles from './treemap.module.scss';
 import { TREE_COLORS } from './constants';
+import { isJavaScriptAsset } from '../../utils/assets';
 import type {
   CallbackDataParams,
   ECElementEvent,
@@ -647,8 +648,35 @@ const AssetTreemapWithFilterInner: React.FC<{
   const [moduleId, setModuleId] = useState<string | number>('');
   const [showAnalyze, setShowAnalyze] = useState(false);
   const [chunkSearchQuery, setChunkSearchQuery] = useState('');
+  const [showOnlyJavaScriptAssets, setShowOnlyJavaScriptAssets] =
+    useState(false);
 
   const containerRef = React.useRef<HTMLDivElement>(null);
+
+  const visibleAssetNames = useMemo(() => {
+    if (!showOnlyJavaScriptAssets) {
+      return assetNames;
+    }
+
+    return assetNames.filter(isJavaScriptAsset);
+  }, [assetNames, showOnlyJavaScriptAssets]);
+
+  const visibleAssetNamesKey = useMemo(
+    () => visibleAssetNames.join('\0'),
+    [visibleAssetNames],
+  );
+  const previousVisibleAssetNamesKeyRef = React.useRef<string | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    if (previousVisibleAssetNamesKeyRef.current === visibleAssetNamesKey) {
+      return;
+    }
+
+    previousVisibleAssetNamesKeyRef.current = visibleAssetNamesKey;
+    setCheckedAssets(visibleAssetNames);
+  }, [visibleAssetNames, visibleAssetNamesKey]);
 
   const handleChartClick = useCallback(
     (params: ECElementEvent) => {
@@ -729,7 +757,11 @@ const AssetTreemapWithFilterInner: React.FC<{
   }, []);
 
   const filteredTreeData = useMemo(() => {
-    let filtered = treeData.filter((item) => checkedAssets.includes(item.name));
+    let filtered = treeData.filter(
+      (item) =>
+        visibleAssetNames.includes(item.name) &&
+        checkedAssets.includes(item.name),
+    );
 
     if (chunkSearchQuery.trim()) {
       const searchLower = chunkSearchQuery.toLowerCase();
@@ -739,7 +771,7 @@ const AssetTreemapWithFilterInner: React.FC<{
     }
 
     return filtered;
-  }, [treeData, checkedAssets, chunkSearchQuery]);
+  }, [treeData, checkedAssets, chunkSearchQuery, visibleAssetNames]);
 
   const searchResults = useMemo(() => {
     if (!searchQuery.trim()) return [];
@@ -876,21 +908,33 @@ const AssetTreemapWithFilterInner: React.FC<{
             <Checkbox
               indeterminate={
                 checkedAssets.length > 0 &&
-                checkedAssets.length < assetNames.length
+                checkedAssets.length < visibleAssetNames.length
               }
-              checked={checkedAssets.length === assetNames.length}
+              checked={
+                visibleAssetNames.length > 0 &&
+                checkedAssets.length === visibleAssetNames.length
+              }
               onChange={(e) =>
-                setCheckedAssets(e.target.checked ? assetNames : [])
+                setCheckedAssets(e.target.checked ? visibleAssetNames : [])
               }
               className={Styles['all-none-checkbox']}
             >
               All
             </Checkbox>
+            <Checkbox
+              checked={showOnlyJavaScriptAssets}
+              onChange={(e) => {
+                setShowOnlyJavaScriptAssets(e.target.checked);
+              }}
+              className={Styles['all-none-checkbox']}
+            >
+              JS only
+            </Checkbox>
             <div
               className={Styles['chunk-list']}
               style={{ maxHeight: 180, overflowY: 'auto' }}
             >
-              {assetNames
+              {visibleAssetNames
                 .filter((name) =>
                   name.toLowerCase().includes(chunkSearchQuery.toLowerCase()),
                 )

--- a/packages/components/src/pages/BundleSize/components/index.tsx
+++ b/packages/components/src/pages/BundleSize/components/index.tsx
@@ -30,6 +30,7 @@ import {
 } from 'src/components/Charts/TreeMap';
 import { Rspack } from '@rsdoctor/utils/common';
 import { TreeGraph } from './tree-graph';
+import { isJavaScriptAsset } from '../../../utils/assets';
 
 interface WebpackModulesOverallProps {
   cwd: string;
@@ -219,23 +220,20 @@ export const WebpackModulesOverallBase: React.FC<
                       >
                         {(data) => {
                           // Filter assets to only show JS (js, cjs, mjs), .bundle, CSS, and HTML files
-                          const isTargetFileType = (
-                            filePath: string,
-                          ): boolean => {
+                          const isVisibleTreemapAsset = (filePath: string) => {
                             const ext =
                               filePath.toLowerCase().split('.').pop() || '';
                             return (
-                              ext === 'js' ||
-                              ext === 'cjs' ||
-                              ext === 'mjs' ||
-                              ext === 'bundle' ||
+                              isJavaScriptAsset(filePath) ||
                               ext === 'css' ||
                               ext === 'html'
                             );
                           };
 
                           const computedTreeData: TreeNode[] = data
-                            .filter((item) => isTargetFileType(item.asset.path))
+                            .filter((item) =>
+                              isVisibleTreemapAsset(item.asset.path),
+                            )
                             .map((item) => {
                               const moduleTree = flattenTreemapData(
                                 item.modules,

--- a/packages/components/src/pages/BundleSize/components/tree-graph.tsx
+++ b/packages/components/src/pages/BundleSize/components/tree-graph.tsx
@@ -2,6 +2,7 @@ import { CodeOutlined, InfoCircleOutlined } from '@ant-design/icons';
 import { type Client, SDK } from '@rsdoctor/types';
 import {
   Card,
+  Checkbox,
   Col,
   Divider,
   Empty,
@@ -26,6 +27,8 @@ import { AssetDetail } from './asset';
 import styles from './index.module.scss';
 import './index.sass';
 import { SearchModal } from './search-modal';
+import { isJavaScriptAsset } from '../../../utils/assets';
+
 const { Option } = Select;
 
 export const TreeGraph = memo(
@@ -47,6 +50,8 @@ export const TreeGraph = memo(
     const [defaultExpandAll, setDefaultExpandAll] = useState(false);
     const [inputModuleUnit, setModuleUnit] = useState('');
     const [inputChunkUnit, setChunkUnit] = useState('');
+    const [showOnlyJavaScriptAssets, setShowOnlyJavaScriptAssets] =
+      useState(false);
     const [assetPath, setAssetPath] = useState<string | null>(null);
     const { showCode, codeDrawerComponent } = useCodeDrawer(
       'Do not have the codes of assets. If you use the lite or brief mode, there will have codes.',
@@ -98,6 +103,10 @@ export const TreeGraph = memo(
         res = res.filter((e) => e.path.indexOf(inputAssetName) > -1);
       }
 
+      if (showOnlyJavaScriptAssets) {
+        res = res.filter((e) => isJavaScriptAsset(e.path));
+      }
+
       if (inputAssetSize > 0) {
         res = res.filter((e) => e.size >= inputAssetSize);
       }
@@ -117,21 +126,25 @@ export const TreeGraph = memo(
         // return _a - _b;
         return _b - _a;
       });
-    }, [assets, selectedEntryPoints, inputAssetName, inputAssetSize]);
+    }, [
+      assets,
+      selectedEntryPoints,
+      inputAssetName,
+      inputAssetSize,
+      showOnlyJavaScriptAssets,
+    ]);
 
     useEffect(() => {
-      function getFileExtension(filePath: string) {
-        const parts = filePath.split('.');
-        return parts.length > 1 ? parts.pop() : '';
+      if (assetPath && filteredAssets.some((f) => f.path === assetPath)) {
+        return;
       }
 
-      summary.all.total.files.forEach((f) => {
-        const ext = getFileExtension(f.path);
-        if (ext === 'js') {
-          setAssetPath(f.path);
-        }
-      });
-    }, [summary.all.total.files]);
+      const nextAsset =
+        filteredAssets.find((f) => isJavaScriptAsset(f.path)) ??
+        filteredAssets[0];
+
+      setAssetPath(nextAsset?.path ?? null);
+    }, [assetPath, filteredAssets]);
 
     const assetsStructures = useMemo(() => {
       const res = createFileStructures({
@@ -227,6 +240,17 @@ export const TreeGraph = memo(
                 placeholder="search asset by keyword"
                 onChange={onSearch}
               />
+            </Col>
+            <Col>
+              <Checkbox
+                checked={showOnlyJavaScriptAssets}
+                onChange={(e) => {
+                  setShowOnlyJavaScriptAssets(e.target.checked);
+                  setDefaultExpandAll(false);
+                }}
+              >
+                JS only
+              </Checkbox>
             </Col>
             <Col span={6}>
               <InputNumber

--- a/packages/components/src/utils/assets.test.ts
+++ b/packages/components/src/utils/assets.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from '@rstest/core';
+import { isJavaScriptAsset } from './assets';
+
+describe('assets utils', () => {
+  it('detects JavaScript assets by extension', () => {
+    expect(isJavaScriptAsset('app.js')).toBe(true);
+    expect(isJavaScriptAsset('chunk.CJS')).toBe(true);
+    expect(isJavaScriptAsset('runtime.mjs')).toBe(true);
+    expect(isJavaScriptAsset('page.jsx')).toBe(true);
+    expect(isJavaScriptAsset('main.bundle')).toBe(true);
+  });
+
+  it('ignores query strings and hashes when checking extensions', () => {
+    expect(isJavaScriptAsset('app.js?x=1')).toBe(true);
+    expect(isJavaScriptAsset('chunk.mjs#content')).toBe(true);
+    expect(isJavaScriptAsset('page.jsx?x=1#content')).toBe(true);
+  });
+
+  it('returns false when the asset path has no extension', () => {
+    expect(isJavaScriptAsset('app')).toBe(false);
+    expect(isJavaScriptAsset('app?x=1')).toBe(false);
+  });
+});

--- a/packages/components/src/utils/assets.ts
+++ b/packages/components/src/utils/assets.ts
@@ -1,0 +1,17 @@
+const JAVASCRIPT_ASSET_EXTENSIONS = new Set([
+  'js',
+  'cjs',
+  'mjs',
+  'jsx',
+  'bundle',
+]);
+
+export const isJavaScriptAsset = (assetPath: string): boolean => {
+  const cleanPath = assetPath.split(/[?#]/, 1)[0] ?? '';
+  const lastDot = cleanPath.lastIndexOf('.');
+
+  if (lastDot === -1) return false;
+
+  const ext = cleanPath.slice(lastDot + 1).toLowerCase();
+  return JAVASCRIPT_ASSET_EXTENSIONS.has(ext);
+};


### PR DESCRIPTION
## Summary

Backport #1782 to `v1.x`. This adds JavaScript-only bundle asset filtering so the Bundle Size view can focus tree map and graph rendering on JS assets.

Validation:
- `corepack pnpm exec nx build @rsdoctor/components`
- `corepack pnpm --filter @rsdoctor/components run test -- packages/components/src/utils/assets.test.ts`

## Related Links

- Backports #1782
- Related to #1229

<!--- Provide links of related issues or pages -->