### PR TITLE
fix(sdk): secure open-in-editor endpoint

### DIFF
--- a/.changeset/secure-open-editor.md
+++ b/.changeset/secure-open-editor.md
@@ -1,0 +1,7 @@
+---
+'@rsdoctor/types': patch
+'@rsdoctor/sdk': patch
+'@rsdoctor/components': patch
+---
+
+Require the socket token when opening local files through the `__open-in-editor` endpoint.

--- a/.changeset/secure-open-editor.md
+++ b/.changeset/secure-open-editor.md
@@ -1,7 +1,0 @@
----
-'@rsdoctor/types': patch
-'@rsdoctor/sdk': patch
-'@rsdoctor/components': patch
----
-
-Require the socket token when opening local files through the `__open-in-editor` endpoint.

--- a/packages/components/src/components/Opener/ide.tsx
+++ b/packages/components/src/components/Opener/ide.tsx
@@ -1,4 +1,5 @@
 import { Lodash } from '@rsdoctor/utils/common';
+import { SDK } from '@rsdoctor/types';
 import React from 'react';
 import VSCodeIcon from '../../common/svg/vscode.svg';
 
@@ -12,13 +13,39 @@ interface VSCodeProps {
 
 const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
 
-type EditorKind = 'code' | 'cursor' | 'trae';
+let openInEditorTokenTask: Promise<string | undefined> | undefined;
+
+function getOpenInEditorTokenFromSocketUrl(socketUrl?: string) {
+  if (!socketUrl) return undefined;
+  try {
+    return (
+      new URL(socketUrl, window.location.origin).searchParams.get('token') ||
+      undefined
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+async function getOpenInEditorToken(base: string) {
+  if (!base) return undefined;
+  if (!openInEditorTokenTask) {
+    openInEditorTokenTask = fetch(`${base}${SDK.ServerAPI.API.Manifest}`)
+      .then((res) => (res.ok ? res.json() : undefined))
+      .then((manifest) =>
+        getOpenInEditorTokenFromSocketUrl(manifest?.__SOCKET__URL__),
+      )
+      .catch(() => undefined);
+  }
+
+  return openInEditorTokenTask;
+}
 
 async function openInEditor(
   file: string,
   line: number | string,
   column: number | string,
-  editor: EditorKind,
+  editor: SDK.OpenInEditorKind,
   urlSchemeFallback: () => void,
 ) {
   const fileSpec = `${file}:${line}:${column}`;
@@ -27,8 +54,19 @@ async function openInEditor(
       typeof window !== 'undefined' && window.location?.origin
         ? window.location.origin
         : '';
-    const url = `${base}${OPEN_IN_EDITOR_PATH}?file=${encodeURIComponent(fileSpec)}&editor=${editor}`;
-    const res = await fetch(url, { method: 'GET' });
+    const token = await getOpenInEditorToken(base);
+    if (!token) {
+      urlSchemeFallback();
+      return;
+    }
+    const params = new URLSearchParams({
+      file: fileSpec,
+      editor,
+      token,
+    });
+    const res = await fetch(`${base}${OPEN_IN_EDITOR_PATH}?${params}`, {
+      method: 'GET',
+    });
     if (!res.ok) {
       urlSchemeFallback();
     }

--- a/packages/sdk/src/sdk/server/index.ts
+++ b/packages/sdk/src/sdk/server/index.ts
@@ -19,6 +19,7 @@ import { randomBytes } from 'crypto';
 import {
   DEFAULT_ALLOWED_CORS_ORIGINS,
   isAllowedCorsRequest,
+  isAllowedOpenInEditorToken,
   isAllowedRequestHost,
 } from './security';
 
@@ -28,6 +29,7 @@ export * from './utils';
 /** Path for launch-editor: open file in editor from the UI (see https://github.com/yyx990803/launch-editor) */
 const OPEN_IN_EDITOR_PATH = '/__open-in-editor';
 const LISTEN_RETRY_LIMIT = 10;
+const OPEN_IN_EDITOR_EDITORS = new Set<string>(SDK.OPEN_IN_EDITOR_EDITORS);
 
 export type ISocketType = { port: number; socketUrl: string; token: string };
 
@@ -39,6 +41,12 @@ export type RsdoctorServerOptions = {
 
 function isAddressInUseError(error: unknown) {
   return (error as { code?: string }).code === 'EADDRINUSE';
+}
+
+function isAllowedOpenInEditorEditor(
+  editor: string | null,
+): editor is SDK.OpenInEditorKind {
+  return typeof editor === 'string' && OPEN_IN_EDITOR_EDITORS.has(editor);
 }
 
 export class RsdoctorServer implements SDK.RsdoctorServerInstance {
@@ -231,10 +239,21 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
         }
         const url = new URL(req.url || '', `http://localhost`);
         const file = url.searchParams.get('file');
-        const editor = url.searchParams.get('editor') || undefined;
+        const editor = url.searchParams.get('editor');
+        const token = url.searchParams.get('token');
+        if (!isAllowedOpenInEditorToken(token, this._socketToken)) {
+          res.statusCode = 403;
+          res.end();
+          return;
+        }
         if (!file) {
           res.statusCode = 400;
           res.end('Missing file parameter');
+          return;
+        }
+        if (!isAllowedOpenInEditorEditor(editor)) {
+          res.statusCode = 400;
+          res.end('Unsupported editor parameter');
           return;
         }
         try {

--- a/packages/sdk/src/sdk/server/security.ts
+++ b/packages/sdk/src/sdk/server/security.ts
@@ -1,4 +1,5 @@
 import { isIP } from 'node:net';
+import { timingSafeEqual } from 'node:crypto';
 
 export const DEFAULT_ALLOWED_CORS_ORIGINS =
   /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/;
@@ -71,4 +72,19 @@ export function isAllowedCorsRequest(
   }
 
   return true;
+}
+
+export function isAllowedOpenInEditorToken(
+  token: string | null,
+  expectedToken: string,
+) {
+  if (typeof token !== 'string' || !expectedToken) {
+    return false;
+  }
+  const tokenBuffer = Buffer.from(token);
+  const expectedTokenBuffer = Buffer.from(expectedToken);
+  return (
+    tokenBuffer.length === expectedTokenBuffer.length &&
+    timingSafeEqual(tokenBuffer, expectedTokenBuffer)
+  );
 }

--- a/packages/sdk/tests/server/apis/project.test.ts
+++ b/packages/sdk/tests/server/apis/project.test.ts
@@ -153,6 +153,40 @@ describe('test server/apis/project.ts', () => {
     });
   });
 
+  it('requires socket token for open-in-editor requests', async () => {
+    const host = `127.0.0.1:${target.server.port}`;
+
+    await expect(
+      requestWithHost('/__open-in-editor?file=/tmp/example.js', host),
+    ).resolves.toStrictEqual({
+      statusCode: 403,
+    });
+    await expect(
+      requestWithHost(
+        '/__open-in-editor?file=/tmp/example.js&token=invalid',
+        host,
+      ),
+    ).resolves.toStrictEqual({
+      statusCode: 403,
+    });
+    await expect(
+      requestWithHost(
+        `/__open-in-editor?token=${target.server.socketUrl.token}`,
+        host,
+      ),
+    ).resolves.toStrictEqual({
+      statusCode: 400,
+    });
+    await expect(
+      requestWithHost(
+        `/__open-in-editor?file=/tmp/example.js&editor=sh%20-c&token=${target.server.socketUrl.token}`,
+        host,
+      ),
+    ).resolves.toStrictEqual({
+      statusCode: 400,
+    });
+  });
+
   it('supports custom server.cors options', async () => {
     await expect(
       optionsWithOrigin(customCorsTarget, 'https://example.com'),

--- a/packages/sdk/tests/server/security.test.ts
+++ b/packages/sdk/tests/server/security.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@rstest/core';
 import {
   isAllowedCorsRequest,
+  isAllowedOpenInEditorToken,
   isAllowedRequestHost,
   isAllowedRequestOrigin,
 } from '../../src/sdk/server/security';
@@ -51,5 +52,12 @@ describe('test server/security.ts', () => {
     expect(
       isAllowedCorsRequest('http://foo.localhost:3001', '127.0.0.1:3000'),
     ).toBe(false);
+  });
+
+  it('requires the exact token for open-in-editor requests', () => {
+    expect(isAllowedOpenInEditorToken(null, 'secret')).toBe(false);
+    expect(isAllowedOpenInEditorToken('wrong', 'secret')).toBe(false);
+    expect(isAllowedOpenInEditorToken('secret-extra', 'secret')).toBe(false);
+    expect(isAllowedOpenInEditorToken('secret', 'secret')).toBe(true);
   });
 });

--- a/packages/types/src/sdk/server/index.ts
+++ b/packages/types/src/sdk/server/index.ts
@@ -5,6 +5,10 @@ import { API, APIExtends } from './apis';
 
 export * as ServerAPI from './apis';
 
+export const OPEN_IN_EDITOR_EDITORS = ['code', 'cursor', 'trae'] as const;
+
+export type OpenInEditorKind = (typeof OPEN_IN_EDITOR_EDITORS)[number];
+
 interface ClientUrlFunctionWithRouteDefined<T> {
   (
     route: RsdoctorClientRoutes.BundleDiff,


### PR DESCRIPTION
## Summary
- Require the socket token for `__open-in-editor` requests to prevent cross-site GET requests from triggering local editor actions.
- Share `OpenInEditorKind` and `OPEN_IN_EDITOR_EDITORS` from `@rsdoctor/types`, and restrict server-side `editor` values to `code`, `cursor`, and `trae`.
- Update the client opener to read the token from the manifest socket URL and include it in open-in-editor requests.
- Add regression tests for token validation and unsupported editor rejection.

## Related Links

<!--- Provide links of related issues or pages -->
