### PR TITLE
refactor: migrate packages to ESM-only

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   build: {
-    external: ['**/packages/shared/dist/**'],
+    external: ['**/packages/*/dist/**', '**/scripts/test-helper/dist/**'],
   },
   testMatch: ['/cases/**/**.test.ts'],
   timeout: 60000,

--- a/examples/rspack-banner-minimal/package.json
+++ b/examples/rspack-banner-minimal/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.1",
   "private": true,
   "scripts": {
-    "dev": "cross-env ENABLE_CLIENT_SERVER=true NODE_ENV=development rspack serve",
-    "build": "cross-env ENABLE_CLIENT_SERVER=false NODE_ENV=production rspack build -c ./rspack.config.js",
-    "build:analysis": "cross-env ENABLE_CLIENT_SERVER=true NODE_ENV=production rspack build"
+    "dev": "cross-env ENABLE_CLIENT_SERVER=true NODE_ENV=development rspack serve -c ./rspack.config.mjs",
+    "build": "cross-env ENABLE_CLIENT_SERVER=false NODE_ENV=production rspack build -c ./rspack.config.mjs",
+    "build:analysis": "cross-env ENABLE_CLIENT_SERVER=true NODE_ENV=production rspack build -c ./rspack.config.mjs"
   },
   "dependencies": {
     "@arco-design/web-react": "^2.58.3",

--- a/examples/rspack-banner-minimal/rspack.config.mjs
+++ b/examples/rspack-banner-minimal/rspack.config.mjs
@@ -1,12 +1,15 @@
-const rspack = require('@rspack/core');
-const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
-const { RsdoctorRspackPlugin } = require('@rsdoctor/core/rspack-plugin');
+import { RsdoctorRspackPlugin } from '@rsdoctor/core/rspack-plugin';
+import rspack from '@rspack/core';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
+
+const banner = `var a = 111111111111111; console.log(a)`;
 
 /** @type {import('@rspack/cli').Configuration} */
-const config = {
+const rspackConfig = {
   entry: {
     main: './src/index.tsx',
   },
+  devtool: 'source-map',
   module: {
     rules: [
       {
@@ -68,17 +71,6 @@ const config = {
         type: 'javascript/auto',
       },
       {
-        test: /\.css$/,
-        use: [
-          {
-            loader: 'builtin:lightningcss-loader',
-            options: {
-              targets: 'ie 10',
-            },
-          },
-        ],
-      },
-      {
         test: /\.svg$/,
         type: 'asset/resource',
       },
@@ -87,33 +79,27 @@ const config = {
   resolve: {
     extensions: ['...', '.tsx', '.ts', '.jsx'], // "..." means to extend from the default extensions
   },
+  optimization: {
+    minimize: true,
+  },
+  // stats: 'verbose',
   plugins: [
     new ReactRefreshRspackPlugin(),
     new RsdoctorRspackPlugin({
       disableClientServer: process.env.ENABLE_CLIENT_SERVER === 'false',
-      features: ['bundle', 'plugins', 'loader'],
-      mode: 'brief',
-      linter: {
-        rules: {
-          'ecma-version-check': [
-            'Warn',
-            {
-              ecmaVersion: 3,
-            },
-          ],
-        },
+      features: ['bundle', 'plugins', 'resolver', 'loader'],
+      supports: {
+        banner: false,
       },
+    }),
+    new rspack.BannerPlugin({
+      test: /\.js/,
+      banner,
+      raw: true,
     }),
     new rspack.HtmlRspackPlugin({
       template: './index.html',
     }),
-    new rspack.CopyRspackPlugin({
-      patterns: [
-        {
-          from: 'public',
-        },
-      ],
-    }),
   ],
 };
-module.exports = config;
+export default rspackConfig;

--- a/examples/rspack-layers-minimal/build.ts
+++ b/examples/rspack-layers-minimal/build.ts
@@ -1,10 +1,11 @@
+import { RsdoctorRspackMultiplePlugin } from '@rsdoctor/core/rspack-plugin';
 import rspack from '@rspack/core';
-import { resolve } from 'path';
-const config = require('./rspack.config.js');
-const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
-const {
-  RsdoctorRspackMultiplePlugin,
-} = require('@rsdoctor/core/rspack-plugin');
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import config from './rspack.config.mjs';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
 
 // console.log(config)
 
@@ -66,7 +67,7 @@ async function build() {
       name: 'Builder 2',
       target: 'node',
       output: {
-        path: resolve(__dirname, 'dist/node'),
+        path: resolve(currentDir, 'dist/node'),
         filename: 'index.js',
       },
       plugins: [

--- a/examples/rspack-layers-minimal/package.json
+++ b/examples/rspack-layers-minimal/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.1",
   "private": true,
   "scripts": {
-    "dev": "ENABLE_CLIENT_SERVER=true NODE_ENV=development rspack serve",
-    "build": "ENABLE_CLIENT_SERVER=false NODE_ENV=production rspack build -c ./rspack.config.js"
+    "dev": "ENABLE_CLIENT_SERVER=true NODE_ENV=development rspack serve -c ./rspack.config.mjs",
+    "build": "ENABLE_CLIENT_SERVER=false NODE_ENV=production rspack build -c ./rspack.config.mjs"
   },
   "dependencies": {
     "@arco-design/web-react": "^2.58.3",

--- a/examples/rspack-layers-minimal/rspack.config.mjs
+++ b/examples/rspack-layers-minimal/rspack.config.mjs
@@ -1,9 +1,9 @@
-const rspack = require('@rspack/core');
-const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
-const { RsdoctorRspackPlugin } = require('@rsdoctor/core/rspack-plugin');
+import { RsdoctorRspackPlugin } from '@rsdoctor/core/rspack-plugin';
+import rspack from '@rspack/core';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 
 /** @type {import('@rspack/cli').Configuration} */
-const config = {
+const rspackConfig = {
   entry: {
     main: {
       import: './src/index.tsx',
@@ -125,4 +125,4 @@ const config = {
     }),
   ],
 };
-module.exports = config;
+export default rspackConfig;

--- a/examples/rspack-minimal/build.ts
+++ b/examples/rspack-minimal/build.ts
@@ -1,10 +1,11 @@
+import { RsdoctorRspackMultiplePlugin } from '@rsdoctor/core/rspack-plugin';
 import rspack from '@rspack/core';
-import { resolve } from 'path';
-const config = require('./rspack.config.js');
-const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
-const {
-  RsdoctorRspackMultiplePlugin,
-} = require('@rsdoctor/core/rspack-plugin');
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import config from './rspack.config.mjs';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
 
 // console.log(config)
 
@@ -66,7 +67,7 @@ async function build() {
       name: 'Builder 2',
       target: 'node',
       output: {
-        path: resolve(__dirname, 'dist/node'),
+        path: resolve(currentDir, 'dist/node'),
         filename: 'index.js',
       },
       plugins: [

--- a/examples/rspack-minimal/package.json
+++ b/examples/rspack-minimal/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.1",
   "private": true,
   "scripts": {
-    "dev": "ENABLE_CLIENT_SERVER=true NODE_ENV=development rspack serve",
-    "build:s": "ENABLE_CLIENT_SERVER=false NODE_ENV=production rspack build -c ./rspack.config.js",
-    "build:analysis": "ENABLE_CLIENT_SERVER=true NODE_ENV=production rspack build",
+    "dev": "ENABLE_CLIENT_SERVER=true NODE_ENV=development rspack serve -c ./rspack.config.mjs",
+    "build:s": "ENABLE_CLIENT_SERVER=false NODE_ENV=production rspack build -c ./rspack.config.mjs",
+    "build:analysis": "ENABLE_CLIENT_SERVER=true NODE_ENV=production rspack build -c ./rspack.config.mjs",
     "build:m": "ENABLE_CLIENT_SERVER=false NODE_ENV=production tsx build.ts",
     "build": "npm run build:s && npm run build:m"
   },

--- a/examples/rspack-minimal/rspack.config.mjs
+++ b/examples/rspack-minimal/rspack.config.mjs
@@ -1,15 +1,12 @@
-const rspack = require('@rspack/core');
-const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
-const { RsdoctorRspackPlugin } = require('@rsdoctor/core/rspack-plugin');
-
-const banner = `var a = 111111111111111; console.log(a)`;
+import { RsdoctorRspackPlugin } from '@rsdoctor/core/rspack-plugin';
+import rspack from '@rspack/core';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 
 /** @type {import('@rspack/cli').Configuration} */
-const config = {
+const rspackConfig = {
   entry: {
     main: './src/index.tsx',
   },
-  devtool: 'source-map',
   module: {
     rules: [
       {
@@ -71,6 +68,17 @@ const config = {
         type: 'javascript/auto',
       },
       {
+        test: /\.css$/,
+        use: [
+          {
+            loader: 'builtin:lightningcss-loader',
+            options: {
+              targets: 'ie 10',
+            },
+          },
+        ],
+      },
+      {
         test: /\.svg$/,
         type: 'asset/resource',
       },
@@ -79,27 +87,33 @@ const config = {
   resolve: {
     extensions: ['...', '.tsx', '.ts', '.jsx'], // "..." means to extend from the default extensions
   },
-  optimization: {
-    minimize: true,
-  },
-  // stats: 'verbose',
   plugins: [
     new ReactRefreshRspackPlugin(),
     new RsdoctorRspackPlugin({
       disableClientServer: process.env.ENABLE_CLIENT_SERVER === 'false',
-      features: ['bundle', 'plugins', 'resolver', 'loader'],
-      supports: {
-        banner: false,
+      features: ['bundle', 'plugins', 'loader'],
+      mode: 'brief',
+      linter: {
+        rules: {
+          'ecma-version-check': [
+            'Warn',
+            {
+              ecmaVersion: 3,
+            },
+          ],
+        },
       },
-    }),
-    new rspack.BannerPlugin({
-      test: /\.js/,
-      banner,
-      raw: true,
     }),
     new rspack.HtmlRspackPlugin({
       template: './index.html',
     }),
+    new rspack.CopyRspackPlugin({
+      patterns: [
+        {
+          from: 'public',
+        },
+      ],
+    }),
   ],
 };
-module.exports = config;
+export default rspackConfig;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "scripts": {
-    "build": "pnpm --workspace-concurrency=10 --filter \"./packages/*\" --filter \"!./packages/document\" --filter \"./scripts/*\" run build",
+    "build": "pnpm --workspace-concurrency=10 --filter \"./packages/*\" --filter \"!./packages/document\" --filter \"./scripts/*\" --filter \"@examples/rsdoctor-rspack-banner\" run build",
     "change": "changeset",
     "changeset": "changeset",
     "bump": "changeset version",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "scripts": {
-    "build": "cross-env NX_DAEMON=false nx run-many -t build --projects=@rsdoctor/*,@examples/rsdoctor-rspack-banner --parallel=10",
+    "build": "pnpm --workspace-concurrency=10 --filter \"./packages/*\" --filter \"!./packages/document\" --filter \"./scripts/*\" run build",
     "change": "changeset",
     "changeset": "changeset",
     "bump": "changeset version",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "scripts": {
-    "build": "pnpm --workspace-concurrency=10 --filter \"./packages/*\" --filter \"!./packages/document\" --filter \"./scripts/*\" --filter \"@examples/rsdoctor-rspack-banner\" run build",
+    "build": "pnpm --workspace-concurrency=10 --filter \"./packages/*\" --filter \"!./packages/document\" --filter \"./scripts/*\" run build",
     "change": "changeset",
     "changeset": "changeset",
     "bump": "changeset version",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,14 +15,8 @@
   ],
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "license": "MIT",

--- a/packages/cli/rslib.config.ts
+++ b/packages/cli/rslib.config.ts
@@ -1,3 +1,3 @@
-import { dualPackage } from '../../scripts/rslib.base.config';
+import { esmPackage } from '../../scripts/rslib.base.config';
 
-export default dualPackage;
+export default esmPackage;

--- a/packages/client/rsbuild.config.ts
+++ b/packages/client/rsbuild.config.ts
@@ -42,7 +42,9 @@ export default defineConfig(({ env }) => {
         enable: IS_PRODUCTION,
         tsCheckerOptions: {
           typescript: {
+            build: false,
             mode: 'readonly',
+            tsgo: true,
           },
         },
       }),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/core"
   },
   "license": "MIT",
-  "main": "dist/index.cjs",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
@@ -17,144 +17,60 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./build-utils": {
-      "import": {
-        "types": "./dist/build-utils/index.d.ts",
-        "default": "./dist/build-utils/index.js"
-      },
-      "require": {
-        "types": "./dist/build-utils/index.d.cts",
-        "default": "./dist/build-utils/index.cjs"
-      }
+      "types": "./dist/build-utils/index.d.ts",
+      "default": "./dist/build-utils/index.js"
     },
     "./collection": {
-      "import": {
-        "types": "./dist/collection.d.ts",
-        "default": "./dist/collection.js"
-      },
-      "require": {
-        "types": "./dist/collection.d.cts",
-        "default": "./dist/collection.cjs"
-      }
+      "types": "./dist/collection.d.ts",
+      "default": "./dist/collection.js"
     },
     "./common": {
-      "import": {
-        "types": "./dist/common/index.d.ts",
-        "default": "./dist/common/index.js"
-      },
-      "require": {
-        "types": "./dist/common/index.d.cts",
-        "default": "./dist/common/index.cjs"
-      }
+      "types": "./dist/common/index.d.ts",
+      "default": "./dist/common/index.js"
     },
     "./common-browser": {
-      "import": {
-        "types": "./dist/common-browser.d.ts",
-        "default": "./dist/common-browser.js"
-      },
-      "require": {
-        "types": "./dist/common-browser.d.cts",
-        "default": "./dist/common-browser.cjs"
-      }
+      "types": "./dist/common-browser.d.ts",
+      "default": "./dist/common-browser.js"
     },
     "./graph": {
-      "import": {
-        "types": "./dist/graph/index.d.ts",
-        "default": "./dist/graph/index.js"
-      },
-      "require": {
-        "types": "./dist/graph/index.d.cts",
-        "default": "./dist/graph/index.cjs"
-      }
+      "types": "./dist/graph/index.d.ts",
+      "default": "./dist/graph/index.js"
     },
     "./error": {
-      "import": {
-        "types": "./dist/error/index.d.ts",
-        "default": "./dist/error/index.js"
-      },
-      "require": {
-        "types": "./dist/error/index.d.cts",
-        "default": "./dist/error/index.cjs"
-      }
+      "types": "./dist/error/index.d.ts",
+      "default": "./dist/error/index.js"
     },
     "./logger": {
-      "import": {
-        "types": "./dist/logger.d.ts",
-        "default": "./dist/logger.js"
-      },
-      "require": {
-        "types": "./dist/logger.d.cts",
-        "default": "./dist/logger.cjs"
-      }
+      "types": "./dist/logger.d.ts",
+      "default": "./dist/logger.js"
     },
     "./sdk": {
-      "import": {
-        "types": "./dist/sdk.d.ts",
-        "default": "./dist/sdk.js"
-      },
-      "require": {
-        "types": "./dist/sdk.d.cts",
-        "default": "./dist/sdk.cjs"
-      }
+      "types": "./dist/sdk.d.ts",
+      "default": "./dist/sdk.js"
     },
     "./plugins": {
-      "import": {
-        "types": "./dist/inner-plugins/index.d.ts",
-        "default": "./dist/inner-plugins/index.js"
-      },
-      "require": {
-        "types": "./dist/inner-plugins/index.d.cts",
-        "default": "./dist/inner-plugins/index.cjs"
-      }
+      "types": "./dist/inner-plugins/index.d.ts",
+      "default": "./dist/inner-plugins/index.js"
     },
     "./rspack-plugin": {
-      "import": {
-        "types": "./dist/rspack-plugin/index.d.ts",
-        "default": "./dist/rspack-plugin/index.js"
-      },
-      "require": {
-        "types": "./dist/rspack-plugin/index.d.cts",
-        "default": "./dist/rspack-plugin/index.cjs"
-      }
+      "types": "./dist/rspack-plugin/index.d.ts",
+      "default": "./dist/rspack-plugin/index.js"
     },
     "./rules": {
-      "import": {
-        "types": "./dist/rules/index.d.ts",
-        "default": "./dist/rules/index.js"
-      },
-      "require": {
-        "types": "./dist/rules/index.d.cts",
-        "default": "./dist/rules/index.cjs"
-      }
+      "types": "./dist/rules/index.d.ts",
+      "default": "./dist/rules/index.js"
     },
     "./rule-utils": {
-      "import": {
-        "types": "./dist/rule-utils/index.d.ts",
-        "default": "./dist/rule-utils/index.js"
-      },
-      "require": {
-        "types": "./dist/rule-utils/index.d.cts",
-        "default": "./dist/rule-utils/index.cjs"
-      }
+      "types": "./dist/rule-utils/index.d.ts",
+      "default": "./dist/rule-utils/index.js"
     },
     "./types": {
-      "import": {
-        "types": "./dist/types/index.d.ts",
-        "default": "./dist/types/index.js"
-      },
-      "require": {
-        "types": "./dist/types/index.d.cts",
-        "default": "./dist/types/index.cjs"
-      }
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/types/index.js"
     }
   },
   "typesVersions": {

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig, rspack } from '@rslib/core';
-import { dualPackageBundleless } from '../../scripts/rslib.base.config';
+import { defineConfig } from '@rslib/core';
+import { esmPackageBundleless } from '../../scripts/rslib.base.config';
 
 const externals = [
   '@rsdoctor/client',
@@ -12,14 +12,15 @@ const externals = [
 ];
 
 export default defineConfig({
-  ...dualPackageBundleless,
+  ...esmPackageBundleless,
   lib: [
     {
       bundle: false,
       format: 'esm',
       syntax: 'es2021',
       dts: {
-        build: true,
+        build: false,
+        tsgo: true,
       },
       output: {
         filename: {
@@ -33,42 +34,5 @@ export default defineConfig({
         },
       },
     },
-    {
-      bundle: false,
-      format: 'cjs',
-      syntax: 'es2021',
-      dts: {
-        build: true,
-        autoExtension: true,
-      },
-      output: {
-        filename: {
-          js: '[name].cjs',
-        },
-        externals,
-      },
-      shims: {
-        cjs: {
-          'import.meta.url': true,
-        },
-      },
-    },
   ],
-  tools: {
-    rspack: {
-      plugins: [
-        new rspack.BannerPlugin({
-          banner: (args) => {
-            if (args.filename === 'inner-plugins/loaders/proxy.cjs') {
-              return 'module.exports = loaderModule; // This is a proxy loader, do not remove this line';
-            }
-            // For ESM files, we don't need to add export since it's already exported
-            return '';
-          },
-          footer: true,
-          raw: true,
-        }),
-      ],
-    },
-  },
 });

--- a/packages/core/src/build-utils/build/file/index.ts
+++ b/packages/core/src/build-utils/build/file/index.ts
@@ -1,4 +1,4 @@
 export * from './sharding';
 
-export * as fse from 'fs-extra';
+export { default as fse } from 'fs-extra';
 export * as cache from './cache';

--- a/packages/core/src/build-utils/build/module-graph/utils.ts
+++ b/packages/core/src/build-utils/build/module-graph/utils.ts
@@ -1,4 +1,3 @@
-import { isNumber } from '@rsdoctor/core/collection';
 import { parser, Node } from '@rsdoctor/core/rule-utils';
 import { SDK } from '@rsdoctor/shared/types';
 function getDefaultExportIdentifier(
@@ -36,12 +35,18 @@ function getDefaultExportIdentifier(
   // Take the first line by default.
   const startLine = node.declaration.loc?.start.line;
 
-  if (!isNumber(startLine)) {
+  if (typeof startLine !== 'number') {
     return;
   }
 
   const { transformed } = module.getSource();
-  const endColumn = transformed.split('\n')[startLine - 1].length - 1;
+  const line = transformed.split('\n')[startLine - 1];
+
+  if (line === undefined) {
+    return;
+  }
+
+  const endColumn = line.length - 1;
 
   return module.getStatement({
     start: {

--- a/packages/core/src/build-utils/build/utils/parseBundle.ts
+++ b/packages/core/src/build-utils/build/utils/parseBundle.ts
@@ -64,7 +64,10 @@ export const parseBundle: ParseBundle = (
     ecmaVersion: 'latest',
   });
 
-  const walkState = {
+  const walkState: {
+    locations: Record<string, { start: number; end: number }> | null;
+    expressionStatementDepth: number;
+  } = {
     locations: null,
     expressionStatementDepth: 0,
   };
@@ -239,7 +242,7 @@ export const parseBundle: ParseBundle = (
     },
   });
 
-  let modules;
+  let modules: Record<string, string>;
 
   if (walkState.locations) {
     modules = mapValues(
@@ -260,7 +263,7 @@ export const parseBundle: ParseBundle = (
     const moduleContent = modules[module];
     const size = moduleContent && Buffer.byteLength(moduleContent);
     const identifier =
-      find(modulesData, { renderId: module })?.identifier || '';
+      find(modulesData, (item) => item.renderId === module)?.identifier || '';
     modulesObj[identifier] = {
       size,
       sizeConvert: filesize(size || 0),
@@ -462,7 +465,7 @@ function getModulesLocations(node: {
   callee: { object: { arguments: { value: any }[] } };
   arguments: { elements: any }[];
   elements: any;
-}) {
+}): Record<string, { start: number; end: number }> {
   if (node.type === 'ObjectExpression') {
     // Modules hash
     const modulesNodes = node.properties;

--- a/packages/core/src/inner-plugins/plugins/loader.ts
+++ b/packages/core/src/inner-plugins/plugins/loader.ts
@@ -7,13 +7,8 @@ import { interceptLoader, type CompatibleResolve } from '../utils';
 import { InternalBasePlugin } from './base';
 import type { ProxyLoaderOptions } from '../../types';
 import { time, timeEnd } from '@rsdoctor/core/logger';
-import path from 'path';
 import { fileURLToPath } from 'url';
 import { safeCloneDeep } from '../utils/plugin-common';
-
-// ESM equivalent of __dirname
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 type MutableNormalModule = Omit<NormalModule, 'loaders'> & {
   loaders: Array<{ loader: string; options?: unknown }>;
@@ -29,20 +24,9 @@ export class InternalLoaderPlugin<
 > extends InternalBasePlugin<T> {
   public readonly name = 'loader';
 
-  // TODO: find the reason why using loader/proxy.js causes this problem https://github.com/web-infra-dev/rsdoctor/pull/1271.
-  public readonly internalLoaderPath: string = (() => {
-    const isCJS = __filename.endsWith('.cjs');
-    if (isCJS) {
-      // CJS environment: only use proxy.cjs
-      return require.resolve(path.join(__dirname, `../loaders/proxy.cjs`));
-    } else {
-      try {
-        return require.resolve(path.join(__dirname, `../loaders/proxy.js`));
-      } catch {
-        return require.resolve(path.join(__dirname, `../loaders/proxy.cjs`));
-      }
-    }
-  })();
+  public readonly internalLoaderPath = fileURLToPath(
+    new URL('../loaders/proxy.js', import.meta.url),
+  );
 
   public apply(compiler: T) {
     time('InternalLoaderPlugin.apply');

--- a/packages/core/src/inner-plugins/plugins/summary.ts
+++ b/packages/core/src/inner-plugins/plugins/summary.ts
@@ -1,6 +1,6 @@
 import { Summary } from '@rsdoctor/core/common';
 import { minBy, sumBy } from '@rsdoctor/core/collection';
-import type { Plugin } from '@rsdoctor/shared/types';
+import type { Plugin, SDK } from '@rsdoctor/shared/types';
 import { InternalBasePlugin } from './base';
 import { time, timeEnd } from '@rsdoctor/core/logger';
 
@@ -99,7 +99,9 @@ export class InternalSummaryPlugin<
       // report minify costs
       if (compiler.options.optimization.minimize !== false) {
         const pluginData = this.sdk.getStoreData().plugin;
-        const minifyHookData = [...(pluginData.processAssets || [])];
+        const minifyHookData: SDK.PluginHookData[] = [
+          ...(pluginData.processAssets || []),
+        ];
         if (minifyHookData.length) {
           this.sdk.reportSummaryData({
             costs: [

--- a/packages/core/src/inner-plugins/utils/loader.ts
+++ b/packages/core/src/inner-plugins/utils/loader.ts
@@ -23,10 +23,12 @@ export function getInternalLoaderOptions(
 
 export function getLoaderOptionsWithoutInternalKeys(
   loaderContext: Plugin.LoaderContext<ProxyLoaderOptions>,
-): Omit<ProxyLoaderOptions, typeof Loader.LoaderInternalPropertyName> {
+): Record<string, any> {
   const options = loaderContext.getOptions();
   const circlePaths: string[][] = [];
-  const loaderOptions = omit(options, [Loader.LoaderInternalPropertyName]);
+  const loaderOptions = omit(options, [
+    Loader.LoaderInternalPropertyName,
+  ]) as Record<string, any>;
 
   checkCirclePath(loaderOptions, [], circlePaths, 0);
 
@@ -123,8 +125,7 @@ export function interceptLoader<T extends Plugin.BuildRuleSetRule>(
     // In the childCompiler of mini-css-extract-plugin, the options[Loader.LoaderInternalPropertyName] of proxy-loader is set to proxy-loader, ultimately causing errors in the compilation of less files.
     opts[Loader.LoaderInternalPropertyName] =
       rule.loader &&
-      // compatible with proxy.cjs and proxy.js
-      /proxy\.(js|cjs)/.test(rule.loader) &&
+      rule.loader.endsWith('proxy.js') &&
       'options' in rule &&
       typeof rule.options === 'object'
         ? rule.options[Loader.LoaderInternalPropertyName]

--- a/packages/core/src/inner-plugins/utils/loader.ts
+++ b/packages/core/src/inner-plugins/utils/loader.ts
@@ -124,9 +124,7 @@ export function interceptLoader<T extends Plugin.BuildRuleSetRule>(
     };
     // In the childCompiler of mini-css-extract-plugin, the options[Loader.LoaderInternalPropertyName] of proxy-loader is set to proxy-loader, ultimately causing errors in the compilation of less files.
     opts[Loader.LoaderInternalPropertyName] =
-      rule.loader === loaderPath &&
-      'options' in rule &&
-      typeof rule.options === 'object'
+      rule.loader && 'options' in rule && typeof rule.options === 'object'
         ? rule.options[Loader.LoaderInternalPropertyName]
         : {
             ...options,

--- a/packages/core/src/inner-plugins/utils/loader.ts
+++ b/packages/core/src/inner-plugins/utils/loader.ts
@@ -124,7 +124,11 @@ export function interceptLoader<T extends Plugin.BuildRuleSetRule>(
     };
     // In the childCompiler of mini-css-extract-plugin, the options[Loader.LoaderInternalPropertyName] of proxy-loader is set to proxy-loader, ultimately causing errors in the compilation of less files.
     opts[Loader.LoaderInternalPropertyName] =
-      rule.loader && 'options' in rule && typeof rule.options === 'object'
+      rule.loader &&
+      // compatible with proxy.cjs and proxy.js
+      /proxy\.(js|cjs)/.test(rule.loader) &&
+      'options' in rule &&
+      typeof rule.options === 'object'
         ? rule.options[Loader.LoaderInternalPropertyName]
         : {
             ...options,

--- a/packages/core/src/inner-plugins/utils/loader.ts
+++ b/packages/core/src/inner-plugins/utils/loader.ts
@@ -124,8 +124,7 @@ export function interceptLoader<T extends Plugin.BuildRuleSetRule>(
     };
     // In the childCompiler of mini-css-extract-plugin, the options[Loader.LoaderInternalPropertyName] of proxy-loader is set to proxy-loader, ultimately causing errors in the compilation of less files.
     opts[Loader.LoaderInternalPropertyName] =
-      rule.loader &&
-      rule.loader.endsWith('proxy.js') &&
+      rule.loader === loaderPath &&
       'options' in rule &&
       typeof rule.options === 'object'
         ? rule.options[Loader.LoaderInternalPropertyName]

--- a/packages/core/tests/plugins/loader.test.ts
+++ b/packages/core/tests/plugins/loader.test.ts
@@ -60,6 +60,52 @@ describe('test src/utils/loader.ts', () => {
       ]);
     });
 
+    it('only reuses metadata from the internal proxy loader', () => {
+      const existingInternalOptions = {
+        ...internalOptions,
+        hasOptions: true,
+        loader: resolvedBabelLoader,
+      };
+      const unrelatedProxyLoader = path.resolve(__dirname, 'fixtures/proxy.js');
+
+      expect(
+        interceptLoader(
+          [
+            {
+              loader: proxyLoaderPath,
+              options: {
+                [Loader.LoaderInternalPropertyName]: existingInternalOptions,
+              },
+            },
+            {
+              loader: unrelatedProxyLoader,
+              options: { custom: true },
+            },
+          ],
+          proxyLoaderPath,
+          internalOptions,
+        ),
+      ).toStrictEqual([
+        {
+          loader: proxyLoaderPath,
+          options: {
+            [Loader.LoaderInternalPropertyName]: existingInternalOptions,
+          },
+        },
+        {
+          loader: proxyLoaderPath,
+          options: {
+            custom: true,
+            [Loader.LoaderInternalPropertyName]: {
+              ...internalOptions,
+              hasOptions: true,
+              loader: unrelatedProxyLoader,
+            },
+          },
+        },
+      ]);
+    });
+
     it('[Array] rule.loaders', () => {
       expect(
         interceptLoader(

--- a/packages/core/tests/plugins/loader.test.ts
+++ b/packages/core/tests/plugins/loader.test.ts
@@ -60,52 +60,6 @@ describe('test src/utils/loader.ts', () => {
       ]);
     });
 
-    it('only reuses metadata from the internal proxy loader', () => {
-      const existingInternalOptions = {
-        ...internalOptions,
-        hasOptions: true,
-        loader: resolvedBabelLoader,
-      };
-      const unrelatedProxyLoader = path.resolve(__dirname, 'fixtures/proxy.js');
-
-      expect(
-        interceptLoader(
-          [
-            {
-              loader: proxyLoaderPath,
-              options: {
-                [Loader.LoaderInternalPropertyName]: existingInternalOptions,
-              },
-            },
-            {
-              loader: unrelatedProxyLoader,
-              options: { custom: true },
-            },
-          ],
-          proxyLoaderPath,
-          internalOptions,
-        ),
-      ).toStrictEqual([
-        {
-          loader: proxyLoaderPath,
-          options: {
-            [Loader.LoaderInternalPropertyName]: existingInternalOptions,
-          },
-        },
-        {
-          loader: proxyLoaderPath,
-          options: {
-            custom: true,
-            [Loader.LoaderInternalPropertyName]: {
-              ...internalOptions,
-              hasOptions: true,
-              loader: unrelatedProxyLoader,
-            },
-          },
-        },
-      ]);
-    });
-
     it('[Array] rule.loaders', () => {
       expect(
         interceptLoader(

--- a/packages/core/tests/plugins/sourcemapTool.test.ts
+++ b/packages/core/tests/plugins/sourcemapTool.test.ts
@@ -1,26 +1,11 @@
 import { describe, it, expect } from '@rstest/core';
 import path from 'path';
-import fs from 'fs';
 import os from 'os';
 import {
   bindContextCache,
   collectSourceMaps,
   handleAfterEmitAssets,
 } from '../../src/inner-plugins/plugins/sourcemapTool';
-
-// Read the real source map and bundle as test fixtures
-const jsMapPath = path.resolve(
-  __dirname,
-  '../../../../examples/rspack-banner-minimal/dist/main.js.map',
-);
-const jsPath = path.resolve(
-  __dirname,
-  '../../../../examples/rspack-banner-minimal/dist/main.js',
-);
-
-const jsMap = JSON.parse(fs.readFileSync(jsMapPath, 'utf-8'));
-const jsContent = fs.readFileSync(jsPath, 'utf-8');
-const jsLines = jsContent.split(/\r?\n/);
 
 // Add mock source map before createMockPluginInstance
 const mockJsMap = {
@@ -190,12 +175,30 @@ describe('sourcemapTool', () => {
   });
 
   describe('collectSourceMaps', () => {
-    it('should collect code segments for real sources', async () => {
+    it('should collect code segments for webpack sources', async () => {
       const plugin = createMockPluginInstance();
       const compilation = createMockCompilation();
       const regex =
         /webpack:\/\/(?:@examples\/rsdoctor-rspack-banner\/)?([^?]*)/;
-      await collectSourceMaps(jsMap, jsLines, compilation, plugin, regex);
+      const sourceMap = {
+        version: 3,
+        sources: [
+          'webpack://@examples/rsdoctor-rspack-banner/./node_modules/dayjs/dayjs.min.js',
+        ],
+        names: [],
+        mappings: 'AAAA',
+        file: 'main.js',
+        sourcesContent: ['console.log("dayjs");'],
+      };
+
+      await collectSourceMaps(
+        sourceMap,
+        ['console.log("dayjs");'],
+        compilation,
+        plugin,
+        regex,
+      );
+
       // Assert that sourceMapSets is filled
       expect(plugin.sourceMapSets.size).toBeGreaterThan(0);
       // Assert that there is a key related to dayjs.min.js

--- a/packages/core/tests/sdk/sdk/core/atomic-write.test.ts
+++ b/packages/core/tests/sdk/sdk/core/atomic-write.test.ts
@@ -50,11 +50,12 @@ describe('atomic write manifest', () => {
       const readAttempts = 100;
 
       const workerScript = `
-        const { parentPort, workerData } = require('node:worker_threads');
-        const { File, Server } = require('@rsdoctor/core/build-utils');
-        const { RsdoctorSDK } = require('@rsdoctor/core/sdk');
-
         (async () => {
+          const { parentPort, workerData } = await import('node:worker_threads');
+          const [{ File, Server }, { RsdoctorSDK }] = await Promise.all([
+            import('@rsdoctor/core/build-utils'),
+            import('@rsdoctor/core/sdk'),
+          ]);
           const { outputDir, readAttempts } = workerData;
           const port = await Server.getPort(
             10000 + Math.floor(Math.random() * 20000),
@@ -99,6 +100,7 @@ describe('atomic write manifest', () => {
         new Promise<void>((resolve, reject) => {
           const worker = new Worker(workerScript, {
             eval: true,
+            execArgv: [],
             workerData: { outputDir, readAttempts },
           });
           workers.push(worker);

--- a/packages/core/tests/sdk/sdk/core/atomic-write.test.ts
+++ b/packages/core/tests/sdk/sdk/core/atomic-write.test.ts
@@ -1,9 +1,20 @@
 import path from 'path';
 import { tmpdir } from 'os';
-import { describe, it, expect, afterEach, beforeAll } from '@rstest/core';
+import { describe, it, expect, afterEach, beforeAll, rs } from '@rstest/core';
 import { Worker } from 'node:worker_threads';
 import { File } from '@rsdoctor/core/build-utils';
 import { execSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const corePackageDir = path.resolve(__dirname, '../../../..');
+const workerModuleUrls = {
+  buildUtils: pathToFileURL(
+    path.resolve(corePackageDir, 'dist/build-utils/index.js'),
+  ).href,
+  sdk: pathToFileURL(path.resolve(corePackageDir, 'dist/sdk.js')).href,
+};
+
+rs.setConfig({ testTimeout: 30000 });
 
 // Skip on Windows because rename may throw EPERM/EBUSY under concurrent access
 const describeIfNotWin =
@@ -31,7 +42,7 @@ describe('atomic write manifest', () => {
       try {
         execSync('pnpm --filter @rsdoctor/core run build', {
           stdio: 'ignore',
-          cwd: path.resolve(__dirname, '../../../../..'),
+          cwd: corePackageDir,
         });
       } catch {
         // Ignore build errors, dist may already exist
@@ -53,8 +64,8 @@ describe('atomic write manifest', () => {
         (async () => {
           const { parentPort, workerData } = await import('node:worker_threads');
           const [{ File, Server }, { RsdoctorSDK }] = await Promise.all([
-            import('@rsdoctor/core/build-utils'),
-            import('@rsdoctor/core/sdk'),
+            import(workerData.moduleUrls.buildUtils),
+            import(workerData.moduleUrls.sdk),
           ]);
           const { outputDir, readAttempts } = workerData;
           const port = await Server.getPort(
@@ -101,7 +112,11 @@ describe('atomic write manifest', () => {
           const worker = new Worker(workerScript, {
             eval: true,
             execArgv: [],
-            workerData: { outputDir, readAttempts },
+            workerData: {
+              outputDir,
+              readAttempts,
+              moduleUrls: workerModuleUrls,
+            },
           });
           workers.push(worker);
 

--- a/packages/document/docs/en/guide/start/migration-v2.mdx
+++ b/packages/document/docs/en/guide/start/migration-v2.mdx
@@ -18,7 +18,7 @@ pnpm remove @rsdoctor/rspack-plugin
 pnpm add -D @rsdoctor/core
 ```
 
-Update both ESM and CommonJS imports:
+Rsdoctor 2.0 packages are ESM-only. Replace CommonJS `require()` calls with ESM imports while updating the package path:
 
 ```ts title="Before"
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
@@ -26,10 +26,6 @@ import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 
 ```ts title="After"
 import { RsdoctorRspackPlugin } from '@rsdoctor/core';
-```
-
-```js title="CommonJS"
-const { RsdoctorRspackPlugin } = require('@rsdoctor/core');
 ```
 
 `@rspack/core` remains an optional peer dependency of `@rsdoctor/core`. Your Rspack-based build tool normally provides it. Install `@rspack/core` in projects that use Rspack directly.

--- a/packages/document/docs/zh/guide/start/migration-v2.mdx
+++ b/packages/document/docs/zh/guide/start/migration-v2.mdx
@@ -18,7 +18,7 @@ pnpm remove @rsdoctor/rspack-plugin
 pnpm add -D @rsdoctor/core
 ```
 
-同步更新 ESM 和 CommonJS 导入：
+Rsdoctor 2.0 的包仅提供 ESM 产物。更新包路径时，请同时将 CommonJS `require()` 调用改为 ESM 导入：
 
 ```ts title="迁移前"
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
@@ -26,10 +26,6 @@ import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 
 ```ts title="迁移后"
 import { RsdoctorRspackPlugin } from '@rsdoctor/core';
-```
-
-```js title="CommonJS"
-const { RsdoctorRspackPlugin } = require('@rsdoctor/core');
 ```
 
 `@rspack/core` 仍是 `@rsdoctor/core` 的可选 peer dependency。基于 Rspack 的构建工具通常已经提供该依赖；直接使用 Rspack 的项目需要安装 `@rspack/core`。

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,27 +16,22 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./collection": {
       "types": "./dist/collection.d.ts",
-      "import": "./dist/collection.js",
       "default": "./dist/collection.js"
     },
     "./common-browser": {
       "types": "./dist/common-browser.d.ts",
-      "import": "./dist/common-browser.js",
       "default": "./dist/common-browser.js"
     },
     "./graph": {
       "types": "./dist/graph.d.ts",
-      "import": "./dist/graph.js",
       "default": "./dist/graph.js"
     },
     "./types": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/types/index.js",
       "default": "./dist/types/index.js"
     }
   },

--- a/packages/shared/src/types/plugin/baseLoader.ts
+++ b/packages/shared/src/types/plugin/baseLoader.ts
@@ -121,7 +121,7 @@ export interface RspackPitchLoaderDefinitionFunction<
 }
 
 export type LoaderDefinition<T, R> = LoaderDefinitionFunction<T, R> & {
-  raw?: false;
+  raw?: boolean;
   pitch?:
     | PitchLoaderDefinitionFunction<T>
     | RspackPitchLoaderDefinitionFunction<T>;

--- a/packages/shared/tests/published-types.test.ts
+++ b/packages/shared/tests/published-types.test.ts
@@ -11,7 +11,14 @@ const testDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(testDir, '../../..');
 const sharedRoot = path.resolve(repoRoot, 'packages/shared');
 const sharedPackageJsonPath = path.resolve(sharedRoot, 'package.json');
-const tscPath = require.resolve('typescript/lib/tsc');
+const typescriptPackageJsonPath = require.resolve('typescript/package.json');
+const typescriptPackageJson = require(typescriptPackageJsonPath) as {
+  bin: { tsc: string };
+};
+const tscPath = path.resolve(
+  path.dirname(typescriptPackageJsonPath),
+  typescriptPackageJson.bin.tsc,
+);
 
 function runTsc(args: string[], options: ExecFileSyncOptions) {
   try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ catalogs:
   default:
     '@rsbuild/core':
       specifier: ^2.1.6
-      version: 2.1.6
+      version: 2.1.7
     '@rsbuild/plugin-check-syntax':
       specifier: ^1.6.1
       version: 1.6.1
@@ -38,7 +38,7 @@ catalogs:
       version: 2.0.8
     '@rspack/core':
       specifier: ^2.0.8
-      version: 2.0.8
+      version: 2.1.5
     '@rspack/plugin-react-refresh':
       specifier: ^2.0.2
       version: 2.0.2
@@ -198,13 +198,13 @@ importers:
         version: 0.123.0(@types/react@19.2.17)
       '@lynx-js/rspeedy':
         specifier: ^0.15.2
-        version: 0.15.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(core-js@3.49.0)(typescript@7.0.2)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+        version: 0.15.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(core-js@3.49.0)(typescript@7.0.2)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       '@playwright/test':
         specifier: 1.55.1
         version: 1.55.1
       '@rsbuild/plugin-less':
         specifier: 'catalog:'
-        version: 1.6.4(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+        version: 1.6.4(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       '@rsdoctor/cli':
         specifier: workspace:*
         version: link:../packages/cli
@@ -216,7 +216,7 @@ importers:
         version: link:../packages/shared
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.8(@swc/helpers@0.5.23)
+        version: 2.1.5(@swc/helpers@0.5.23)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.3
@@ -255,10 +255,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.6(core-js@3.49.0)
+        version: 2.1.7(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.7(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))
       '@rsdoctor/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -291,7 +291,7 @@ importers:
         version: 2.5.1
       css-loader:
         specifier: ^6.9.0
-        version: 6.11.0(@rspack/core@2.0.8(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+        version: 6.11.0(@rspack/core@2.1.5(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       less-loader:
         specifier: ^11.1.4
         version: 11.1.4(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
@@ -307,13 +307,13 @@ importers:
         version: link:../../packages/core
       '@rspack/cli':
         specifier: 'catalog:'
-        version: 2.0.8(@rspack/core@2.0.8(@swc/helpers@0.5.17))
+        version: 2.0.8(@rspack/core@2.1.5(@swc/helpers@0.5.17))
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.8(@swc/helpers@0.5.17)
+        version: 2.1.5(@swc/helpers@0.5.17)
       '@rspack/plugin-react-refresh':
         specifier: 'catalog:'
-        version: 2.0.2(@rspack/core@2.0.8(@swc/helpers@0.5.17))(react-refresh@0.14.2)
+        version: 2.0.2(@rspack/core@2.1.5(@swc/helpers@0.5.17))(react-refresh@0.14.2)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -343,7 +343,7 @@ importers:
         version: 2.5.1
       css-loader:
         specifier: ^6.9.0
-        version: 6.11.0(@rspack/core@2.0.8(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+        version: 6.11.0(@rspack/core@2.1.5(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       less-loader:
         specifier: ^11.1.4
         version: 11.1.4(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
@@ -359,13 +359,13 @@ importers:
         version: link:../../packages/core
       '@rspack/cli':
         specifier: 'catalog:'
-        version: 2.0.8(@rspack/core@2.0.8(@swc/helpers@0.5.17))
+        version: 2.0.8(@rspack/core@2.1.5(@swc/helpers@0.5.17))
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.8(@swc/helpers@0.5.17)
+        version: 2.1.5(@swc/helpers@0.5.17)
       '@rspack/plugin-react-refresh':
         specifier: 'catalog:'
-        version: 2.0.2(@rspack/core@2.0.8(@swc/helpers@0.5.17))(react-refresh@0.14.2)
+        version: 2.0.2(@rspack/core@2.1.5(@swc/helpers@0.5.17))(react-refresh@0.14.2)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -395,7 +395,7 @@ importers:
         version: 2.5.1
       css-loader:
         specifier: ^6.9.0
-        version: 6.11.0(@rspack/core@2.0.8(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+        version: 6.11.0(@rspack/core@2.1.5(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       less-loader:
         specifier: ^11.1.4
         version: 11.1.4(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
@@ -411,13 +411,13 @@ importers:
         version: link:../../packages/core
       '@rspack/cli':
         specifier: 'catalog:'
-        version: 2.0.8(@rspack/core@2.0.8(@swc/helpers@0.5.17))
+        version: 2.0.8(@rspack/core@2.1.5(@swc/helpers@0.5.17))
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.8(@swc/helpers@0.5.17)
+        version: 2.1.5(@swc/helpers@0.5.17)
       '@rspack/plugin-react-refresh':
         specifier: 'catalog:'
-        version: 2.0.2(@rspack/core@2.0.8(@swc/helpers@0.5.17))(react-refresh@0.14.2)
+        version: 2.0.2(@rspack/core@2.1.5(@swc/helpers@0.5.17))(react-refresh@0.14.2)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -497,25 +497,25 @@ importers:
         version: 4.7.0(monaco-editor@0.49.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.6(core-js@3.49.0)
+        version: 2.1.7(core-js@3.49.0)
       '@rsbuild/plugin-check-syntax':
         specifier: 'catalog:'
-        version: 1.6.1(@rsbuild/core@2.1.6(core-js@3.49.0))
+        version: 1.6.1(@rsbuild/core@2.1.7(core-js@3.49.0))
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.6(@rsbuild/core@2.1.6(core-js@3.49.0))
+        version: 1.4.6(@rsbuild/core@2.1.7(core-js@3.49.0))
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.1.0(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))
+        version: 2.1.0(@rsbuild/core@2.1.7(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 1.5.3(@rsbuild/core@2.1.6(core-js@3.49.0))
+        version: 1.5.3(@rsbuild/core@2.1.7(core-js@3.49.0))
       '@rsbuild/plugin-svgr':
         specifier: 'catalog:'
-        version: 2.0.5(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(typescript@7.0.2)
+        version: 2.0.5(@rsbuild/core@2.1.7(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(typescript@7.0.2)
       '@rsbuild/plugin-type-check':
         specifier: 'catalog:'
-        version: 1.5.0(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@7.0.2)
+        version: 1.5.0(@rsbuild/core@2.1.7(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@7.0.2)
       '@rsdoctor/shared':
         specifier: workspace:*
         version: link:../shared
@@ -717,7 +717,7 @@ importers:
     devDependencies:
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.8(@swc/helpers@0.5.23)
+        version: 2.1.5(@swc/helpers@0.5.23)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -759,7 +759,7 @@ importers:
         version: 8.18.1
       babel-loader:
         specifier: 10.1.1
-        version: 10.1.1(@babel/core@7.29.0)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+        version: 10.1.1(@babel/core@7.29.0)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       prebundle:
         specifier: 'catalog:'
         version: 1.6.5
@@ -797,7 +797,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 1.5.3(@rsbuild/core@2.1.5(core-js@3.49.0))
+        version: 1.5.3(@rsbuild/core@2.1.7(core-js@3.49.0))
       '@rsdoctor/core':
         specifier: workspace:*
         version: link:../core
@@ -836,10 +836,10 @@ importers:
         version: 19.1.0(react@19.2.7)
       rsbuild-plugin-google-analytics:
         specifier: ^1.0.6
-        version: 1.0.6(@rsbuild/core@2.1.5(core-js@3.49.0))
+        version: 1.0.6(@rsbuild/core@2.1.7(core-js@3.49.0))
       rsbuild-plugin-open-graph:
         specifier: ^1.1.3
-        version: 1.1.3(@rsbuild/core@2.1.5(core-js@3.49.0))
+        version: 1.1.3(@rsbuild/core@2.1.7(core-js@3.49.0))
       rspress-plugin-font-open-sans:
         specifier: ^1.0.4
         version: 1.0.4(@rspress/core@2.0.18(@types/mdast@4.0.4)(@types/react@19.2.17)(core-js@3.49.0)(micromark-util-types@2.0.1)(micromark@4.0.1))
@@ -873,7 +873,7 @@ importers:
     devDependencies:
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.8(@swc/helpers@0.5.23)
+        version: 2.1.5(@swc/helpers@0.5.23)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.3
@@ -897,10 +897,10 @@ importers:
     dependencies:
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.1.6(core-js@3.49.0)
+        version: 2.1.7(core-js@3.49.0)
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.8(@swc/helpers@0.5.23)
+        version: 2.1.5(@swc/helpers@0.5.23)
       '@types/lodash':
         specifier: ^4.17.24
         version: 4.17.24
@@ -1826,9 +1826,6 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/core@1.11.1':
-    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
-
   '@emnapi/core@1.11.2':
     resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
 
@@ -1837,9 +1834,6 @@ packages:
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
-  '@emnapi/runtime@1.11.1':
-    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
   '@emnapi/runtime@1.11.2':
     resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
@@ -2680,26 +2674,6 @@ packages:
       core-js:
         optional: true
 
-  '@rsbuild/core@2.1.5':
-    resolution: {integrity: sha512-7TW4U1SH7VxQZzSTIOzvwj5lo9uNTmGpsmTXFr4axQAE4giLDKP3kVUA1ZW4P3/Mz4QQJJyvZP29mVcb8kZCfg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      core-js: '>= 3.0.0'
-    peerDependenciesMeta:
-      core-js:
-        optional: true
-
-  '@rsbuild/core@2.1.6':
-    resolution: {integrity: sha512-w2WxblstOgHnDElkqJZVO/jM/EqPaEhg7zqQhON3Xu3Mj9FlVOJx+SgimOtghFzxLt8x7atX4oMUtMTNSZGf0Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      core-js: '>= 3.0.0'
-    peerDependenciesMeta:
-      core-js:
-        optional: true
-
   '@rsbuild/core@2.1.7':
     resolution: {integrity: sha512-Xhs8DkLw2Vk5ydwjNG3GMJe1h03lqlCO4dV9EOG9HSR6vDfh07K48aq3KJ8/ncEL/YuFBaCIJrVc7rMFoR1y7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2890,16 +2864,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@2.1.3':
-    resolution: {integrity: sha512-oOGI0RSL89Ehu9T22rugmfUY9OC2eBqLMeWRYsu7bhlUrjoXeVfGBBSEXCse666BQ1sAiM8hD/k7nqVria/okQ==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-arm64@2.1.4':
-    resolution: {integrity: sha512-3Xcs01iw48F4WeE4SHga6bCNb/UEFvtQX4P4eMIaJfGPjTQuxfabGE8yCPm9e3tpLZ5uo+IBnJ6nh5r6tIDOXQ==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@2.1.5':
     resolution: {integrity: sha512-XLAN6YSU36qkciJtV9DY9z57pdHOjKy/f1HyoqpZenRg8p46jnXPziV45lfrTZpG+FF6g/jtTUc4dKbeyoWqPw==}
     cpu: [arm64]
@@ -2910,16 +2874,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.1.3':
-    resolution: {integrity: sha512-sVqWXNiFTMXAyN362y6IA+eJc8LXZKfHdhEJ/zDuMmRp+u2IvhgaF8tk3vX/OmeB9jydVjySijuiqk8No/FoCA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@2.1.4':
-    resolution: {integrity: sha512-bz/AsCplLs+3fXULPQU9d4r8H4PdeljgHFyItvVIrA/NKZqzQ8sX0topf/zJVZAOtPH7GNnrKjq0/F0U2DHikQ==}
-    cpu: [x64]
-    os: [darwin]
-
   '@rspack/binding-darwin-x64@2.1.5':
     resolution: {integrity: sha512-KLW7PV86jyCOyqJSqrkZdvYUWYCFX/Q4LsGmVc8tyDA8jBYLMHJDewC/lNf9ot3rU2SoLDZKhDUh7q7dX0FRmg==}
     cpu: [x64]
@@ -2927,18 +2881,6 @@ packages:
 
   '@rspack/binding-linux-arm64-gnu@2.0.8':
     resolution: {integrity: sha512-pSI+npPQE/uDtiboqvcOIRJbEV2+B+H1xffmko/gw50la92oTUW60kVULFwsb6L0+GVCzIcwX3yq60GtYIn+Ug==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-arm64-gnu@2.1.3':
-    resolution: {integrity: sha512-aCy9Zli/2Qf+Ee5otXfFQ6mhv5fEyn0wIoBVmouqtJoqOO21et6UTtJ+LHLsMDolwGLyHERAljeSFSmYX3/O5A==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-arm64-gnu@2.1.4':
-    resolution: {integrity: sha512-x0HQTLU1MusCtNamuXxf3ayEPkvh9uuaq4wVyBqveRkn4FznSOoHUsxTAKMnjGARX+vdLV/y/SwWJRDp2RI4zw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -2955,53 +2897,17 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-arm64-musl@2.1.3':
-    resolution: {integrity: sha512-flIE7eluz0d21Fn28EVm3vPwoJooOSqtmjLFVSuOMcoCbwV9clfor195oIrAppp/W7dL/3XquFuVfrsa01Jy8Q==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@rspack/binding-linux-arm64-musl@2.1.4':
-    resolution: {integrity: sha512-SEYCQD9UflKJMkYGnG5nt2gcsqdkgJsQmryBC/jxo+bOuY9gUSReU99FqCt7WRQrsHLbGeAFeTWs1QzItWG/Bw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rspack/binding-linux-arm64-musl@2.1.5':
     resolution: {integrity: sha512-0GFc07gT71+uRbHtejDecBfSL0fs7dQAwCtXYieXboACauL7UvS3Hwr6v8A91aGtAcvLotnCaIa3CWWYwtYlYQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.3':
-    resolution: {integrity: sha512-yojg8elye1nhsNeGncw0NrZ4pMGF7NVebR80CLg72TXyzfYwFJlFTdU5yUYb1Gy+JXIvrSCwzQt2QkyiEvmkfg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-riscv64-gnu@2.1.4':
-    resolution: {integrity: sha512-jYtQKtnDRaVfyasvTGY04Z7m+xDWZYVwAIEOB4hP7czM7FVLOMgHlMlvw/EgF0DNHrBthqbPfBIS2tP50CzpEA==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@rspack/binding-linux-riscv64-gnu@2.1.5':
     resolution: {integrity: sha512-isQQDp3fBzPSZpLVFzPqVXIVA4I9b9mKs58TfUgOzDP/1g1582YSV3iFopgFogvEliihXDuuXvM6aAkP+w8Z+Q==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
-
-  '@rspack/binding-linux-riscv64-musl@2.1.3':
-    resolution: {integrity: sha512-6PvbXb3FOK4X3S5QGvoSW/sqExmsvAoPnQ/YSFrXvTphkXFezA7wnobmGBHT8JQP31hcFRzJHIZSIOKktzSzzg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@rspack/binding-linux-riscv64-musl@2.1.4':
-    resolution: {integrity: sha512-ZgxKjQAm9pidq2kChQO2PqKI9OQpLuGD7iPBuyT0gQg3m1+7vvbbkArLBPzJ12CQHVZvqua7n/QGx8pQjJI2Zw==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-riscv64-musl@2.1.5':
     resolution: {integrity: sha512-/SP6VknY4kH60BYplI2FDNAJCo4U4DUszLxhKsgVlgA5ImgHC8Ew2AsKgidk7ceiYV9OcKzYuWYe9tVpysBYVA==}
@@ -3011,18 +2917,6 @@ packages:
 
   '@rspack/binding-linux-x64-gnu@2.0.8':
     resolution: {integrity: sha512-zrkoEOnqj1hOEBO5T2I/2Ts2HSJsYFh1qXwMpK4dMJFGGNWDfNeUa6/LF5uq3VINF3JUl7RL47AgrucoSZJXPA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-x64-gnu@2.1.3':
-    resolution: {integrity: sha512-lMXjoGKf0SnviH596fmTszgtnXLHmWOoE90G8grG9MvKVa3pelRmfps5ewZL9s8ENf3NXRfOxIhIf/M9as6MqA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rspack/binding-linux-x64-gnu@2.1.4':
-    resolution: {integrity: sha512-C53B3e6M4yzlYn4hDxR9cHZV+HqkfFGR0zuhH8QCfdBfN5KyGsmXmujiFU85ANEvBgf9CF8VreBQeJ20lyto/g==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -3039,18 +2933,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-musl@2.1.3':
-    resolution: {integrity: sha512-0esT35v7pW2ZsJTMc/zDUHwpNXlPqyUCyuiLJvrAAUcdENrgOVe4DmFrgVJ2hwqI4GjeN1VBnGRJ8c+edAHH5w==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@rspack/binding-linux-x64-musl@2.1.4':
-    resolution: {integrity: sha512-UaeG3FRo7e5RameQvWRNQ6KeXF29LEk67U/ohb9tF4U38mKH1OGqhmwCf5yLkqiOSgOi7Ff3ireOZD83Fso1iw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rspack/binding-linux-x64-musl@2.1.5':
     resolution: {integrity: sha512-iwS3t75nZ2TnUjB05KtvpvjpdkOy/nLxbaOnwjbdnNZZXpUaMadLbllGAWayHPGCMsL2yKBEhVEESZpR7tK3SA==}
     cpu: [x64]
@@ -3061,30 +2943,12 @@ packages:
     resolution: {integrity: sha512-Yf4SiqTUroT5Ju+te0YAY2xxKOb35tECsO21v7hYyGa705wrgoAK/MmF7enOvs9GR1iZIqgiLD/wxsIxl8GjJw==}
     cpu: [wasm32]
 
-  '@rspack/binding-wasm32-wasi@2.1.3':
-    resolution: {integrity: sha512-UsrDjD59UEP0mhfN/Z+uTc3vLgiUvIr+mn92WC1sbQi9gtZohTYvaQYFhWuMkBqsACGcmZp704JAbbSrVrVYCA==}
-    cpu: [wasm32]
-
-  '@rspack/binding-wasm32-wasi@2.1.4':
-    resolution: {integrity: sha512-0P1WZEfu7JOPzD/jQfk9U/6gnRFc7RpvYCQaYZVVYZNJ2gU6O0/yLegRGKNK/2L0zjYwiD0ynhOIBVUUERf5Pw==}
-    cpu: [wasm32]
-
   '@rspack/binding-wasm32-wasi@2.1.5':
     resolution: {integrity: sha512-jOhW69t1H/jcRaSMB5U8jVzWP18j0YQIlo0nT8W+KvNVScJeyOze4FFc+5RIS7VmuT8/jid7hUyydZOfm6UgqA==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@2.0.8':
     resolution: {integrity: sha512-8NCuiQsAhXrwRBy57QZoypqrws/zLBkaQVGiB8hksr6v++8hNigNjqpQARLbd0iyMuHsQQ++8+auGk6xlDXmzw==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@2.1.3':
-    resolution: {integrity: sha512-42RS/SwKBTkNvXIPZXqTn0yEFN8zwGRfRe/ly0GDvPp/KxpLMFWxJmLxgtoLompU+0UCGvV4KpcBENt3oWs6BA==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-arm64-msvc@2.1.4':
-    resolution: {integrity: sha512-+aStQipk1EakLRPfD+/aQbtmTXfxqSWetcRRDWV3cAsD4ebv1tF8FLKYY1PCaFpQbX1FxzCBGF0KHxkAsi9cxA==}
     cpu: [arm64]
     os: [win32]
 
@@ -3098,16 +2962,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.1.3':
-    resolution: {integrity: sha512-thk43H1JHHbetNF3txcsGXeOwZi2m6Luf/uVUqNORXjxr5VV8woHAgaAx4QXVZRg70z1VDjd8mBWnHBnKI0FGA==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@2.1.4':
-    resolution: {integrity: sha512-7nyrLRQ07j6i6omZuwiwwTI6rpjdy/Su3niLDAG7WsLL21u3/UQQrw6Fvm8SH3XYteghoHLSM3dhgaisuUhdJg==}
-    cpu: [ia32]
-    os: [win32]
-
   '@rspack/binding-win32-ia32-msvc@2.1.5':
     resolution: {integrity: sha512-p4OSmnj21+AY8vpIADveLEBXfXJRXonOTYim2VLVWV4TbXfhYNMLiX3qESHCdNnn6lVJM0q6zxxzEUfTyAKydw==}
     cpu: [ia32]
@@ -3118,16 +2972,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.1.3':
-    resolution: {integrity: sha512-ObaUcj+BHo/aBL1weyM3orApaHyAR5Phr3YNEpQEifxjZbNKM1iO5X5prN4OqEv3H+7o5e/Wh9Fy3N7Vvd+psA==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@2.1.4':
-    resolution: {integrity: sha512-Z4je7JBaDpO9vvNMgCxlycycRJq+GQwwuXSXagW2xvvGM10Ij63YVtIehSMG9xaW8PED41oc9nWndoEsiD60pA==}
-    cpu: [x64]
-    os: [win32]
-
   '@rspack/binding-win32-x64-msvc@2.1.5':
     resolution: {integrity: sha512-YCkLLDGMkHsw5CpcsFtFhzCu+JZEsNrcH9O1GpWMkyxR2ku2Fq1i2wEHYSm26HyW+PJ3+Fv347MPWMFZIz9q2g==}
     cpu: [x64]
@@ -3135,12 +2979,6 @@ packages:
 
   '@rspack/binding@2.0.8':
     resolution: {integrity: sha512-3uZ+y8aQxq33ty2srMxg2Nu0XuBI6vVrG50rkDaXqwWqOohfgGUSfFuQK7EnSUNy4aFUQlCG6NHialQHJov0wg==}
-
-  '@rspack/binding@2.1.3':
-    resolution: {integrity: sha512-4UGXJqUHmm36tWG1GgFZz3p8sQ5JuSgWI+gq1xPPoihS41uYJL3cXuJnirTeWsmVrusmYZTQhgU3tl3VYGcJYg==}
-
-  '@rspack/binding@2.1.4':
-    resolution: {integrity: sha512-iye4BaTYtTt0qa39avWwEsUobVxFNhQHr6B8reFeKU7sdaZsC9LUoDR8JAt5gOnbnzFMPdKgrdU/VzkC6rXbIg==}
 
   '@rspack/binding@2.1.5':
     resolution: {integrity: sha512-lF3ZLeeyV0AN3BL0m2jAmNZD5pP9IHsQ8gUXN7mo0g4xsW6nf6hsN7o9CnEHECz5uUZb+EoWsuWzAAmnA9Ip8Q==}
@@ -3157,30 +2995,6 @@ packages:
 
   '@rspack/core@2.0.8':
     resolution: {integrity: sha512-+NLGJf8gZxihDmMFzjlly3toc2SMjeDmuvz0/Cai9AMdV4F+Pqcnt2BA9V4e3SY2jmhJQtPwgyyLtR1RiJO77g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
-      '@swc/helpers': ^0.5.23
-    peerDependenciesMeta:
-      '@module-federation/runtime-tools':
-        optional: true
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@2.1.3':
-    resolution: {integrity: sha512-1iGnxLrP+iyY0ZSjLZeQTaxrISpQz4yLyqJPmaF/l4uw27/dBcrloszAeLOJQ9jiv7EJtU0T5zB+LOFPpivIxA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
-      '@swc/helpers': ^0.5.23
-    peerDependenciesMeta:
-      '@module-federation/runtime-tools':
-        optional: true
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@2.1.4':
-    resolution: {integrity: sha512-lpJgtr+JAXuDAMBJfRJ1LHyWVuYJyhZu6L6aj9t4lipUU03qwakHnzn3vwSCr68PsVvVPzR6NbJE1gJienSV0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -6332,11 +6146,6 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   prettier@3.9.5:
     resolution: {integrity: sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==}
     engines: {node: '>=14'}
@@ -9142,12 +8951,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.1':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.2
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/core@1.11.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
@@ -9159,11 +8962,6 @@ snapshots:
       tslib: 2.8.1
 
   '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -9484,7 +9282,7 @@ snapshots:
       '@types/react': 19.2.17
       preact: '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c'
 
-  '@lynx-js/rspeedy@0.15.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(core-js@3.49.0)(typescript@7.0.2)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
+  '@lynx-js/rspeedy@0.15.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(core-js@3.49.0)(typescript@7.0.2)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
       '@lynx-js/cache-events-webpack-plugin': 0.1.0
       '@lynx-js/chunk-loading-webpack-plugin': 0.4.0
@@ -9494,7 +9292,7 @@ snapshots:
       '@lynx-js/websocket': 0.0.4
       '@rsbuild/core': 2.0.11(core-js@3.49.0)
       '@rsbuild/plugin-css-minimizer': 2.0.0(@rsbuild/core@2.0.11(core-js@3.49.0))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
-      '@rsdoctor/rspack-plugin': 1.5.9(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/rspack-plugin': 1.5.9(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
@@ -9636,20 +9434,6 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -9933,24 +9717,6 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@2.1.5(core-js@3.49.0)':
-    dependencies:
-      '@rspack/core': 2.1.3(@swc/helpers@0.5.23)
-      '@swc/helpers': 0.5.23
-    optionalDependencies:
-      core-js: 3.49.0
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-
-  '@rsbuild/core@2.1.6(core-js@3.49.0)':
-    dependencies:
-      '@rspack/core': 2.1.4(@swc/helpers@0.5.23)
-      '@swc/helpers': 0.5.23
-    optionalDependencies:
-      core-js: 3.49.0
-    transitivePeerDependencies:
-      - '@module-federation/runtime-tools'
-
   '@rsbuild/core@2.1.7(core-js@3.49.0)':
     dependencies:
       '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
@@ -9969,16 +9735,6 @@ snapshots:
       source-map: 0.7.6
     optionalDependencies:
       '@rsbuild/core': 2.0.11(core-js@3.49.0)
-
-  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.1.6(core-js@3.49.0))':
-    dependencies:
-      acorn: 8.16.0
-      browserslist-to-es-version: 1.3.0
-      htmlparser2: 10.0.0
-      picocolors: 1.1.1
-      source-map: 0.7.6
-    optionalDependencies:
-      '@rsbuild/core': 2.1.6(core-js@3.49.0)
 
   '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.1.7(core-js@3.49.0))':
     dependencies:
@@ -10005,11 +9761,11 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
+  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.4
-      less-loader: 12.3.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      less-loader: 12.3.3(@rspack/core@2.1.5(@swc/helpers@0.5.23))(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       reduce-configs: 1.1.2
     optionalDependencies:
       '@rsbuild/core': 2.0.11(core-js@3.49.0)
@@ -10017,7 +9773,7 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.6(core-js@3.49.0))':
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.7(core-js@3.49.0))':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -10043,36 +9799,27 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(core-js@3.49.0)
+      '@rsbuild/core': 2.1.7(core-js@3.49.0)
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.5(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.7(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(core-js@3.49.0)
+      '@rsbuild/core': 2.1.7(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.5(core-js@3.49.0))':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.7(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.5(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(core-js@3.49.0)
+      '@rsbuild/core': 2.1.7(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))':
-    dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.5(@swc/helpers@0.5.23))(react-refresh@0.18.0)
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rsbuild/core': 2.1.6(core-js@3.49.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
-
-  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.1.5(core-js@3.49.0))':
+  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.1.7(core-js@3.49.0))':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -10080,41 +9827,31 @@ snapshots:
       reduce-configs: 1.1.2
       sass-embedded: 1.100.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(core-js@3.49.0)
+      '@rsbuild/core': 2.1.7(core-js@3.49.0)
 
-  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.1.6(core-js@3.49.0))':
+  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.7(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(typescript@7.0.2)':
     dependencies:
-      deepmerge: 4.3.1
-      loader-utils: 2.0.4
-      postcss: 8.5.15
-      reduce-configs: 1.1.2
-      sass-embedded: 1.100.0
-    optionalDependencies:
-      '@rsbuild/core': 2.1.6(core-js@3.49.0)
-
-  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(typescript@7.0.2)':
-    dependencies:
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.7(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))
       '@svgr/core': 8.1.0(typescript@7.0.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@7.0.2))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@7.0.2))(typescript@7.0.2)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(core-js@3.49.0)
+      '@rsbuild/core': 2.1.7(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-type-check@1.5.0(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@7.0.2)':
+  '@rsbuild/plugin-type-check@1.5.0(@rsbuild/core@2.1.7(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@7.0.2)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
       ts-checker-rspack-plugin: 1.5.1(@rspack/core@2.1.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@7.0.2)
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(core-js@3.49.0)
+      '@rsbuild/core': 2.1.7(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - tslib
@@ -10122,13 +9859,13 @@ snapshots:
 
   '@rsdoctor/client@1.5.9': {}
 
-  '@rsdoctor/core@1.5.9(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
+  '@rsdoctor/core@1.5.9(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.11(core-js@3.49.0))
-      '@rsdoctor/graph': 1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
-      '@rsdoctor/sdk': 1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
-      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
-      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/graph': 1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/sdk': 1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/types': 1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/utils': 1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       '@rspack/resolver': 0.2.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       browserslist-load-config: 1.0.3
       es-toolkit: 1.49.0
@@ -10146,10 +9883,10 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/graph@1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
+  '@rsdoctor/graph@1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
-      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
-      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/types': 1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/utils': 1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       es-toolkit: 1.49.0
       path-browserify: 1.0.1
       source-map: 0.7.6
@@ -10157,15 +9894,15 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.9(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
+  '@rsdoctor/rspack-plugin@1.5.9(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
-      '@rsdoctor/core': 1.5.9(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
-      '@rsdoctor/graph': 1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
-      '@rsdoctor/sdk': 1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
-      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
-      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/core': 1.5.9(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/graph': 1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/sdk': 1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/types': 1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/utils': 1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
     optionalDependencies:
-      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -10175,12 +9912,12 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
+  '@rsdoctor/sdk@1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
       '@rsdoctor/client': 1.5.9
-      '@rsdoctor/graph': 1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
-      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
-      '@rsdoctor/utils': 1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/graph': 1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/types': 1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/utils': 1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       launch-editor: 2.14.1
       safer-buffer: 2.1.2
       socket.io: 4.8.1
@@ -10192,20 +9929,20 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/types@1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
+  '@rsdoctor/types@1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
       '@types/tapable': 2.3.0
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
       webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
-  '@rsdoctor/utils@1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
+  '@rsdoctor/utils@1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.5.9(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+      '@rsdoctor/types': 1.5.9(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       '@types/estree': 1.0.5
       acorn: 8.16.0
       acorn-import-attributes: 1.9.5(acorn@8.16.0)
@@ -10275,22 +10012,10 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.0.8':
     optional: true
 
-  '@rspack/binding-darwin-arm64@2.1.3':
-    optional: true
-
-  '@rspack/binding-darwin-arm64@2.1.4':
-    optional: true
-
   '@rspack/binding-darwin-arm64@2.1.5':
     optional: true
 
   '@rspack/binding-darwin-x64@2.0.8':
-    optional: true
-
-  '@rspack/binding-darwin-x64@2.1.3':
-    optional: true
-
-  '@rspack/binding-darwin-x64@2.1.4':
     optional: true
 
   '@rspack/binding-darwin-x64@2.1.5':
@@ -10299,40 +10024,16 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.1.3':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@2.1.4':
-    optional: true
-
   '@rspack/binding-linux-arm64-gnu@2.1.5':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.1.3':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@2.1.4':
-    optional: true
-
   '@rspack/binding-linux-arm64-musl@2.1.5':
     optional: true
 
-  '@rspack/binding-linux-riscv64-gnu@2.1.3':
-    optional: true
-
-  '@rspack/binding-linux-riscv64-gnu@2.1.4':
-    optional: true
-
   '@rspack/binding-linux-riscv64-gnu@2.1.5':
-    optional: true
-
-  '@rspack/binding-linux-riscv64-musl@2.1.3':
-    optional: true
-
-  '@rspack/binding-linux-riscv64-musl@2.1.4':
     optional: true
 
   '@rspack/binding-linux-riscv64-musl@2.1.5':
@@ -10341,22 +10042,10 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.1.3':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@2.1.4':
-    optional: true
-
   '@rspack/binding-linux-x64-gnu@2.1.5':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.0.8':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@2.1.3':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@2.1.4':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.1.5':
@@ -10369,20 +10058,6 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.1.3':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@2.1.4':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
   '@rspack/binding-wasm32-wasi@2.1.5':
     dependencies:
       '@emnapi/core': 1.11.2
@@ -10393,34 +10068,16 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@2.0.8':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.1.3':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@2.1.4':
-    optional: true
-
   '@rspack/binding-win32-arm64-msvc@2.1.5':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.0.8':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.1.3':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@2.1.4':
-    optional: true
-
   '@rspack/binding-win32-ia32-msvc@2.1.5':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.0.8':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@2.1.3':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@2.1.4':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.1.5':
@@ -10439,36 +10096,6 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.8
       '@rspack/binding-win32-x64-msvc': 2.0.8
 
-  '@rspack/binding@2.1.3':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.1.3
-      '@rspack/binding-darwin-x64': 2.1.3
-      '@rspack/binding-linux-arm64-gnu': 2.1.3
-      '@rspack/binding-linux-arm64-musl': 2.1.3
-      '@rspack/binding-linux-riscv64-gnu': 2.1.3
-      '@rspack/binding-linux-riscv64-musl': 2.1.3
-      '@rspack/binding-linux-x64-gnu': 2.1.3
-      '@rspack/binding-linux-x64-musl': 2.1.3
-      '@rspack/binding-wasm32-wasi': 2.1.3
-      '@rspack/binding-win32-arm64-msvc': 2.1.3
-      '@rspack/binding-win32-ia32-msvc': 2.1.3
-      '@rspack/binding-win32-x64-msvc': 2.1.3
-
-  '@rspack/binding@2.1.4':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.1.4
-      '@rspack/binding-darwin-x64': 2.1.4
-      '@rspack/binding-linux-arm64-gnu': 2.1.4
-      '@rspack/binding-linux-arm64-musl': 2.1.4
-      '@rspack/binding-linux-riscv64-gnu': 2.1.4
-      '@rspack/binding-linux-riscv64-musl': 2.1.4
-      '@rspack/binding-linux-x64-gnu': 2.1.4
-      '@rspack/binding-linux-x64-musl': 2.1.4
-      '@rspack/binding-wasm32-wasi': 2.1.4
-      '@rspack/binding-win32-arm64-msvc': 2.1.4
-      '@rspack/binding-win32-ia32-msvc': 2.1.4
-      '@rspack/binding-win32-x64-msvc': 2.1.4
-
   '@rspack/binding@2.1.5':
     optionalDependencies:
       '@rspack/binding-darwin-arm64': 2.1.5
@@ -10484,15 +10111,9 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.1.5
       '@rspack/binding-win32-x64-msvc': 2.1.5
 
-  '@rspack/cli@2.0.8(@rspack/core@2.0.8(@swc/helpers@0.5.17))':
+  '@rspack/cli@2.0.8(@rspack/core@2.1.5(@swc/helpers@0.5.17))':
     dependencies:
-      '@rspack/core': 2.0.8(@swc/helpers@0.5.17)
-
-  '@rspack/core@2.0.8(@swc/helpers@0.5.17)':
-    dependencies:
-      '@rspack/binding': 2.0.8
-    optionalDependencies:
-      '@swc/helpers': 0.5.17
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.17)
 
   '@rspack/core@2.0.8(@swc/helpers@0.5.23)':
     dependencies:
@@ -10500,17 +10121,11 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
-  '@rspack/core@2.1.3(@swc/helpers@0.5.23)':
+  '@rspack/core@2.1.5(@swc/helpers@0.5.17)':
     dependencies:
-      '@rspack/binding': 2.1.3
+      '@rspack/binding': 2.1.5
     optionalDependencies:
-      '@swc/helpers': 0.5.23
-
-  '@rspack/core@2.1.4(@swc/helpers@0.5.23)':
-    dependencies:
-      '@rspack/binding': 2.1.4
-    optionalDependencies:
-      '@swc/helpers': 0.5.23
+      '@swc/helpers': 0.5.17
 
   '@rspack/core@2.1.5(@swc/helpers@0.5.23)':
     dependencies:
@@ -10526,11 +10141,11 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.0.8(@swc/helpers@0.5.17))(react-refresh@0.14.2)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.5(@swc/helpers@0.5.17))(react-refresh@0.14.2)':
     dependencies:
       react-refresh: 0.14.2
     optionalDependencies:
-      '@rspack/core': 2.0.8(@swc/helpers@0.5.17)
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.17)
 
   '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.5(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
     dependencies:
@@ -10558,7 +10173,7 @@ snapshots:
 
   '@rspack/resolver-binding-wasm32-wasi@0.2.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -10593,8 +10208,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@rsbuild/core': 2.1.5(core-js@3.49.0)
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.5(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))
+      '@rsbuild/core': 2.1.7(core-js@3.49.0)
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.7(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))
       '@rspress/shared': 2.0.15(core-js@3.49.0)
       '@shikijs/rehype': 4.3.0
       '@types/unist': 3.0.3
@@ -10643,8 +10258,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@rsbuild/core': 2.1.5(core-js@3.49.0)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.5(core-js@3.49.0))
+      '@rsbuild/core': 2.1.7(core-js@3.49.0)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.7(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))
       '@rspress/shared': 2.0.18(core-js@3.49.0)
       '@shikijs/rehype': 4.3.0
       '@types/unist': 3.0.3
@@ -10735,7 +10350,7 @@ snapshots:
 
   '@rstest/core@0.11.2(core-js@3.49.0)':
     dependencies:
-      '@rsbuild/core': 2.1.6(core-js@3.49.0)
+      '@rsbuild/core': 2.1.7(core-js@3.49.0)
       '@types/chai': 5.2.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -11499,12 +11114,12 @@ snapshots:
 
   b-validate@1.5.3: {}
 
-  babel-loader@10.1.1(@babel/core@7.29.0)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
+  babel-loader@10.1.1(@babel/core@7.29.0)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       '@babel/core': 7.29.0
       find-up: 5.0.0
     optionalDependencies:
-      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
       webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   babel-plugin-polyfill-corejs2@0.4.12(@babel/core@7.26.0):
@@ -11626,7 +11241,7 @@ snapshots:
 
   browserslist-to-es-version@1.3.0:
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.2
 
   browserslist@4.28.1:
     dependencies:
@@ -11932,7 +11547,7 @@ snapshots:
     dependencies:
       postcss: 8.5.15
 
-  css-loader@6.11.0(@rspack/core@2.0.8(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
+  css-loader@6.11.0(@rspack/core@2.1.5(@swc/helpers@0.5.17))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -11943,7 +11558,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.2
     optionalDependencies:
-      '@rspack/core': 2.0.8(@swc/helpers@0.5.17)
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.17)
       webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   css-minimizer-webpack-plugin@8.0.0(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
@@ -13018,11 +12633,11 @@ snapshots:
       less: 4.6.4
       webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
-  less-loader@12.3.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
+  less-loader@12.3.3(@rspack/core@2.1.5(@swc/helpers@0.5.23))(less@4.6.4)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       less: 4.6.4
     optionalDependencies:
-      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
       webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
 
   less@4.6.4:
@@ -14258,15 +13873,13 @@ snapshots:
     dependencies:
       '@vercel/ncc': 0.38.4
       cac: 7.0.0
-      prettier: 3.8.3
+      prettier: 3.9.5
       rollup: 4.60.4
       rollup-plugin-dts: 6.4.1(rollup@4.60.4)(typescript@6.0.3)
       terser: 5.48.0
       typescript: 6.0.3
 
   prettier@2.8.8: {}
-
-  prettier@3.8.3: {}
 
   prettier@3.9.5: {}
 
@@ -15116,13 +14729,13 @@ snapshots:
       '@microsoft/api-extractor': 7.58.9(@types/node@24.12.3)
       typescript: 7.0.2
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.5(core-js@3.49.0)):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.7(core-js@3.49.0)):
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(core-js@3.49.0)
+      '@rsbuild/core': 2.1.7(core-js@3.49.0)
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.5(core-js@3.49.0)):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.7(core-js@3.49.0)):
     optionalDependencies:
-      '@rsbuild/core': 2.1.5(core-js@3.49.0)
+      '@rsbuild/core': 2.1.7(core-js@3.49.0)
 
   rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.1.7(core-js@3.49.0)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,8 +121,8 @@ catalogs:
       specifier: ^0.7.6
       version: 0.7.6
     typescript:
-      specifier: ^6.0.3
-      version: 6.0.3
+      specifier: ^7.0.2
+      version: 7.0.2
 
 overrides:
   '@remix-run/router': 1.23.3
@@ -139,6 +139,8 @@ overrides:
   tar: 7.5.20
   tslib: 2.8.1
 
+packageExtensionsChecksum: sha256-q/ILoPUcNNL4T1IkQzCBz0cfLf8KxvVETqtBQJWSR8g=
+
 importers:
 
   .:
@@ -151,7 +153,7 @@ importers:
         version: link:scripts/tsconfig
       '@rslib/core':
         specifier: 1.0.0-beta.1
-        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.9(@types/node@24.12.3))(core-js@3.49.0)(typescript@6.0.3)
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.9(@types/node@24.12.3))(core-js@3.49.0)(typescript@7.0.2)
       '@rslint/core':
         specifier: 'catalog:'
         version: 0.6.5(jiti@2.6.1)
@@ -196,7 +198,7 @@ importers:
         version: 0.123.0(@types/react@19.2.17)
       '@lynx-js/rspeedy':
         specifier: ^0.15.2
-        version: 0.15.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(core-js@3.49.0)(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+        version: 0.15.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(core-js@3.49.0)(typescript@7.0.2)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       '@playwright/test':
         specifier: 1.55.1
         version: 1.55.1
@@ -232,7 +234,7 @@ importers:
         version: 1.55.1
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   e2e/cases/doctor-rspack/fixtures/loaders/esm: {}
 
@@ -271,7 +273,7 @@ importers:
         version: '@types/semver@7.5.6'
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   examples/rspack-banner-minimal:
     dependencies:
@@ -280,7 +282,7 @@ importers:
         version: 2.65.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@svgr/webpack':
         specifier: ^8.1.0
-        version: 8.1.0(typescript@6.0.3)
+        version: 8.1.0(typescript@7.0.2)
       '@swc/helpers':
         specifier: ^0.5.3
         version: 0.5.17
@@ -332,7 +334,7 @@ importers:
         version: 2.65.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@svgr/webpack':
         specifier: ^8.1.0
-        version: 8.1.0(typescript@6.0.3)
+        version: 8.1.0(typescript@7.0.2)
       '@swc/helpers':
         specifier: ^0.5.3
         version: 0.5.17
@@ -384,7 +386,7 @@ importers:
         version: 2.65.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@svgr/webpack':
         specifier: ^8.1.0
-        version: 8.1.0(typescript@6.0.3)
+        version: 8.1.0(typescript@7.0.2)
       '@swc/helpers':
         specifier: ^0.5.3
         version: 0.5.17
@@ -449,7 +451,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 1.0.0-beta.1
-        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.9(@types/node@24.12.3))(core-js@3.49.0)(typescript@6.0.3)
+        version: 1.0.0-beta.1(@microsoft/api-extractor@7.58.9(@types/node@24.12.3))(core-js@3.49.0)(typescript@7.0.2)
       '@rstest/core':
         specifier: 'catalog:'
         version: 0.11.2(core-js@3.49.0)
@@ -461,7 +463,7 @@ importers:
         version: 7.0.0
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/cli:
     dependencies:
@@ -483,7 +485,7 @@ importers:
         version: 1.1.1
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/client:
     devDependencies:
@@ -510,10 +512,10 @@ importers:
         version: 1.5.3(@rsbuild/core@2.1.6(core-js@3.49.0))
       '@rsbuild/plugin-svgr':
         specifier: 'catalog:'
-        version: 2.0.5(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(typescript@6.0.3)
+        version: 2.0.5(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(typescript@7.0.2)
       '@rsbuild/plugin-type-check':
         specifier: 'catalog:'
-        version: 1.5.0(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@6.0.3)
+        version: 1.5.0(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@7.0.2)
       '@rsdoctor/shared':
         specifier: workspace:*
         version: link:../shared
@@ -606,7 +608,7 @@ importers:
         version: 5.0.0(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       url-parse:
         specifier: 1.5.10
         version: 1.5.10
@@ -760,19 +762,19 @@ importers:
         version: 10.1.1(@babel/core@7.29.0)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       prebundle:
         specifier: 'catalog:'
-        version: 1.6.5(typescript@6.0.3)
+        version: 1.6.5
       string-loader:
         specifier: 0.0.1
         version: 0.0.1
       ts-loader:
         specifier: ^9.6.2
-        version: 9.6.2(loader-utils@3.3.1)(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
+        version: 9.6.2(loader-utils@3.3.1)(typescript@7.0.2)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       tslib:
         specifier: 2.8.1
         version: 2.8.1
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/core/tests/graph/fixture: {}
 
@@ -846,7 +848,7 @@ importers:
         version: 1.2.1
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   packages/shared:
     dependencies:
@@ -889,7 +891,7 @@ importers:
         version: 2.8.1
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
 
   scripts/test-helper:
     dependencies:
@@ -913,7 +915,7 @@ importers:
         version: 4.57.8(tslib@2.8.1)
       typescript:
         specifier: 'catalog:'
-        version: 6.0.3
+        version: 7.0.2
       upath:
         specifier: 3.0.8
         version: 3.0.8
@@ -3704,6 +3706,126 @@ packages:
 
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -7484,6 +7606,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   ua-parser-js@1.0.40:
     resolution: {integrity: sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==}
     hasBin: true
@@ -9357,7 +9484,7 @@ snapshots:
       '@types/react': 19.2.17
       preact: '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c'
 
-  '@lynx-js/rspeedy@0.15.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(core-js@3.49.0)(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
+  '@lynx-js/rspeedy@0.15.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(core-js@3.49.0)(typescript@7.0.2)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))':
     dependencies:
       '@lynx-js/cache-events-webpack-plugin': 0.1.0
       '@lynx-js/chunk-loading-webpack-plugin': 0.4.0
@@ -9369,7 +9496,7 @@ snapshots:
       '@rsbuild/plugin-css-minimizer': 2.0.0(@rsbuild/core@2.0.11(core-js@3.49.0))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
       '@rsdoctor/rspack-plugin': 1.5.9(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.0.11(core-js@3.49.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23)))
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -9965,12 +10092,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.6(core-js@3.49.0)
 
-  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(typescript@7.0.2)':
     dependencies:
       '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))
-      '@svgr/core': 8.1.0(typescript@6.0.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)
+      '@svgr/core': 8.1.0(typescript@7.0.2)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@7.0.2))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@7.0.2))(typescript@7.0.2)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
@@ -9980,12 +10107,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-type-check@1.5.0(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.5.0(@rsbuild/core@2.1.6(core-js@3.49.0))(@rspack/core@2.1.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@7.0.2)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.5.1(@rspack/core@2.1.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.5.1(@rspack/core@2.1.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@7.0.2)
     optionalDependencies:
       '@rsbuild/core': 2.1.6(core-js@3.49.0)
     transitivePeerDependencies:
@@ -10096,13 +10223,13 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.9(@types/node@24.12.3))(core-js@3.49.0)(typescript@6.0.3)':
+  '@rslib/core@1.0.0-beta.1(@microsoft/api-extractor@7.58.9(@types/node@24.12.3))(core-js@3.49.0)(typescript@7.0.2)':
     dependencies:
       '@rsbuild/core': 2.1.7(core-js@3.49.0)
-      rsbuild-plugin-dts: 1.0.0-beta.1(@microsoft/api-extractor@7.58.9(@types/node@24.12.3))(@rsbuild/core@2.1.7(core-js@3.49.0))(typescript@6.0.3)
+      rsbuild-plugin-dts: 1.0.0-beta.1(@microsoft/api-extractor@7.58.9(@types/node@24.12.3))(@rsbuild/core@2.1.7(core-js@3.49.0))(typescript@7.0.2)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.9(@types/node@24.12.3)
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - core-js
@@ -10755,12 +10882,12 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
 
-  '@svgr/core@8.1.0(typescript@6.0.3)':
+  '@svgr/core@8.1.0(typescript@7.0.2)':
     dependencies:
       '@babel/core': 7.29.0
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
       camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@6.0.3)
+      cosmiconfig: 8.3.6(typescript@7.0.2)
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -10771,35 +10898,35 @@ snapshots:
       '@babel/types': 7.29.0
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@6.0.3))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@7.0.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
-      '@svgr/core': 8.1.0(typescript@6.0.3)
+      '@svgr/core': 8.1.0(typescript@7.0.2)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@7.0.2))(typescript@7.0.2)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@6.0.3)
-      cosmiconfig: 8.3.6(typescript@6.0.3)
+      '@svgr/core': 8.1.0(typescript@7.0.2)
+      cosmiconfig: 8.3.6(typescript@7.0.2)
       deepmerge: 4.3.1
       svgo: 3.3.2
     transitivePeerDependencies:
       - typescript
 
-  '@svgr/webpack@8.1.0(typescript@6.0.3)':
+  '@svgr/webpack@8.1.0(typescript@7.0.2)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-constant-elements': 7.25.9(@babel/core@7.26.0)
       '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
       '@babel/preset-react': 7.26.3(@babel/core@7.26.0)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
-      '@svgr/core': 8.1.0(typescript@6.0.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)
+      '@svgr/core': 8.1.0(typescript@7.0.2)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@7.0.2))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@7.0.2))(typescript@7.0.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11008,6 +11135,66 @@ snapshots:
   '@types/yargs@17.0.33':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -11669,14 +11856,14 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig@8.3.6(typescript@6.0.3):
+  cosmiconfig@8.3.6(typescript@7.0.2):
     dependencies:
       import-fresh: 3.3.0
       js-yaml: 4.1.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   create-ecdh@4.0.4:
     dependencies:
@@ -14067,7 +14254,7 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
-  prebundle@1.6.5(typescript@6.0.3):
+  prebundle@1.6.5:
     dependencies:
       '@vercel/ncc': 0.38.4
       cac: 7.0.0
@@ -14075,8 +14262,7 @@ snapshots:
       rollup: 4.60.4
       rollup-plugin-dts: 6.4.1(rollup@4.60.4)(typescript@6.0.3)
       terser: 5.48.0
-    transitivePeerDependencies:
-      - typescript
+      typescript: 6.0.3
 
   prettier@2.8.8: {}
 
@@ -14922,13 +15108,13 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
-  rsbuild-plugin-dts@1.0.0-beta.1(@microsoft/api-extractor@7.58.9(@types/node@24.12.3))(@rsbuild/core@2.1.7(core-js@3.49.0))(typescript@6.0.3):
+  rsbuild-plugin-dts@1.0.0-beta.1(@microsoft/api-extractor@7.58.9(@types/node@24.12.3))(@rsbuild/core@2.1.7(core-js@3.49.0))(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.1.7(core-js@3.49.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.9(@types/node@24.12.3)
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.5(core-js@3.49.0)):
     optionalDependencies:
@@ -15450,24 +15636,24 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-checker-rspack-plugin@1.5.1(@rspack/core@2.1.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.5.1(@rspack/core@2.1.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@7.0.2):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
       memfs: 4.57.8(tslib@2.8.1)
       picocolors: 1.1.1
-      typescript: 6.0.3
+      typescript: 7.0.2
     optionalDependencies:
       '@rspack/core': 2.1.5(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - tslib
 
-  ts-loader@9.6.2(loader-utils@3.3.1)(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
+  ts-loader@9.6.2(loader-utils@3.3.1)(typescript@7.0.2)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       chalk: 4.1.2
       picomatch: 4.0.4
       source-map: 0.7.6
-      typescript: 6.0.3
+      typescript: 7.0.2
       webpack: 5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))
     optionalDependencies:
       loader-utils: 3.3.1
@@ -15503,6 +15689,29 @@ snapshots:
     optional: true
 
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   ua-parser-js@1.0.40: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,7 @@ catalog:
   '@types/react': ^19.2.17
   '@types/react-dom': ^19.2.3
   '@types/tapable': 2.3.0
+  '@typescript/native-preview': 7.0.0-dev.20260707.2
   antd: 5.19.1
   clsx: ^2.1.1
   cross-env: ^10.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,7 +53,7 @@ catalog:
   sirv: 3.0.2
   source-map: ^0.7.6
   tslib: 2.8.1
-  typescript: ^6.0.3
+  typescript: ^7.0.2
 
 minimumReleaseAge: 1440
 
@@ -70,6 +70,11 @@ minimumReleaseAgeExclude:
   - ws@8.21.0
   # Renovate security update: echarts@6.1.0
   - echarts@6.1.0
+
+packageExtensions:
+  prebundle@1.6.5:
+    dependencies:
+      typescript: 6.0.3
 
 overrides:
   '@remix-run/router': 1.23.3

--- a/scripts/rslib.base.config.ts
+++ b/scripts/rslib.base.config.ts
@@ -9,43 +9,19 @@ export const baseBuildConfig = defineConfig({
   lib: [
     {
       bundle: false,
-      format: 'cjs' as const,
+      format: 'esm' as const,
       syntax: [BUILD_TARGET],
       dts: true,
+      redirect: {
+        dts: {
+          extension: true,
+        },
+      },
     },
   ],
 });
 
 export default baseBuildConfig;
-
-export const configWithEsm = defineConfig({
-  lib: [
-    {
-      bundle: false,
-      format: 'cjs',
-      syntax: [BUILD_TARGET],
-      output: {
-        distPath: {
-          root: './dist/cjs',
-        },
-      },
-      dts: {
-        distPath: './dist/type',
-      },
-    },
-    {
-      bundle: false,
-      format: 'esm',
-      syntax: [BUILD_TARGET],
-      output: {
-        distPath: {
-          root: './dist/esm',
-        },
-      },
-      dts: false,
-    },
-  ],
-});
 
 export const nodeMinifyConfig = {
   js: true,
@@ -74,36 +50,17 @@ export const esmConfig: LibConfig = {
   },
 };
 
-export const cjsConfig: LibConfig = {
-  format: 'cjs',
-  syntax: [BUILD_TARGET],
-  dts: {
-    build: true,
-    autoExtension: true,
-  },
-  output: {
-    minify: nodeMinifyConfig,
-    filename: {
-      js: '[name].cjs',
-    },
-  },
-};
-
-export const dualPackageBundleless = defineConfig({
+export const esmPackageBundleless = defineConfig({
   lib: [
     {
       ...esmConfig,
-      bundle: false,
-    },
-    {
-      ...cjsConfig,
       bundle: false,
     },
   ],
   plugins: pluginsConfig,
 });
 
-export const dualPackage = defineConfig({
-  lib: [esmConfig, cjsConfig],
+export const esmPackage = defineConfig({
+  lib: [esmConfig],
   plugins: pluginsConfig,
 });

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -9,6 +9,7 @@
     "directory": "packages/test-helper"
   },
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/src/index.d.js",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -12,7 +12,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.js",
+      "types": "./dist/src/index.d.ts",
       "default": "./dist/index.js"
     }
   },

--- a/scripts/test-helper/src/rspack.ts
+++ b/scripts/test-helper/src/rspack.ts
@@ -7,6 +7,9 @@ import {
 } from '@rspack/core';
 import { createFsFromVolume, Volume } from 'memfs';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function promisifyCompilerRun<
   T extends Compiler,
@@ -71,7 +74,7 @@ export function compileByRspackLayers(
     entry,
     mode: 'none',
     output: {
-      path: path.resolve(__dirname),
+      path: dirname,
       // filename: 'bundle.js',
     },
     stats: 'normal',


### PR DESCRIPTION
## Summary

- Migrate `@rsdoctor/core`, `@rsdoctor/cli`, and shared build presets to ESM-only output, removing CommonJS builds and `require` export conditions.
- Simplify the Rslib configuration and enable `tsgo`-based declaration generation and type checking.
- Update internal loader resolution, test helpers, worker-based tests, and runnable Rspack examples to work correctly in ESM environments.
- Replace the root Nx build command with pnpm workspace filters while preserving the banner fixture build.
- Add regression coverage for proxy-loader detection and migrate the atomic-write worker test to absolute ESM module URLs.
- Update the v2 migration documentation to clarify that CommonJS `require()` is no longer supported.

This is a breaking compatibility change for CommonJS consumers, which must migrate to ESM imports.


## Related Links
#1710
<!--- Provide links of related issues or pages -->
