### PR TITLE
feat(client): treemap ui/ux improvements

### DIFF
--- a/packages/client/src/components/Charts/TreeMap.tsx
+++ b/packages/client/src/components/Charts/TreeMap.tsx
@@ -556,18 +556,13 @@ export const TreeMap: React.FC<TreeMapProps> = memo(
     }, []);
 
     return option ? (
-      <div className={Styles['chart-container']}>
+      <div className={Styles.mainArea}>
         <Alert
           message="If parsed size lacks detailed module information, you can enable sourceMap when RSDOCTOR = true. This is because Rsdoctor relies on SourceMap to obtain Parsed Size. Rspack provides SourceMap information to Rsdoctor by default without affecting the build output."
           type="info"
           showIcon
-          style={{ marginBottom: 0 }}
         />
-        <div
-          style={{
-            flex: 1,
-          }}
-        >
+        <div className={Styles.chartRoot}>
           <EChartsReactCore
             ref={chartRef}
             option={option}
@@ -605,6 +600,9 @@ export const TreeMap: React.FC<TreeMapProps> = memo(
             style={{
               width: '100%',
               height: '100%',
+              position: 'absolute',
+              left: 0,
+              top: 0,
             }}
           />
         </div>
@@ -995,33 +993,27 @@ const AssetTreemapWithFilterInner: React.FC<{
           </div>
         </div>
       </div>
-
-      <div className={Styles['chart-wrapper']}>
-        <TreeMap
-          treeData={filteredTreeData}
-          sizeType={sizeType}
-          onChartClick={handleChartClick}
-          highlightNodeId={highlightNodeId}
-          centerNodeId={centerNodeId}
-          rootPath={rootPath}
-        />
-        {moduleId ? (
-          <ServerAPIProvider
-            api={SDK.ServerAPI.API.GetAllModuleGraph}
-            body={{}}
-          >
-            {(modules) => (
-              <ModuleAnalyzeComponent
-                cwd={rootPath}
-                moduleId={moduleId}
-                modules={modules}
-                show={showAnalyze}
-                setShow={setShowAnalyze}
-              />
-            )}
-          </ServerAPIProvider>
-        ) : null}
-      </div>
+      <TreeMap
+        treeData={filteredTreeData}
+        sizeType={sizeType}
+        onChartClick={handleChartClick}
+        highlightNodeId={highlightNodeId}
+        centerNodeId={centerNodeId}
+        rootPath={rootPath}
+      />
+      {moduleId ? (
+        <ServerAPIProvider api={SDK.ServerAPI.API.GetAllModuleGraph} body={{}}>
+          {(modules) => (
+            <ModuleAnalyzeComponent
+              cwd={rootPath}
+              moduleId={moduleId}
+              modules={modules}
+              show={showAnalyze}
+              setShow={setShowAnalyze}
+            />
+          )}
+        </ServerAPIProvider>
+      ) : null}
     </div>
   );
 };

--- a/packages/client/src/components/Charts/TreeMap.tsx
+++ b/packages/client/src/components/Charts/TreeMap.tsx
@@ -18,7 +18,7 @@ import {
   FullscreenExitOutlined,
 } from '@ant-design/icons';
 import type { ComposeOption, EChartsType } from 'echarts/core';
-import { formatSize, useThemeToken } from 'src/utils';
+import { formatSize, usePersistedState, useThemeToken } from 'src/utils';
 import { SDK } from '@rsdoctor/shared/types';
 import { ServerAPIProvider } from 'src/components/Manifest';
 import { ModuleAnalyzeComponent } from '../../pages/ModuleAnalyze';
@@ -557,11 +557,7 @@ export const TreeMap: React.FC<TreeMapProps> = memo(
 
     return option ? (
       <div className={Styles.mainArea}>
-        <Alert
-          message="If parsed size lacks detailed module information, you can enable sourceMap when RSDOCTOR = true. This is because Rsdoctor relies on SourceMap to obtain Parsed Size. Rspack provides SourceMap information to Rsdoctor by default without affecting the build output."
-          type="info"
-          showIcon
-        />
+        <TreemapAlert />
         <div className={Styles.chartRoot}>
           <EChartsReactCore
             ref={chartRef}
@@ -610,6 +606,23 @@ export const TreeMap: React.FC<TreeMapProps> = memo(
     ) : null;
   },
 );
+
+const TreemapAlert = () => {
+  const [visible, setVisible] = usePersistedState(
+    'treemap-alert-visible',
+    true,
+  );
+  if (!visible) return null;
+  return (
+    <Alert
+      closable
+      onClose={() => setVisible(false)}
+      message="If parsed size lacks detailed module information, you can enable sourceMap when RSDOCTOR = true. This is because Rsdoctor relies on SourceMap to obtain Parsed Size. Rspack provides SourceMap information to Rsdoctor by default without affecting the build output."
+      type="info"
+      showIcon
+    />
+  );
+};
 
 export const AssetTreemapWithFilter: React.FC<{
   treeData: TreeNode[];

--- a/packages/client/src/components/Charts/treemap.module.scss
+++ b/packages/client/src/components/Charts/treemap.module.scss
@@ -1,7 +1,7 @@
 .treemap {
   display: flex;
   flex-direction: row;
-  height: calc(100vh - 100px);
+  flex: 1;
   position: relative;
   overflow: hidden;
   border: 2px solid var(--color-border-secondary);
@@ -29,15 +29,13 @@
   min-width: 300px;
   background-color: var(--color-bg-box-elevated);
   border-right: 1px solid var(--color-border-secondary);
-  display: flex;
-  flex-direction: column;
   transition: transform 0.3s ease;
   z-index: 10;
-  height: 100%;
   position: relative;
   overflow: visible;
 
   &.collapsed {
+    height: 100%;
     transform: translateX(-100%);
     position: absolute;
     left: 0;
@@ -45,9 +43,10 @@
 }
 
 .sidebar-content {
+  position: absolute;
+  inset: 0;
   padding: 15px;
   overflow-y: auto;
-  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -77,20 +76,22 @@
   }
 }
 
-.chart-wrapper {
-  flex: 1;
-  position: relative;
-  height: 100%;
-  width: 100%;
-  overflow: hidden;
-}
-
-.chart-container {
+.mainArea {
   display: flex;
   flex-direction: column;
   position: relative;
-  width: 100%;
-  height: 100%;
+
+  [role='alert'] {
+    margin: var(--spacing-base);
+    margin-block-end: 0;
+  }
+}
+
+.chartRoot {
+  position: relative;
+  overflow: hidden;
+  flex: 1;
+  min-height: var(--treemap-chart-min-height, 300px);
 }
 
 .fullscreen-button {

--- a/packages/client/src/components/Charts/treemap.module.scss
+++ b/packages/client/src/components/Charts/treemap.module.scss
@@ -21,6 +21,10 @@
     height: 100vh;
     width: 100vw;
     border: none;
+
+    [role='alert'] {
+      display: none;
+    }
   }
 }
 
@@ -80,6 +84,7 @@
   display: flex;
   flex-direction: column;
   position: relative;
+  flex: 1;
 
   [role='alert'] {
     margin: var(--spacing-base);

--- a/packages/client/src/components/Charts/treemap.module.scss
+++ b/packages/client/src/components/Charts/treemap.module.scss
@@ -87,8 +87,8 @@
   flex: 1;
 
   [role='alert'] {
-    margin: var(--spacing-base);
-    margin-block-end: 0;
+    /* higher top margin to prevent overlapping with the fullscreen button */
+    margin: 50px var(--spacing-base) 0 var(--spacing-base);
   }
 }
 

--- a/packages/client/src/pages/BundleSize/components/cards.tsx
+++ b/packages/client/src/pages/BundleSize/components/cards.tsx
@@ -1,5 +1,5 @@
 /* rslint-disable react/jsx-key */
-import React, { useState, useMemo } from 'react';
+import React, { memo, useState, useMemo } from 'react';
 import { Divider, Segmented, Avatar, Tree } from 'antd';
 import { Client, SDK } from '@rsdoctor/shared/types';
 import { RightOutlined, FileFilled, GoldenFilled } from '@ant-design/icons';
@@ -109,7 +109,7 @@ export const BundleCards: React.FC<{
   cwd: string;
   errors: SDK.ErrorsData;
   summary: SDK.ServerAPI.InferResponseType<SDK.ServerAPI.API.GetAssetsSummary>;
-}> = ({ errors, summary }) => {
+}> = memo(({ errors, summary }) => {
   const duplicatePackages = useDuplicatePackagesByErrors(errors);
   const [totalSize, totalSizeUnit] = formatSize(summary.all.total.size).split(
     ' ',
@@ -288,4 +288,4 @@ export const BundleCards: React.FC<{
       }}
     </ServerAPIProvider>
   );
-};
+});

--- a/packages/client/src/pages/BundleSize/components/index.tsx
+++ b/packages/client/src/pages/BundleSize/components/index.tsx
@@ -17,7 +17,7 @@ import {
   Typography,
   Tabs,
 } from 'antd';
-import React, { useId } from 'react';
+import React, { memo, useId } from 'react';
 import { ServerAPIProvider } from '../../../components/Manifest';
 import { useProjectInfo } from '../../../components/Layout/project-info-context';
 import {
@@ -223,59 +223,7 @@ export const WebpackModulesOverallBase: React.FC<
             {
               key: 'treemap',
               label: 'Treemap',
-              children: (
-                <ServerAPIProvider api={SDK.ServerAPI.API.GetProjectInfo}>
-                  {(data) => {
-                    const { isRspack, hasSourceMap } =
-                      Rspack.checkSourceMapSupport(data.configs);
-                    return (
-                      <ServerAPIProvider
-                        api={SDK.ServerAPI.API.GetSummaryBundles}
-                      >
-                        {(data) => {
-                          // Filter assets to only show JS (js, cjs, mjs), .bundle, CSS, and HTML files
-                          const isVisibleTreemapAsset = (filePath: string) => {
-                            const ext =
-                              filePath.toLowerCase().split('.').pop() || '';
-                            return (
-                              isJavaScriptAsset(filePath) ||
-                              ext === 'css' ||
-                              ext === 'html'
-                            );
-                          };
-
-                          const computedTreeData: TreeNode[] = data
-                            .filter((item) =>
-                              isVisibleTreemapAsset(item.asset.path),
-                            )
-                            .map((item) => {
-                              const moduleTree = flattenTreemapData(
-                                item.modules,
-                              );
-                              const hasModules = item.modules.length > 0;
-                              return {
-                                name: item.asset.path,
-                                sourceSize: hasModules
-                                  ? (moduleTree.sourceSize ?? 0)
-                                  : item.asset.size,
-                                bundledSize: item.asset.size,
-                                gzipSize: item.asset.gzipSize ?? 0,
-                                children: moduleTree.children,
-                              };
-                            });
-
-                          return (
-                            <AssetTreemapWithFilter
-                              treeData={computedTreeData}
-                              bundledSize={hasSourceMap || isRspack}
-                            />
-                          );
-                        }}
-                      </ServerAPIProvider>
-                    );
-                  }}
-                </ServerAPIProvider>
-              ),
+              children: <AssetTreemapWithFilterAndData />,
             },
           ]}
           defaultActiveKey="tree"
@@ -284,6 +232,54 @@ export const WebpackModulesOverallBase: React.FC<
     </>
   );
 };
+
+const AssetTreemapWithFilterAndData = memo(() => {
+  return (
+    <ServerAPIProvider api={SDK.ServerAPI.API.GetProjectInfo}>
+      {(data) => {
+        const { isRspack, hasSourceMap } = Rspack.checkSourceMapSupport(
+          data.configs,
+        );
+        return (
+          <ServerAPIProvider api={SDK.ServerAPI.API.GetSummaryBundles}>
+            {(data) => {
+              // Filter assets to only show JS (js, cjs, mjs), .bundle, CSS, and HTML files
+              const isVisibleTreemapAsset = (filePath: string) => {
+                const ext = filePath.toLowerCase().split('.').pop() || '';
+                return (
+                  isJavaScriptAsset(filePath) || ext === 'css' || ext === 'html'
+                );
+              };
+
+              const computedTreeData: TreeNode[] = data
+                .filter((item) => isVisibleTreemapAsset(item.asset.path))
+                .map((item) => {
+                  const moduleTree = flattenTreemapData(item.modules);
+                  const hasModules = item.modules.length > 0;
+                  return {
+                    name: item.asset.path,
+                    sourceSize: hasModules
+                      ? (moduleTree.sourceSize ?? 0)
+                      : item.asset.size,
+                    bundledSize: item.asset.size,
+                    gzipSize: item.asset.gzipSize ?? 0,
+                    children: moduleTree.children,
+                  };
+                });
+
+              return (
+                <AssetTreemapWithFilter
+                  treeData={computedTreeData}
+                  bundledSize={hasSourceMap || isRspack}
+                />
+              );
+            }}
+          </ServerAPIProvider>
+        );
+      }}
+    </ServerAPIProvider>
+  );
+});
 
 export const WebpackModulesOverall: React.FC = () => {
   const { project } = useProjectInfo();

--- a/packages/client/src/pages/BundleSize/components/index.tsx
+++ b/packages/client/src/pages/BundleSize/components/index.tsx
@@ -50,6 +50,10 @@ export const WebpackModulesOverallBase: React.FC<
     'bundle-size-tabs-card-expanded',
     false,
   );
+  const [activeTab, setActiveTab] = usePersistedState(
+    'bundle-size-tabs-default-tab',
+    'tree',
+  );
   const cardDomId = useId();
   const expandActionText = expanded ? 'Shrink card' : 'Expand card';
   const { isLight } = useTheme();
@@ -66,6 +70,8 @@ export const WebpackModulesOverallBase: React.FC<
         id={cardDomId}
       >
         <Tabs
+          activeKey={activeTab}
+          onChange={setActiveTab}
           size="middle"
           className={styles.tabsRoot}
           tabBarExtraContent={{


### PR DESCRIPTION
## Summary

The chart takes all available vertical space instead of 100vh - something:


https://github.com/user-attachments/assets/355c7b45-5fec-462f-990d-96b144c19703

The alert is hidden in fullscreen mode:




<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/6128109e-e1ba-4fce-b05c-3f16d1596353" />

It can also be closed (the state is persisted):


https://github.com/user-attachments/assets/721b9e63-fb81-4816-be40-01a9000e2df3

Active tab is persisted across page reloads:

https://github.com/user-attachments/assets/a1a1d6fe-db63-454b-94ba-1c001dcf612b


## Related Links

<!--- Provide links of related issues or pages -->
