### PR TITLE
docs: document bundle diff JSON output

### DIFF
--- a/packages/document/docs/en/guide/start/cli.mdx
+++ b/packages/document/docs/en/guide/start/cli.mdx
@@ -48,24 +48,36 @@ rsdoctor analyze --profile <manifestFile>
 rsdoctor analyze --profile "./dist/.rsdoctor/manifest.json"
 ```
 
-### `bundle-diff` Command
+### `bundle-diff` command
 
-The `bundle-diff` command is used to load **two** [manifest.json](/config/options/term#manifestjson) files **locally** and open the Rsdoctor [Bundle Diff](../usage/bundle-diff) page for **comparison and analysis of build bundles**.
+The `bundle-diff` command loads **two** [manifest.json](/config/options/term#manifestjson) files **locally** and compares their build bundles. By default, it opens the Rsdoctor [Bundle Diff](../usage/bundle-diff) page in the browser. Use `--json [path]` to generate a JSON report without starting the report server or opening the browser.
 
 ```bash
 rsdoctor bundle-diff --baseline <baselineManifestJsonPath> --current <currentManifestJsonPath>
 ```
 
-**Parameter Definitions**
+**Parameter definitions**
 
-- `baselineManifestJsonPath` Path to the [manifest.json](/config/options/term#manifestjson) used as the **baseline** (supports local paths as well as online URLs).
-- `currentManifestJsonPath` Path to the [manifest.json](/config/options/term#manifestjson) used as the **current** (supports local paths as well as online URLs) for comparison with the **baseline**.
+- `--baseline <path>`: Path or online URL of the [manifest.json](/config/options/term#manifestjson) used as the **baseline**.
+- `--current <path>`: Path or online URL of the [manifest.json](/config/options/term#manifestjson) used as the **current** build.
+- `--json [path]`: Generate a JSON diff report. The default output path is `rsdoctor-diff.json`.
 
-**Usage Example**
+**Open the report in the browser**
 
 ```bash
 rsdoctor bundle-diff --baseline="baseline/.rsdoctor/manifest.json" --current="current/.rsdoctor/manifest.json"
 ```
+
+**Generate a JSON report**
+
+```bash
+rsdoctor bundle-diff \
+  --baseline="baseline/.rsdoctor/manifest.json" \
+  --current="current/.rsdoctor/manifest.json" \
+  --json="result.json"
+```
+
+The JSON report contains diff data for assets, modules, and packages. You can consume it in CI workflows or use it to generate pull request comments.
 
 ## Node API
 

--- a/packages/document/docs/en/guide/usage/bundle-diff.mdx
+++ b/packages/document/docs/en/guide/usage/bundle-diff.mdx
@@ -8,14 +8,28 @@ We provide the Bundle Diff feature, which allows you to compare and analyze the 
 
 Currently, we offer the following usage methods:
 
-- [Open locally with CLI](/guide/start/cli)
+- [Open the report locally with CLI](/guide/start/cli)
+- [Generate a JSON report with CLI](#generate-a-json-report-with-cli)
 - Online upload analysis (planned support)
 
 ## Usage
 
-### Open locally with CLI
+### Open the report locally with CLI
 
 First, you need to prepare **2 copies** of the [manifest.json](/config/options/term#manifestjson) produced by Rsdoctor. Then, install [@rsdoctor/cli](/guide/start/cli#cli-tutorial) and use the CLI command `bundle-diff`. For detailed command usage, see [command usage tutorial](/guide/start/cli#bundle-diff-command).
+
+### Generate a JSON report with CLI
+
+Use the `--json [path]` option to generate a structured diff report without starting the report server or opening the browser:
+
+```bash
+rsdoctor bundle-diff \
+  --baseline="baseline/.rsdoctor/manifest.json" \
+  --current="current/.rsdoctor/manifest.json" \
+  --json="result.json"
+```
+
+If you omit the path after `--json`, the report is saved as `rsdoctor-diff.json`. The report contains `assets`, `modules`, and `packages` diff data, which can be consumed in CI workflows or used to generate pull request comments.
 
 ### Online upload analysis (planned support)
 

--- a/packages/document/docs/zh/guide/start/cli.mdx
+++ b/packages/document/docs/zh/guide/start/cli.mdx
@@ -50,7 +50,7 @@ rsdoctor analyze --profile "./dist/.rsdoctor/manifest.json"
 
 ### bundle-diff 命令
 
-`bundle-diff` 命令是用于在**本地**加载**两份** [manifest.json](/config/options/term#manifestjson) 并且打开 Rsdoctor 的 [Bundle Diff](../usage/bundle-diff) 页面进行**构建产物的对比和分析**。
+`bundle-diff` 命令用于在**本地**加载**两份** [manifest.json](/config/options/term#manifestjson)，并对比分析两次构建产物。默认情况下，该命令会在浏览器中打开 Rsdoctor 的 [Bundle Diff](../usage/bundle-diff) 页面。使用 `--json [path]` 可以直接生成 JSON 报告，而不会启动报告服务器或打开浏览器。
 
 ```bash
 rsdoctor bundle-diff --baseline <baselineManifestJsonPath> --current <currentManifestJsonPath>
@@ -58,14 +58,26 @@ rsdoctor bundle-diff --baseline <baselineManifestJsonPath> --current <currentMan
 
 **参数定义**
 
-- `baselineManifestJsonPath` 当作 **基准** 的 [manifest.json](/config/options/term#manifestjson) 的路径（支持本地路径以及在线 url）
-- `currentManifestJsonPath` 当作 **当前** 的 [manifest.json](/config/options/term#manifestjson) 的路径（支持本地路径以及在线 url），用于和 **基准** 进行对比
+- `--baseline <path>`：作为**基准**的 [manifest.json](/config/options/term#manifestjson) 路径或在线 URL。
+- `--current <path>`：作为**当前构建**的 [manifest.json](/config/options/term#manifestjson) 路径或在线 URL。
+- `--json [path]`：生成 JSON 差异报告，默认输出路径为 `rsdoctor-diff.json`。
 
-**使用示例**
+**在浏览器中打开报告**
 
 ```bash
 rsdoctor bundle-diff --baseline="baseline/.rsdoctor/manifest.json" --current="current/.rsdoctor/manifest.json"
 ```
+
+**生成 JSON 报告**
+
+```bash
+rsdoctor bundle-diff \
+  --baseline="baseline/.rsdoctor/manifest.json" \
+  --current="current/.rsdoctor/manifest.json" \
+  --json="result.json"
+```
+
+JSON 报告包含 assets、modules 和 packages 的差异数据，可用于 CI 流程或生成 Pull Request 评论。
 
 ## Node API
 

--- a/packages/document/docs/zh/guide/usage/bundle-diff.mdx
+++ b/packages/document/docs/zh/guide/usage/bundle-diff.mdx
@@ -8,14 +8,28 @@ import { Badge } from '@theme';
 
 目前我们提供了以下几种使用方式：
 
-- [CLI 本地打开](/guide/start/cli)
+- [通过 CLI 在本地打开报告](/guide/start/cli)
+- [通过 CLI 生成 JSON 报告](#通过-cli-生成-json-报告)
 - 在线上传分析（计划支持）
 
 ## 使用方式
 
-### CLI 本地打开
+### 通过 CLI 在本地打开报告
 
 首先你需要准备 **2 份** Rsdoctor 产出的[manifest.json](/config/options/term#manifestjson)，然后通过安装[@rsdoctor/cli](/guide/start/cli#%E5%AE%89%E8%A3%85-rsdoctorcli) 并使用 CLI 提供的 `bundle-diff` 命令，详见[命令使用教程](/guide/start/cli#bundle-diff-%E5%91%BD%E4%BB%A4)。
+
+### 通过 CLI 生成 JSON 报告
+
+使用 `--json [path]` 可以直接生成结构化差异报告，而不会启动报告服务器或打开浏览器：
+
+```bash
+rsdoctor bundle-diff \
+  --baseline="baseline/.rsdoctor/manifest.json" \
+  --current="current/.rsdoctor/manifest.json" \
+  --json="result.json"
+```
+
+如果省略 `--json` 后的路径，报告将保存为 `rsdoctor-diff.json`。报告包含 `assets`、`modules` 和 `packages` 的差异数据，可用于 CI 流程或生成 Pull Request 评论。
 
 ### 在线上传分析（计划支持）
 


### PR DESCRIPTION
## Summary

- Document `bundle-diff --json [path]` in the English and Chinese CLI guides.
- Add the browserless JSON report workflow, default output filename, report contents, and CI/PR comment use cases to the Bundle Diff guides.
- Validate the updated MDX files with Prettier and `git diff --check`.

## Related Links

- #776