### PR TITLE
refactor(core): use Rspack internal resolver

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,7 +52,6 @@
     // align Node.js version minimum requirements
     '@types/node',
     'acorn',
-    '@rspack/resolver',
     'json-stream-stringify',
     'fs-extra',
     'socket.io',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -130,7 +130,6 @@
     "@babel/code-frame": "7.26.2",
     "@rsbuild/plugin-check-syntax": "catalog:",
     "@rsdoctor/shared": "workspace:*",
-    "@rspack/resolver": "catalog:",
     "@types/estree": "catalog:",
     "acorn": "^8.10.0",
     "acorn-import-attributes": "^1.9.5",

--- a/packages/core/src/inner-plugins/plugins/loader.ts
+++ b/packages/core/src/inner-plugins/plugins/loader.ts
@@ -3,7 +3,7 @@ import type { HookInterceptor } from 'tapable';
 import { Loader } from '@rsdoctor/core/common';
 import { isEqual, omit } from '@rsdoctor/core/collection';
 import type { LoaderContext, NormalModule } from '@rspack/core';
-import { interceptLoader, type CompatibleResolve } from '../utils';
+import { interceptLoader } from '../utils';
 import { InternalBasePlugin } from './base';
 import type { ProxyLoaderOptions } from '../../types';
 import { time, timeEnd } from '@rsdoctor/core/logger';
@@ -188,10 +188,8 @@ export class InternalLoaderPlugin<
         host: this.sdk.server.origin,
         skipLoaders: this.options.loaderInterceptorOptions.skipLoaders, // not implement
       },
+      compiler.resolverFactory.get('loader', compiler.options.resolveLoader),
       this.sdk.root,
-      'resolveLoader' in compiler.options
-        ? (compiler.options.resolveLoader as CompatibleResolve)
-        : {},
     );
   }
 }

--- a/packages/core/src/inner-plugins/utils/loader.ts
+++ b/packages/core/src/inner-plugins/utils/loader.ts
@@ -1,4 +1,3 @@
-import { ResolverFactory } from '@rspack/resolver';
 import { omit } from '@rsdoctor/core/collection';
 import path from 'path';
 import { logger } from '@rsdoctor/core/logger';
@@ -69,36 +68,23 @@ export function shouldSkipLoader(
   return false;
 }
 
-export type CompatibleResolve = Omit<
-  Plugin.Configuration['resolve'],
-  'mainFields'
-> & {
-  mainFields?: string[];
-};
+export type LoaderResolver = ReturnType<
+  Plugin.BaseCompiler['resolverFactory']['get']
+>;
 
 export function interceptLoader<T extends Plugin.BuildRuleSetRule>(
   rules: T[],
   loaderPath: string,
   options: Omit<ProxyLoaderInternalOptions, 'loader' | 'hasOptions'>,
+  loaderResolver: LoaderResolver,
   cwd = process.cwd(),
-  resolveLoader?: CompatibleResolve,
 ): T[] {
-  const loaderResolver = new ResolverFactory({
-    conditionNames: ['loader', 'require', 'node'],
-    exportsFields: ['exports'],
-    mainFiles: ['index'],
-    mainFields: ['loader', 'main'],
-    extensions: ['js', '.json'],
-    modules: ['node_modules'],
-    ...resolveLoader,
-  });
-
   const resolve = (target: string) => {
     try {
-      const result = loaderResolver.sync(cwd, target);
+      const result = loaderResolver.resolveSync({}, cwd, target);
 
-      if (result.path) {
-        return result.path;
+      if (result) {
+        return result;
       }
     } catch {
       // ..

--- a/packages/core/tests/plugins/loader.test.ts
+++ b/packages/core/tests/plugins/loader.test.ts
@@ -1,4 +1,5 @@
 import { Loader } from '@rsdoctor/core/common';
+import { rspack } from '@rspack/core';
 import { describe, it, expect } from '@rstest/core';
 import path from 'path';
 import { ProxyLoaderInternalOptions } from '@/types';
@@ -18,6 +19,23 @@ describe('test src/utils/loader.ts', () => {
     const proxyLoaderPath = path.resolve(
       __dirname,
       '../../src/loaders/proxy.ts',
+    );
+    const compiler = rspack({
+      context: exampleWebpackPath,
+    });
+    const loaderResolver = compiler.resolverFactory.get(
+      'loader',
+      compiler.options.resolveLoader,
+    );
+    const customCompiler = rspack({
+      context: exampleWebpackPath,
+      resolveLoader: {
+        modules: [path.join(exampleWebpackPath, 'node_modules')],
+      },
+    });
+    const customLoaderResolver = customCompiler.resolverFactory.get(
+      'loader',
+      customCompiler.options.resolveLoader,
     );
     const internalOptions: Omit<
       ProxyLoaderInternalOptions,
@@ -42,6 +60,7 @@ describe('test src/utils/loader.ts', () => {
           ],
           proxyLoaderPath,
           internalOptions,
+          loaderResolver,
           path.join(__dirname, '../../'),
         ),
       ).toStrictEqual([
@@ -78,6 +97,7 @@ describe('test src/utils/loader.ts', () => {
           ],
           proxyLoaderPath,
           internalOptions,
+          loaderResolver,
           path.join(__dirname, '../../'),
         ),
       ).toStrictEqual([
@@ -111,6 +131,7 @@ describe('test src/utils/loader.ts', () => {
           ],
           proxyLoaderPath,
           internalOptions,
+          loaderResolver,
           path.join(__dirname, '../../'),
         ),
       ).toStrictEqual([
@@ -151,6 +172,7 @@ describe('test src/utils/loader.ts', () => {
           ],
           proxyLoaderPath,
           internalOptions,
+          loaderResolver,
           path.join(__dirname, '../../'),
         ),
       ).toStrictEqual([
@@ -199,6 +221,7 @@ describe('test src/utils/loader.ts', () => {
           ],
           proxyLoaderPath,
           internalOptions,
+          loaderResolver,
           path.join(__dirname, '../../'),
         ),
       ).toStrictEqual([
@@ -245,6 +268,7 @@ describe('test src/utils/loader.ts', () => {
           ],
           proxyLoaderPath,
           internalOptions,
+          loaderResolver,
           path.join(__dirname, '../../'),
         ),
       ).toStrictEqual([
@@ -286,7 +310,7 @@ describe('test src/utils/loader.ts', () => {
       ]);
     });
 
-    it('[string] rule.loader with resolveOptions', () => {
+    it('[string] rule.loader with resolveLoader', () => {
       expect(
         interceptLoader(
           [
@@ -300,10 +324,8 @@ describe('test src/utils/loader.ts', () => {
           ],
           proxyLoaderPath,
           internalOptions,
-          undefined,
-          {
-            modules: [path.join(exampleWebpackPath, 'node_modules')],
-          },
+          customLoaderResolver,
+          exampleWebpackPath,
         ),
       ).toStrictEqual([
         {
@@ -351,6 +373,7 @@ describe('test src/utils/loader.ts', () => {
           ],
           proxyLoaderPath,
           internalOptions,
+          loaderResolver,
         ),
       ).toStrictEqual([
         {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,6 @@ catalogs:
     '@rspack/plugin-react-refresh':
       specifier: ^2.0.2
       version: 2.0.2
-    '@rspack/resolver':
-      specifier: ^0.2.8
-      version: 0.2.8
     '@rstest/core':
       specifier: 0.11.4
       version: 0.11.4
@@ -627,9 +624,6 @@ importers:
       '@rsdoctor/shared':
         specifier: workspace:*
         version: link:../shared
-      '@rspack/resolver':
-        specifier: 'catalog:'
-        version: 0.2.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       '@types/estree':
         specifier: 'catalog:'
         version: 1.0.5


### PR DESCRIPTION
## Summary

- Reuse Rspack's internal loader resolver from `compiler.resolverFactory` instead of creating a separate `@rspack/resolver` instance.
- Align loader interception with the compiler's `resolveLoader` configuration.
- Remove the redundant `@rspack/resolver` dependency from `@rsdoctor/core`, the lockfile, and Renovate configuration.
- Update loader interception tests to cover both default and customized `resolveLoader` behavior.

This reduces the installation footprint and avoids maintaining duplicate resolver configuration.

## Related Links
#1710

<!--- Provide links of related issues or pages -->
