### PR TITLE
refactor(core): replace strip-ansi with Node.js API

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -150,7 +150,6 @@
     "rslog": "^2.1.3",
     "semver": "^7.8.5",
     "source-map": "catalog:",
-    "strip-ansi": "^7.2.0",
     "@rsdoctor/client": "workspace:*",
     "cors": "2.8.6",
     "dayjs": "catalog:",

--- a/packages/core/src/error/error.ts
+++ b/packages/core/src/error/error.ts
@@ -1,9 +1,9 @@
+import { stripVTControlCharacters } from 'node:util';
 import { codeFrameColumns } from '@babel/code-frame';
 import { Lodash } from '@rsdoctor/core/common';
 import { Err, Rule } from '@rsdoctor/shared/types';
 import { createColors } from 'picocolors';
 import deepEql from 'deep-eql';
-import stripAnsi from 'strip-ansi';
 import { transform } from './transform';
 import { insertSpace, toLevel } from './utils';
 
@@ -219,7 +219,9 @@ export class DevToolError extends Error implements Err.DevToolErrorInstance {
       ...this.detail,
       id: this.id,
       category: this.category,
-      description: stripAnsi(this.detail?.description ?? this.message),
+      description: stripVTControlCharacters(
+        this.detail?.description ?? this.message,
+      ),
       title: this.title.toUpperCase(),
       code: this.code,
       level: this.level.toLowerCase(),

--- a/packages/core/src/error/transform.ts
+++ b/packages/core/src/error/transform.ts
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi';
+import { stripVTControlCharacters } from 'node:util';
 // import { parse as stackParse } from '@web-doctor/stack-trace'; // TODO: add doctor stack-trace
 import { Esbuild, Babel, Err, Linter } from '@rsdoctor/shared/types';
 import { DevToolError } from './error';
@@ -26,7 +26,7 @@ function isDiagnosticError(err: any): err is Linter.Diagnostic {
 }
 
 function parseBabelErrorMessage(input: string) {
-  const lines = stripAnsi(truncateMessage(input)).split('\n');
+  const lines = stripVTControlCharacters(truncateMessage(input)).split('\n');
   const filePath = lines[0].replace(/^([^:]+):.*/, '$1');
   const message = lines[0].replace(/.*: (.*) \(\d+:\d+\)*/, '$1');
   const lineText =
@@ -40,7 +40,10 @@ function parseBabelErrorMessage(input: string) {
 }
 
 function clearMessage(str: string) {
-  return stripAnsi(truncateMessage(str)).replace(/.*: (.*)\n\n[\s\S]*/g, '$1');
+  return stripVTControlCharacters(truncateMessage(str)).replace(
+    /.*: (.*)\n\n[\s\S]*/g,
+    '$1',
+  );
 }
 
 function clearStack(str: string) {

--- a/packages/core/tests/error/error.test.ts
+++ b/packages/core/tests/error/error.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from '@rstest/core';
+import { DevToolError } from '@/error';
+
+describe('DevToolError', () => {
+  it('strips VT control characters from error descriptions', () => {
+    const transformedError = DevToolError.from(
+      new Error('\u001B[31mmessage\u001B[39m'),
+    );
+    const detailedError = new DevToolError('title', 'message', {
+      detail: {
+        description: '\u001B[33mdescription\u001B[39m',
+      },
+    });
+
+    expect(transformedError.message).toBe('message');
+    expect(detailedError.toData().description).toBe('description');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,7 +183,7 @@ importers:
         version: 3.9.6
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.1.8(core-js@3.49.0))
+        version: 0.3.4(@rsbuild/core@2.1.7(core-js@3.49.0))
 
   e2e:
     devDependencies:
@@ -699,9 +699,6 @@ importers:
       source-map:
         specifier: 'catalog:'
         version: 0.7.6
-      strip-ansi:
-        specifier: ^7.2.0
-        version: 7.2.0
       tapable:
         specifier: 2.3.3
         version: 2.3.3
@@ -14654,12 +14651,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.7(core-js@3.49.0)
 
-  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.1.8(core-js@3.49.0)):
+  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.1.7(core-js@3.49.0)):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.17
     optionalDependencies:
-      '@rsbuild/core': 2.1.8(core-js@3.49.0)
+      '@rsbuild/core': 2.1.7(core-js@3.49.0)
 
   rslog@1.3.2: {}
 


### PR DESCRIPTION
## Summary

- Replace the direct `strip-ansi` dependency in `@rsdoctor/core` with Node.js `stripVTControlCharacters`.
- Add regression coverage for stripping VT control characters from transformed errors and stored descriptions.

## Related Links

None.