### PR TITLE
perf(core): remove unused dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -144,7 +144,6 @@
     "json-stream-stringify": "3.0.1",
     "lines-and-columns": "2.0.4",
     "open": "^11.0.0",
-    "path-browserify": "catalog:",
     "picocolors": "catalog:",
     "raw-body": "3.0.2",
     "rslog": "^2.1.3",
@@ -154,7 +153,6 @@
     "cors": "2.8.6",
     "dayjs": "catalog:",
     "launch-editor": "^2.14.1",
-    "safer-buffer": "2.1.2",
     "sirv": "catalog:",
     "tapable": "2.3.3",
     "ws": "8.21.1"
@@ -169,7 +167,6 @@
     "@types/fs-extra": "catalog:",
     "@types/node": "catalog:",
     "@types/node-fetch": "^2.6.13",
-    "@types/path-browserify": "catalog:",
     "@types/semver": "^7.7.1",
     "@types/tapable": "catalog:",
     "babel-loader": "10.1.1",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -1,12 +1,7 @@
 /** @type {import('prebundle').Config} */
 export default {
   dependencies: [],
-  exclude: [
-    '@rsdoctor/client',
-    '@rsdoctor/shared/types',
-    '@rspack/core',
-    'safer-buffer',
-  ],
+  exclude: ['@rsdoctor/client', '@rsdoctor/shared/types', '@rspack/core'],
 
   build: {
     platform: 'node',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -675,9 +675,6 @@ importers:
       open:
         specifier: ^11.0.0
         version: 11.0.0
-      path-browserify:
-        specifier: 'catalog:'
-        version: 1.0.1
       picocolors:
         specifier: 'catalog:'
         version: 1.1.1
@@ -687,9 +684,6 @@ importers:
       rslog:
         specifier: ^2.1.3
         version: 2.1.3
-      safer-buffer:
-        specifier: 2.1.2
-        version: 2.1.2
       semver:
         specifier: ^7.8.5
         version: 7.8.5
@@ -736,9 +730,6 @@ importers:
       '@types/node-fetch':
         specifier: ^2.6.13
         version: 2.6.13
-      '@types/path-browserify':
-        specifier: 'catalog:'
-        version: 1.0.3
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1


### PR DESCRIPTION
## Summary

- Remove unused `path-browserify` and `safer-buffer` runtime dependencies from `@rsdoctor/core`.
- Remove the obsolete `@types/path-browserify` package and `safer-buffer` prebundle exclusion, then refresh the lockfile.