### PR TITLE
fix(core): preserve structural code-frame equality

### DIFF
--- a/packages/core/src/error/error.ts
+++ b/packages/core/src/error/error.ts
@@ -1,5 +1,6 @@
-import { isDeepStrictEqual, stripVTControlCharacters } from 'node:util';
+import { stripVTControlCharacters } from 'node:util';
 import { codeFrameColumns } from '@babel/code-frame';
+import { isEqual } from '@rsdoctor/core/collection';
 import { Lodash } from '@rsdoctor/core/common';
 import { Err, Rule } from '@rsdoctor/shared/types';
 import { createColors } from 'picocolors';
@@ -267,8 +268,7 @@ export class DevToolError extends Error implements Err.DevToolErrorInstance {
       this.level === error.level &&
       this.title === error.title &&
       this.referenceUrl === error.referenceUrl &&
-      this.code === error.code &&
-      isDeepStrictEqual(this.codeFrame, error.codeFrame)
+      isEqual(this.codeFrame, error.codeFrame)
     );
   }
 }


### PR DESCRIPTION
## Summary

- Preserve structural `CodeFrameOption` equality when values come from another VM realm or use a null prototype.
- Use the existing prototype-agnostic `isEqual` helper and remove the duplicate `code` comparison.

## Related Links

- Follow-up to https://github.com/web-infra-dev/rsdoctor/pull/1852
- https://github.com/web-infra-dev/rsdoctor/pull/1852#discussion_r3657553435
- https://github.com/web-infra-dev/rsdoctor/pull/1852#discussion_r3657560661