### PR TITLE
chore(deps): replace tapable with lite-tapable

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -127,6 +127,7 @@
   "dependencies": {
     "@babel/code-frame": "7.26.2",
     "@rsbuild/plugin-check-syntax": "catalog:",
+    "@rspack/lite-tapable": "catalog:",
     "@rsdoctor/shared": "workspace:*",
     "@types/estree": "catalog:",
     "acorn": "^8.10.0",
@@ -151,7 +152,6 @@
     "dayjs": "catalog:",
     "launch-editor": "^2.14.1",
     "sirv": "catalog:",
-    "tapable": "2.3.3",
     "ws": "8.21.1"
   },
   "devDependencies": {
@@ -162,9 +162,7 @@
     "@types/envinfo": "7.8.4",
     "@types/fs-extra": "catalog:",
     "@types/node": "catalog:",
-    "@types/node-fetch": "^2.6.13",
     "@types/semver": "^7.7.1",
-    "@types/tapable": "catalog:",
     "babel-loader": "10.1.1",
     "string-loader": "0.0.1",
     "ts-loader": "^9.6.2",

--- a/packages/core/src/inner-plugins/constants.ts
+++ b/packages/core/src/inner-plugins/constants.ts
@@ -1,6 +1,4 @@
-import type { Options } from '@rspack/lite-tapable';
-
-type Tap = Exclude<Options, string>;
+import type { Tap } from '@rspack/lite-tapable';
 
 export const pluginTapName = 'RsdoctorRspackPlugin';
 

--- a/packages/core/src/inner-plugins/constants.ts
+++ b/packages/core/src/inner-plugins/constants.ts
@@ -1,4 +1,6 @@
-import type { Tap } from 'tapable';
+import type { Options } from '@rspack/lite-tapable';
+
+type Tap = Exclude<Options, string>;
 
 export const pluginTapName = 'RsdoctorRspackPlugin';
 

--- a/packages/core/src/inner-plugins/plugins/loader.ts
+++ b/packages/core/src/inner-plugins/plugins/loader.ts
@@ -1,5 +1,5 @@
 import { Manifest, Plugin } from '@rsdoctor/shared/types';
-import type { HookInterceptor } from 'tapable';
+import type { HookInterceptor } from '@rspack/lite-tapable';
 import { Loader } from '@rsdoctor/core/common';
 import { isEqual, omit } from '@rsdoctor/core/collection';
 import type { LoaderContext, NormalModule } from '@rspack/core';

--- a/packages/core/src/inner-plugins/plugins/loader.ts
+++ b/packages/core/src/inner-plugins/plugins/loader.ts
@@ -1,5 +1,4 @@
 import { Manifest, Plugin } from '@rsdoctor/shared/types';
-import type { HookInterceptor } from '@rspack/lite-tapable';
 import { Loader } from '@rsdoctor/core/common';
 import { isEqual, omit } from '@rsdoctor/core/collection';
 import type { LoaderContext, NormalModule } from '@rspack/core';
@@ -157,20 +156,20 @@ export class InternalLoaderPlugin<
           }
         };
 
-      const interceptor: HookInterceptor<[object, MutableNormalModule], void> =
-        {
-          register(tap) {
-            const originFn = tap.fn;
-            if (typeof originFn === 'function') {
-              tap.fn = wrapper(originFn as LoaderHookCallback);
-            }
-            return tap;
-          },
-        };
-
-      compiler.webpack.NormalModule.getCompilationHooks(
+      const loaderHook = compiler.webpack.NormalModule.getCompilationHooks(
         compilation as Plugin.BaseCompilationType<'rspack'>,
-      ).loader.intercept(interceptor);
+      ).loader;
+      const interceptor: Parameters<typeof loaderHook.intercept>[0] = {
+        register(tap) {
+          const originFn = tap.fn;
+          if (typeof originFn === 'function') {
+            tap.fn = wrapper(originFn as LoaderHookCallback);
+          }
+          return tap;
+        },
+      };
+
+      loaderHook.intercept(interceptor);
     } finally {
       timeEnd('InternalLoaderPlugin.compilation');
     }

--- a/packages/core/src/rspack-plugin/constants.ts
+++ b/packages/core/src/rspack-plugin/constants.ts
@@ -1,5 +1,7 @@
 import { createRequire } from 'node:module';
-import type { Tap } from 'tapable';
+import type { Options } from '@rspack/lite-tapable';
+
+type Tap = Exclude<Options, string>;
 
 const require = createRequire(import.meta.url);
 const packageJson = require('../../package.json') as { version: string };

--- a/packages/core/src/rspack-plugin/constants.ts
+++ b/packages/core/src/rspack-plugin/constants.ts
@@ -1,7 +1,5 @@
 import { createRequire } from 'node:module';
-import type { Options } from '@rspack/lite-tapable';
-
-type Tap = Exclude<Options, string>;
+import type { Tap } from '@rspack/lite-tapable';
 
 const require = createRequire(import.meta.url);
 const packageJson = require('../../package.json') as { version: string };

--- a/packages/core/src/sdk/sdk/core.ts
+++ b/packages/core/src/sdk/sdk/core.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 import process from 'node:process';
-import { AsyncSeriesHook } from 'tapable';
+import { AsyncSeriesHook } from '@rspack/lite-tapable';
 import { decycle } from '@rsdoctor/core/common';
 import { logger } from '@rsdoctor/core/logger';
 import { transformDataUrls } from '../utils';

--- a/packages/core/tests/rspack-plugin/native-plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/native-plugin.test.ts
@@ -1,4 +1,4 @@
-import { AsyncSeriesHook, SyncHook } from 'tapable';
+import { AsyncSeriesHook, SyncHook } from '@rspack/lite-tapable';
 import { describe, expect, it, rs } from '@rstest/core';
 import { ModuleGraph } from '@rsdoctor/core/graph';
 import type { Plugin } from '@rsdoctor/shared/types';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@types/connect": "catalog:",
     "@types/estree": "catalog:",
-    "@types/tapable": "catalog:",
+    "@rspack/lite-tapable": "catalog:",
     "buffer": "6.0.3",
     "path-browserify": "catalog:",
     "source-map": "catalog:"

--- a/packages/shared/src/types/sdk/hooks.ts
+++ b/packages/shared/src/types/sdk/hooks.ts
@@ -1,4 +1,4 @@
-import type { AsyncSeriesHook } from 'tapable';
+import type { AsyncSeriesHook } from '@rspack/lite-tapable';
 import { RsdoctorManifestWithShardingFiles } from '../manifest';
 
 /**

--- a/packages/shared/src/types/sdk/hooks.ts
+++ b/packages/shared/src/types/sdk/hooks.ts
@@ -1,5 +1,5 @@
 import type { AsyncSeriesHook } from '@rspack/lite-tapable';
-import { RsdoctorManifestWithShardingFiles } from '../manifest';
+import type { RsdoctorManifestWithShardingFiles } from '../manifest';
 
 /**
  * sdk hooks map

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ catalogs:
     '@rspack/core':
       specifier: ^2.1.5
       version: 2.1.5
+    '@rspack/lite-tapable':
+      specifier: ^1.1.2
+      version: 1.1.2
     '@rspack/plugin-react-refresh':
       specifier: ^2.0.2
       version: 2.0.2
@@ -66,9 +69,6 @@ catalogs:
     '@types/react-dom':
       specifier: ^19.2.3
       version: 19.2.3
-    '@types/tapable':
-      specifier: 2.3.0
-      version: 2.3.0
     antd:
       specifier: 5.19.1
       version: 5.19.1
@@ -616,6 +616,9 @@ importers:
       '@rsdoctor/shared':
         specifier: workspace:*
         version: link:../shared
+      '@rspack/lite-tapable':
+        specifier: 'catalog:'
+        version: 1.1.2
       '@types/estree':
         specifier: 'catalog:'
         version: 1.0.5
@@ -682,9 +685,6 @@ importers:
       source-map:
         specifier: 'catalog:'
         version: 0.7.6
-      tapable:
-        specifier: 2.3.3
-        version: 2.3.3
       ws:
         specifier: 8.21.1
         version: 8.21.1
@@ -713,15 +713,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.3
-      '@types/node-fetch':
-        specifier: ^2.6.13
-        version: 2.6.13
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
-      '@types/tapable':
-        specifier: 'catalog:'
-        version: 2.3.0
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -817,15 +811,15 @@ importers:
 
   packages/shared:
     dependencies:
+      '@rspack/lite-tapable':
+        specifier: 'catalog:'
+        version: 1.1.2
       '@types/connect':
         specifier: 'catalog:'
         version: 3.4.38
       '@types/estree':
         specifier: 'catalog:'
         version: 1.0.5
-      '@types/tapable':
-        specifier: 'catalog:'
-        version: 2.3.0
       buffer:
         specifier: 6.0.3
         version: 6.0.3
@@ -3073,9 +3067,6 @@ packages:
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
-  '@types/node-fetch@2.6.13':
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
-
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -3436,9 +3427,6 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -3718,10 +3706,6 @@ packages:
   colorjs.io@0.5.2:
     resolution: {integrity: sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==}
 
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -3978,10 +3962,6 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -4124,10 +4104,6 @@ packages:
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   es-toolkit@1.49.0:
@@ -4288,10 +4264,6 @@ packages:
 
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
-
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
-    engines: {node: '>= 6'}
 
   fs-extra@11.3.0:
     resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
@@ -9812,11 +9784,6 @@ snapshots:
 
   '@types/ms@0.7.34': {}
 
-  '@types/node-fetch@2.6.13':
-    dependencies:
-      '@types/node': 24.12.3
-      form-data: 4.0.4
-
   '@types/node@12.20.55': {}
 
   '@types/node@24.12.3':
@@ -10195,8 +10162,6 @@ snapshots:
 
   astring@1.9.0: {}
 
-  asynckit@0.4.0: {}
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.0.0
@@ -10485,10 +10450,6 @@ snapshots:
 
   colorjs.io@0.5.2: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
@@ -10766,8 +10727,6 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  delayed-stream@1.0.0: {}
-
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -10922,13 +10881,6 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.4
 
   es-toolkit@1.49.0: {}
 
@@ -11134,14 +11086,6 @@ snapshots:
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
-
-  form-data@4.0.4:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.4
-      mime-types: 2.1.35
 
   fs-extra@11.3.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ catalogs:
 
 overrides:
   '@remix-run/router': 1.23.3
-  '@rspack/lite-tapable': 1.1.3
+  '@rspack/lite-tapable': 1.1.4
   call-bind-apply-helpers: 1.0.2
   es-object-atoms: 1.1.2
   get-intrinsic: 1.3.0
@@ -615,8 +615,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@rspack/lite-tapable':
-        specifier: 1.1.3
-        version: 1.1.3
+        specifier: 1.1.4
+        version: 1.1.4
       '@types/estree':
         specifier: 'catalog:'
         version: 1.0.5
@@ -810,8 +810,8 @@ importers:
   packages/shared:
     dependencies:
       '@rspack/lite-tapable':
-        specifier: 1.1.3
-        version: 1.1.3
+        specifier: 1.1.4
+        version: 1.1.4
       '@types/connect':
         specifier: 'catalog:'
         version: 3.4.38
@@ -2693,8 +2693,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/lite-tapable@1.1.3':
-    resolution: {integrity: sha512-Vzr3N3fJ25s4ZYPLAs2Qoqvl+z1JpvPWD2EJO1EyMrpmUCWf8SruDXr7KuebjIP0xYjyeLScBxIWnCEFxuCVnA==}
+  '@rspack/lite-tapable@1.1.4':
+    resolution: {integrity: sha512-ZXl+NUVMkLCmi5aLXgM9I8EQ4/UH4tfhQHuZhwKSR8MUOVT1q/LuFs8No4B0UZ512WGruEUhq4FjW3yheKvIhg==}
 
   '@rspack/plugin-react-refresh@2.0.0':
     resolution: {integrity: sha512-Cf6CxBStNDJbiXMc/GmsvG1G8PRlUpa0MSfWsMTI+e8npzuTN/p8nwLs3shriBZOLciqgkSZpBtPTd10BLpj1g==}
@@ -9269,7 +9269,7 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
-  '@rspack/lite-tapable@1.1.3': {}
+  '@rspack/lite-tapable@1.1.4': {}
 
   '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
     dependencies:
@@ -13948,7 +13948,7 @@ snapshots:
 
   ts-checker-rspack-plugin@1.5.1(@rspack/core@2.1.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@7.0.2):
     dependencies:
-      '@rspack/lite-tapable': 1.1.3
+      '@rspack/lite-tapable': 1.1.4
       chokidar: 3.6.0
       memfs: 4.57.8(tslib@2.8.1)
       picocolors: 1.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,9 +39,6 @@ catalogs:
     '@rspack/core':
       specifier: ^2.1.5
       version: 2.1.5
-    '@rspack/lite-tapable':
-      specifier: ^1.1.2
-      version: 1.1.2
     '@rspack/plugin-react-refresh':
       specifier: ^2.0.2
       version: 2.0.2
@@ -120,6 +117,7 @@ catalogs:
 
 overrides:
   '@remix-run/router': 1.23.3
+  '@rspack/lite-tapable': 1.1.3
   call-bind-apply-helpers: 1.0.2
   es-object-atoms: 1.1.2
   get-intrinsic: 1.3.0
@@ -617,8 +615,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@rspack/lite-tapable':
-        specifier: 'catalog:'
-        version: 1.1.2
+        specifier: 1.1.3
+        version: 1.1.3
       '@types/estree':
         specifier: 'catalog:'
         version: 1.0.5
@@ -812,8 +810,8 @@ importers:
   packages/shared:
     dependencies:
       '@rspack/lite-tapable':
-        specifier: 'catalog:'
-        version: 1.1.2
+        specifier: 1.1.3
+        version: 1.1.3
       '@types/connect':
         specifier: 'catalog:'
         version: 3.4.38
@@ -2695,8 +2693,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/lite-tapable@1.1.2':
-    resolution: {integrity: sha512-1OnyWChLGE46YzWyjlmYJssOu/Y0STAnnr2ueKPqDCYTf63GJMs0mxNnCul4dNiVqHYPKv3/fxrTY3IpqoVwZQ==}
+  '@rspack/lite-tapable@1.1.3':
+    resolution: {integrity: sha512-Vzr3N3fJ25s4ZYPLAs2Qoqvl+z1JpvPWD2EJO1EyMrpmUCWf8SruDXr7KuebjIP0xYjyeLScBxIWnCEFxuCVnA==}
 
   '@rspack/plugin-react-refresh@2.0.0':
     resolution: {integrity: sha512-Cf6CxBStNDJbiXMc/GmsvG1G8PRlUpa0MSfWsMTI+e8npzuTN/p8nwLs3shriBZOLciqgkSZpBtPTd10BLpj1g==}
@@ -9271,7 +9269,7 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
-  '@rspack/lite-tapable@1.1.2': {}
+  '@rspack/lite-tapable@1.1.3': {}
 
   '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
     dependencies:
@@ -13950,7 +13948,7 @@ snapshots:
 
   ts-checker-rspack-plugin@1.5.1(@rspack/core@2.1.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@7.0.2):
     dependencies:
-      '@rspack/lite-tapable': 1.1.2
+      '@rspack/lite-tapable': 1.1.3
       chokidar: 3.6.0
       memfs: 4.57.8(tslib@2.8.1)
       picocolors: 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ catalog:
   '@rslint/core': ^0.6.5
   '@rspack/cli': ^2.0.8
   '@rspack/core': ^2.1.5
+  '@rspack/lite-tapable': ^1.1.2
   '@rspack/plugin-react-refresh': ^2.0.2
   '@rspack/resolver': ^0.2.8
   '@rstest/core': 0.11.4
@@ -33,7 +34,6 @@ catalog:
   '@types/path-browserify': 1.0.3
   '@types/react': ^19.2.17
   '@types/react-dom': ^19.2.3
-  '@types/tapable': 2.3.0
   '@typescript/native-preview': 7.0.0-dev.20260707.2
   antd: 5.19.1
   clsx: ^2.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ catalog:
   '@rslint/core': ^0.6.5
   '@rspack/cli': ^2.0.8
   '@rspack/core': ^2.1.5
-  '@rspack/lite-tapable': ^1.1.3
+  '@rspack/lite-tapable': ^1.1.4
   '@rspack/plugin-react-refresh': ^2.0.2
   '@rspack/resolver': ^0.2.8
   '@rstest/core': 0.11.4
@@ -72,7 +72,7 @@ minimumReleaseAgeExclude:
 
 overrides:
   '@remix-run/router': 1.23.3
-  '@rspack/lite-tapable': 1.1.3
+  '@rspack/lite-tapable': 1.1.4
   call-bind-apply-helpers: 1.0.2
   es-object-atoms: 1.1.2
   get-intrinsic: 1.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ catalog:
   '@rslint/core': ^0.6.5
   '@rspack/cli': ^2.0.8
   '@rspack/core': ^2.1.5
-  '@rspack/lite-tapable': ^1.1.2
+  '@rspack/lite-tapable': ^1.1.3
   '@rspack/plugin-react-refresh': ^2.0.2
   '@rspack/resolver': ^0.2.8
   '@rstest/core': 0.11.4
@@ -72,6 +72,7 @@ minimumReleaseAgeExclude:
 
 overrides:
   '@remix-run/router': 1.23.3
+  '@rspack/lite-tapable': 1.1.3
   call-bind-apply-helpers: 1.0.2
   es-object-atoms: 1.1.2
   get-intrinsic: 1.3.0


### PR DESCRIPTION
## Summary

- Replace `tapable` and `@types/tapable` with `@rspack/lite-tapable` across core, shared types, and related tests.
- Remove the unused `@types/node-fetch` development dependency.

## Related Links

- [`@rspack/lite-tapable`](https://www.npmjs.com/package/@rspack/lite-tapable)