### PR TITLE
fix(core): use rspack compiler API

### DIFF
--- a/packages/core/src/inner-plugins/plugins/loader.ts
+++ b/packages/core/src/inner-plugins/plugins/loader.ts
@@ -156,7 +156,7 @@ export class InternalLoaderPlugin<
           }
         };
 
-      const loaderHook = compiler.webpack.NormalModule.getCompilationHooks(
+      const loaderHook = compiler.rspack.NormalModule.getCompilationHooks(
         compilation as Plugin.BaseCompilationType<'rspack'>,
       ).loader;
       const interceptor: Parameters<typeof loaderHook.intercept>[0] = {

--- a/packages/core/src/inner-plugins/plugins/progress.ts
+++ b/packages/core/src/inner-plugins/plugins/progress.ts
@@ -16,28 +16,26 @@ export class InternalProgressPlugin<
 
   public apply(compiler: T): void {
     const { sdk, currentProgress } = this;
-    if (compiler.rspack && compiler.rspack.ProgressPlugin) {
-      const progress = new compiler.rspack.ProgressPlugin(
-        (percentage: number, msg: string) => {
-          currentProgress.percentage = percentage;
-          currentProgress.message = msg || '';
+    const progress = new compiler.rspack.ProgressPlugin(
+      (percentage: number, msg: string) => {
+        currentProgress.percentage = percentage;
+        currentProgress.message = msg || '';
 
-          const api = SDK.ServerAPI.APIExtends
-            .GetCompileProgress as unknown as SDK.ServerAPI.API;
-          try {
-            sdk.server.sendAPIDataToClient(api, {
-              req: {
-                api,
-                body: undefined,
-              },
-              res: currentProgress,
-            });
-          } catch (e: any) {
-            logger.debug(e);
-          }
-        },
-      );
-      progress.apply(compiler);
-    }
+        const api = SDK.ServerAPI.APIExtends
+          .GetCompileProgress as unknown as SDK.ServerAPI.API;
+        try {
+          sdk.server.sendAPIDataToClient(api, {
+            req: {
+              api,
+              body: undefined,
+            },
+            res: currentProgress,
+          });
+        } catch (e: any) {
+          logger.debug(e);
+        }
+      },
+    );
+    progress.apply(compiler);
   }
 }

--- a/packages/core/src/inner-plugins/plugins/progress.ts
+++ b/packages/core/src/inner-plugins/plugins/progress.ts
@@ -16,8 +16,8 @@ export class InternalProgressPlugin<
 
   public apply(compiler: T): void {
     const { sdk, currentProgress } = this;
-    if (compiler.webpack && compiler.webpack.ProgressPlugin) {
-      const progress = new compiler.webpack.ProgressPlugin(
+    if (compiler.rspack && compiler.rspack.ProgressPlugin) {
+      const progress = new compiler.rspack.ProgressPlugin(
         (percentage: number, msg: string) => {
           currentProgress.percentage = percentage;
           currentProgress.message = msg || '';

--- a/packages/core/src/inner-plugins/plugins/rspack.ts
+++ b/packages/core/src/inner-plugins/plugins/rspack.ts
@@ -21,7 +21,7 @@ export interface RspackNativeGraphState {
 export function getRspackNativePlugin(
   compiler: Plugin.BaseCompiler,
 ): typeof experiments.RsdoctorPlugin {
-  const RsdoctorRspackPlugin = compiler.webpack.experiments?.RsdoctorPlugin;
+  const RsdoctorRspackPlugin = compiler.rspack.experiments?.RsdoctorPlugin;
   if (!RsdoctorRspackPlugin) {
     throw new Error(
       '[RsdoctorRspackPlugin] The current Rspack version does not provide experiments.RsdoctorPlugin. Please upgrade Rspack.',

--- a/packages/core/src/rspack-plugin/plugin.ts
+++ b/packages/core/src/rspack-plugin/plugin.ts
@@ -276,7 +276,7 @@ export class RsdoctorRspackPlugin<
       const configuration = processCompilerConfig(compiler.options);
 
       const rspackVersion =
-        compiler.webpack?.rspackVersion || compiler.webpack?.version;
+        compiler.rspack.rspackVersion || compiler.rspack.version;
 
       // Save Rspack configuration to sdk.
       this.sdk.reportConfiguration({

--- a/packages/core/src/rspack-plugin/plugin.ts
+++ b/packages/core/src/rspack-plugin/plugin.ts
@@ -275,8 +275,7 @@ export class RsdoctorRspackPlugin<
       // Use extracted common function to process configuration
       const configuration = processCompilerConfig(compiler.options);
 
-      const rspackVersion =
-        compiler.rspack.rspackVersion || compiler.rspack.version;
+      const { rspackVersion } = compiler.rspack;
 
       // Save Rspack configuration to sdk.
       this.sdk.reportConfiguration({

--- a/packages/core/tests/rspack-plugin/native-plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/native-plugin.test.ts
@@ -29,7 +29,7 @@ function createHarness() {
     getCompilationHooks: () => nativeHooks,
   };
   const compiler = {
-    webpack: {
+    rspack: {
       experiments: {
         RsdoctorPlugin,
       },
@@ -83,7 +83,7 @@ describe('Rspack native graph collection', () => {
   it('requires the Rspack Rsdoctor native plugin', () => {
     expect(() =>
       getRspackNativePlugin({
-        webpack: {
+        rspack: {
           experiments: {},
         },
       } as unknown as Plugin.BaseCompiler),


### PR DESCRIPTION
## Summary

- Replace legacy `compiler.webpack` accesses with `compiler.rspack` for Rspack APIs and version metadata.
- Update the native plugin test fixtures to exercise the `compiler.rspack` path.