### PR TITLE
feat: require Rspack 2.x for Rsdoctor 2.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -172,7 +172,7 @@
     "@types/ws": "^8.18.1"
   },
   "peerDependencies": {
-    "@rspack/core": ">=1.2.3"
+    "@rspack/core": "^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rspack/core": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -76,7 +76,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@rspack/core": "*"
+    "@rspack/core": "^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rspack/core": {


### PR DESCRIPTION
## Summary

- Rsdoctor 2.0 depends on Rspack APIs available only in Rspack 2.x.
- Restrict the optional `@rspack/core` peer dependency to `^2.0.0` in `@rsdoctor/core` and `@rsdoctor/shared` so package managers can identify incompatible installations.