### PR TITLE
refactor(core): nest gzip options under supports

### DIFF
--- a/packages/core/src/build-utils/build/chunks/assetsModules.ts
+++ b/packages/core/src/build-utils/build/chunks/assetsModules.ts
@@ -2,10 +2,14 @@ import { Chunks } from '@rsdoctor/core/graph';
 import { parseBundle } from '../utils';
 import { SDK } from '@rsdoctor/shared/types';
 
-export interface GzipOptions {
-  enabled: boolean;
-  level: number;
-}
+export type GzipOptions =
+  | {
+      enabled: false;
+    }
+  | {
+      enabled: true;
+      level: number;
+    };
 
 /**
  * Collects module size data from bundle assets, using source maps when available
@@ -38,7 +42,7 @@ export async function getAssetsModulesData(
     {
       ...(hasParseBundle ? { parseBundle } : {}),
       gzip: gzipOptions?.enabled,
-      gzipLevel: gzipOptions?.level,
+      gzipLevel: gzipOptions?.enabled ? gzipOptions.level : undefined,
     },
     sourceMapSets,
     assetsWithoutSourceMap,

--- a/packages/core/src/inner-plugins/plugins/bundle.ts
+++ b/packages/core/src/inner-plugins/plugins/bundle.ts
@@ -81,7 +81,6 @@ export class InternalBundlePlugin<
           this.map,
           this.scheduler.chunkGraph,
           this.scheduler.options?.supports,
-          this.scheduler.options?.gzipLevel,
         );
       }
 

--- a/packages/core/src/inner-plugins/plugins/bundle.ts
+++ b/packages/core/src/inner-plugins/plugins/bundle.ts
@@ -80,7 +80,7 @@ export class InternalBundlePlugin<
         Chunks.assetsContents(
           this.map,
           this.scheduler.chunkGraph,
-          this.scheduler.options?.supports,
+          this.scheduler.options.supports.gzip,
         );
       }
 

--- a/packages/core/src/inner-plugins/plugins/ensureModulesChunkGraph.ts
+++ b/packages/core/src/inner-plugins/plugins/ensureModulesChunkGraph.ts
@@ -116,6 +116,7 @@ async function doneHandler(
    * Optionally parses bundle if enabled in options.
    */
   const shouldParseBundle = _this.options.supports.parseBundle !== false;
+  const gzip = _this.options.supports.gzip;
   await getModulesInfos(
     compiler,
     _this.modulesGraph,
@@ -123,10 +124,9 @@ async function doneHandler(
     shouldParseBundle,
     _this.sourceMapSets,
     _this.assetsWithoutSourceMap,
-    {
-      enabled: _this.options.supports.gzip !== false,
-      level: _this.options.gzipLevel,
-    },
+    gzip === false
+      ? { enabled: false }
+      : { enabled: true, level: gzip.gzipLevel },
   );
 
   // Report graphs to SDK for further processing or client display

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -25,22 +25,39 @@ function getDefaultOutput() {
 function getDefaultSupports() {
   return {
     parseBundle: true,
-    gzip: true, // change the gzip to true by default.
   };
 }
 function isJsonOutputEnv(value: unknown): boolean {
   return value === 'json';
 }
 function normalizeGzipLevel(value: unknown): number {
-  const gzipLevel = value ?? 9;
+  const gzipLevel = value === undefined ? 9 : value;
   assert(
     typeof gzipLevel === 'number' &&
       Number.isInteger(gzipLevel) &&
       gzipLevel >= 0 &&
       gzipLevel <= 9,
-    '`gzipLevel` must be an integer between 0 and 9.',
+    '`supports.gzip.gzipLevel` must be an integer between 0 and 9.',
   );
   return gzipLevel;
+}
+function normalizeGzip(value: unknown): false | { gzipLevel: number } {
+  assert(
+    value === undefined ||
+      typeof value === 'boolean' ||
+      (typeof value === 'object' && value !== null && !Array.isArray(value)),
+    '`supports.gzip` must be a boolean or an object.',
+  );
+  if (value === false) {
+    return false;
+  }
+  const gzipLevel =
+    typeof value === 'object' && value !== null
+      ? (value as { gzipLevel?: unknown }).gzipLevel
+      : undefined;
+  return {
+    gzipLevel: normalizeGzipLevel(gzipLevel),
+  };
 }
 function normalizeFeatures(features: any, mode: keyof typeof SDK.IMode) {
   if (Array.isArray(features)) {
@@ -107,15 +124,17 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     innerClientPath = '',
     output = outputConfig,
     supports: userSupports = {},
-    gzipLevel: userGzipLevel,
     port,
     server: userServer = {},
     printLog = { serverUrls: true },
     mode = undefined,
     brief = undefined,
   } = normalizedConfig;
-  const supports = { ...getDefaultSupports(), ...userSupports };
-  const gzipLevel = normalizeGzipLevel(userGzipLevel);
+  const supports = {
+    ...getDefaultSupports(),
+    ...userSupports,
+    gzip: normalizeGzip(userSupports.gzip),
+  };
   // If process.env.RSTEST is set to true, disableClientServer should be false
   // Otherwise, if process.env.CI is set, disableClientServer should be true
   const disableClientServer =
@@ -193,7 +212,6 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     },
     innerClientPath,
     supports,
-    gzipLevel,
     port,
     server,
     printLog,

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -41,7 +41,7 @@ function normalizeGzipLevel(value: unknown): number {
   );
   return gzipLevel;
 }
-function normalizeGzip(value: unknown): false | { gzipLevel: number } {
+function normalizeGzip(value: unknown): Plugin.NormalizedGzipConfig {
   assert(
     value === undefined ||
       typeof value === 'boolean' ||

--- a/packages/core/tests/build/utils/config.test.ts
+++ b/packages/core/tests/build/utils/config.test.ts
@@ -107,30 +107,87 @@ describe('normalizeUserConfig', () => {
 
   it('should use default supports when not provided', () => {
     const result = normalizeUserConfig();
-    expect(result.supports.gzip).toEqual(true);
+    expect(result.supports.gzip).toEqual({ gzipLevel: 9 });
     expect(result.supports.parseBundle).toEqual(true);
-    expect(result.gzipLevel).toBe(9);
   });
 
-  it('should respect custom supports', () => {
-    const customSupports = {
+  it('should normalize enabled gzip support with the default level', () => {
+    const result = normalizeUserConfig({
+      supports: {
+        gzip: true,
+      },
+    });
+    expect(result.supports.gzip).toEqual({ gzipLevel: 9 });
+  });
+
+  it('should normalize an empty gzip config with the default level', () => {
+    const result = normalizeUserConfig({
+      supports: {
+        gzip: {},
+      },
+    });
+    expect(result.supports.gzip).toEqual({ gzipLevel: 9 });
+  });
+
+  it('should respect disabled gzip support', () => {
+    const result = normalizeUserConfig({
+      supports: {
+        gzip: false,
+      },
+    });
+    expect(result.supports.gzip).toBe(false);
+  });
+
+  it('should respect other custom supports', () => {
+    const result = normalizeUserConfig({
+      supports: {
+        gzip: {
+          gzipLevel: 6,
+        },
+        parseBundle: false,
+      },
+    });
+    expect(result.supports).toEqual({
       parseBundle: false,
-      gzip: true,
-    };
-    const result = normalizeUserConfig({ supports: customSupports });
-    expect(result.supports).toEqual(customSupports);
+      gzip: { gzipLevel: 6 },
+    });
   });
 
   it.each([0, 6, 9])('should respect gzip level %s', (gzipLevel) => {
-    expect(normalizeUserConfig({ gzipLevel }).gzipLevel).toBe(gzipLevel);
+    expect(
+      normalizeUserConfig({
+        supports: {
+          gzip: { gzipLevel },
+        },
+      }).supports.gzip,
+    ).toEqual({ gzipLevel });
   });
 
-  it.each([-1, 1.5, 10, Number.NaN])(
+  it.each([-1, 1.5, 10, Number.NaN, null])(
     'should reject invalid gzip level %s',
     (gzipLevel) => {
-      expect(() => normalizeUserConfig({ gzipLevel })).toThrow(
-        '`gzipLevel` must be an integer between 0 and 9.',
+      expect(() =>
+        normalizeUserConfig({
+          supports: {
+            gzip: { gzipLevel } as never,
+          },
+        }),
+      ).toThrow(
+        '`supports.gzip.gzipLevel` must be an integer between 0 and 9.',
       );
+    },
+  );
+
+  it.each([[null], [1], ['true'], [[]]])(
+    'should reject invalid gzip support %s',
+    (gzip) => {
+      expect(() =>
+        normalizeUserConfig({
+          supports: {
+            gzip: gzip as never,
+          },
+        }),
+      ).toThrow('`supports.gzip` must be a boolean or an object.');
     },
   );
 

--- a/packages/core/tests/graph/gzip.test.ts
+++ b/packages/core/tests/graph/gzip.test.ts
@@ -31,8 +31,7 @@ describe('gzip size collection', () => {
     Chunks.assetsContents(
       new Map([['index.js', { content: source }]]),
       chunkGraph,
-      { gzip: true },
-      1,
+      { gzip: { gzipLevel: 1 } },
     );
 
     expect(asset.gzipSize).toBe(gzipSync(source, { level: 1 }).length);
@@ -47,7 +46,6 @@ describe('gzip size collection', () => {
       new Map([['index.js', { content: source }]]),
       chunkGraph,
       { gzip: false },
-      1,
     );
 
     expect(asset.gzipSize).toBeUndefined();

--- a/packages/core/tests/graph/gzip.test.ts
+++ b/packages/core/tests/graph/gzip.test.ts
@@ -7,6 +7,7 @@ import {
   Module,
   ModuleGraph,
 } from '@rsdoctor/shared/graph';
+import { normalizeUserConfig } from '../../src/inner-plugins/utils/config';
 
 const source = `
   export const values = [${Array.from({ length: 1_000 }, (_, index) => index % 17).join(',')}];
@@ -23,15 +24,37 @@ function createModuleGraph() {
 }
 
 describe('gzip size collection', () => {
+  it('uses the normalized default gzip level for assets', () => {
+    const chunkGraph = new ChunkGraph();
+    const asset = new Asset('index.js', source.length, [], '');
+    chunkGraph.addAsset(asset);
+
+    const gzip = normalizeUserConfig({
+      supports: { gzip: true },
+    }).supports.gzip;
+
+    Chunks.assetsContents(
+      new Map([['index.js', { content: source }]]),
+      chunkGraph,
+      gzip,
+    );
+
+    expect(asset.gzipSize).toBe(gzipSync(source, { level: 9 }).length);
+  });
+
   it('uses the configured gzip level for assets', () => {
     const chunkGraph = new ChunkGraph();
     const asset = new Asset('index.js', source.length, [], '');
     chunkGraph.addAsset(asset);
 
+    const gzip = normalizeUserConfig({
+      supports: { gzip: { gzipLevel: 1 } },
+    }).supports.gzip;
+
     Chunks.assetsContents(
       new Map([['index.js', { content: source }]]),
       chunkGraph,
-      { gzip: { gzipLevel: 1 } },
+      gzip,
     );
 
     expect(asset.gzipSize).toBe(gzipSync(source, { level: 1 }).length);
@@ -42,10 +65,14 @@ describe('gzip size collection', () => {
     const asset = new Asset('index.js', source.length, [], '');
     chunkGraph.addAsset(asset);
 
+    const gzip = normalizeUserConfig({
+      supports: { gzip: false },
+    }).supports.gzip;
+
     Chunks.assetsContents(
       new Map([['index.js', { content: source }]]),
       chunkGraph,
-      { gzip: false },
+      gzip,
     );
 
     expect(asset.gzipSize).toBeUndefined();

--- a/packages/core/tests/rspack-plugin/native-plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/native-plugin.test.ts
@@ -54,6 +54,9 @@ function createHarness() {
       supports: {
         parseBundle: false,
         generateTileGraph: false,
+        gzip: {
+          gzipLevel: 9,
+        },
       },
     },
     sdk: {

--- a/packages/shared/src/graph/transform/chunks/assetsContent.ts
+++ b/packages/shared/src/graph/transform/chunks/assetsContent.ts
@@ -1,5 +1,4 @@
 import { SDK, Plugin } from '../../../types';
-import { DEFAULT_GZIP_LEVEL } from '../../../common/gzip';
 
 const COMPRESSIBLE_REGEX =
   /\.(?:js|css|html|json|svg|txt|xml|xhtml|wasm|manifest)$/i;
@@ -8,8 +7,8 @@ export function assetsContents(
   assetMap: Map<string, { content: string }>,
   chunkGraph: SDK.ChunkGraphInstance,
   supports: Plugin.RsdoctorPluginOptionsNormalized['supports'],
-  gzipLevel = DEFAULT_GZIP_LEVEL,
 ) {
+  const gzip = supports.gzip;
   const assets = chunkGraph.getAssets();
   assets.forEach((asset) => {
     const { content = '' } = assetMap.get(asset.path) || {};
@@ -17,8 +16,8 @@ export function assetsContents(
     if (content.length > 0 && asset.size === 0) {
       asset.size = Buffer.byteLength(content, 'utf8');
     }
-    if (COMPRESSIBLE_REGEX.test(asset.path) && supports?.gzip) {
-      asset.setGzipSize(content, gzipLevel);
+    if (COMPRESSIBLE_REGEX.test(asset.path) && gzip !== false) {
+      asset.setGzipSize(content, gzip.gzipLevel);
     }
   });
 }

--- a/packages/shared/src/graph/transform/chunks/assetsContent.ts
+++ b/packages/shared/src/graph/transform/chunks/assetsContent.ts
@@ -6,9 +6,8 @@ const COMPRESSIBLE_REGEX =
 export function assetsContents(
   assetMap: Map<string, { content: string }>,
   chunkGraph: SDK.ChunkGraphInstance,
-  supports: Plugin.RsdoctorPluginOptionsNormalized['supports'],
+  gzip: Plugin.NormalizedGzipConfig,
 ) {
-  const gzip = supports.gzip;
   const assets = chunkGraph.getAssets();
   assets.forEach((asset) => {
     const { content = '' } = assetMap.get(asset.path) || {};

--- a/packages/shared/src/types/plugin/plugin.ts
+++ b/packages/shared/src/types/plugin/plugin.ts
@@ -63,14 +63,22 @@ export interface RsdoctorPluginOptionsNormalized<
   supports: NormalizedSupports;
 }
 
-interface GzipConfig {
-  /**
-   * Gzip compression level used to calculate asset and module gzip sizes.
-   * Must be an integer between 0 and 9.
-   * @default 9
-   */
-  gzipLevel?: number;
-}
+export type GzipConfig =
+  | boolean
+  | {
+      /**
+       * Gzip compression level used to calculate asset and module gzip sizes.
+       * Must be an integer between 0 and 9.
+       * @default 9
+       */
+      gzipLevel?: number;
+    };
+
+export type NormalizedGzipConfig =
+  | false
+  | {
+      gzipLevel: number;
+    };
 
 interface ISupport {
   parseBundle?: boolean;
@@ -81,11 +89,11 @@ interface ISupport {
    * compression level, or an object to configure `gzipLevel`.
    * @default true
    */
-  gzip?: boolean | GzipConfig;
+  gzip?: GzipConfig;
 }
 
 type NormalizedSupports = Omit<ISupport, 'gzip'> & {
-  gzip: false | Required<GzipConfig>;
+  gzip: NormalizedGzipConfig;
 };
 
 interface OutputBaseConfig {

--- a/packages/shared/src/types/plugin/plugin.ts
+++ b/packages/shared/src/types/plugin/plugin.ts
@@ -60,18 +60,33 @@ export interface RsdoctorPluginOptionsNormalized<
   };
   port?: number;
   server: SDK.RsdoctorServerConfig;
-  supports: ISupport;
+  supports: NormalizedSupports;
+}
+
+interface GzipConfig {
+  /**
+   * Gzip compression level used to calculate asset and module gzip sizes.
+   * Must be an integer between 0 and 9.
+   * @default 9
+   */
+  gzipLevel?: number;
 }
 
 interface ISupport {
   parseBundle?: boolean;
   generateTileGraph?: boolean;
   /**
-   * Whether to calculate gzip sizes for assets and modules.
+   * Whether and how to calculate gzip sizes for assets and modules.
+   * Set to `false` to disable gzip calculation, `true` to use the default
+   * compression level, or an object to configure `gzipLevel`.
    * @default true
    */
-  gzip?: boolean;
+  gzip?: boolean | GzipConfig;
 }
+
+type NormalizedSupports = Omit<ISupport, 'gzip'> & {
+  gzip: false | Required<GzipConfig>;
+};
 
 interface OutputBaseConfig {
   /**
@@ -145,13 +160,6 @@ export interface RsdoctorRspackPluginOptions<
 
   /** Whether to turn on specific analysis capabilities. */
   supports?: ISupport;
-
-  /**
-   * Gzip compression level used to calculate asset and module gzip sizes.
-   * Must be an integer between 0 and 9.
-   * @default 9
-   */
-  gzipLevel?: number;
 
   /**
    * The port of the Rsdoctor server.


### PR DESCRIPTION
## Summary

This PR moves `gzipLevel` into `supports.gzip` so gzip enablement and compression settings share a single public configuration. `supports.gzip` now accepts a boolean or `{ gzipLevel }`, defaults to enabled at level 9, and normalizes to a resolved configuration used consistently by asset and module gzip calculations.

## Related Links

- https://github.com/web-infra-dev/rsdoctor/issues/1816
- https://github.com/web-infra-dev/rsdoctor/pull/1861