### PR TITLE
perf(core): reduce install size with prebundling

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,6 @@
   },
   "dependencies": {
     "@babel/code-frame": "7.26.2",
-    "@rsbuild/plugin-check-syntax": "catalog:",
     "@rspack/lite-tapable": "catalog:",
     "@rsdoctor/shared": "workspace:*",
     "@types/estree": "catalog:",
@@ -53,11 +52,11 @@
     "acorn-import-attributes": "^1.9.5",
     "acorn-walk": "8.3.5",
     "browserslist-load-config": "^1.0.3",
+    "caniuse-lite": "^1.0.30001792",
     "connect": "3.7.0",
     "envinfo": "7.21.0",
     "fs-extra": "catalog:",
     "get-port": "5.1.1",
-    "json-stream-stringify": "3.0.1",
     "lines-and-columns": "2.0.4",
     "open": "^11.0.0",
     "raw-body": "3.0.2",
@@ -71,6 +70,7 @@
     "ws": "8.21.1"
   },
   "devDependencies": {
+    "@rsbuild/plugin-check-syntax": "catalog:",
     "@rspack/core": "catalog:",
     "@scripts/test-helper": "workspace:*",
     "@types/babel__code-frame": "7.27.0",
@@ -81,6 +81,7 @@
     "@types/semver": "^7.7.1",
     "babel-loader": "10.1.1",
     "filesize": "catalog:",
+    "json-stream-stringify": "3.0.1",
     "string-loader": "0.0.1",
     "ts-loader": "^9.6.2",
     "tslib": "catalog:",

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -1,5 +1,13 @@
 import { defineConfig } from '@rslib/core';
+import { fileURLToPath } from 'node:url';
 import { esmConfig, pluginsConfig } from '../../scripts/rslib.base.config';
+
+const htmlParserStub = fileURLToPath(
+  new URL(
+    './src/rules/rules/ecma-version-check/htmlParserStub.ts',
+    import.meta.url,
+  ),
+);
 
 const externals = [
   '@rsdoctor/client',
@@ -9,12 +17,20 @@ const externals = [
   '@rsdoctor/shared/graph',
   '@rsdoctor/shared/types',
   '@rspack/core',
+  /^caniuse-lite(?:\/|$)/,
   'lodash',
   'semver',
   'source-map',
 ];
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // This rule always passes JavaScript source to CheckSyntax, so its HTML
+      // parser branch is unreachable and should not inflate the core bundle.
+      htmlparser2: htmlParserStub,
+    },
+  },
   lib: [
     {
       ...esmConfig,

--- a/packages/core/src/rules/rules/ecma-version-check/htmlParserStub.ts
+++ b/packages/core/src/rules/rules/ecma-version-check/htmlParserStub.ts
@@ -1,0 +1,5 @@
+export class Parser {
+  constructor() {
+    throw new Error('HTML parsing is not supported by ecma-version-check');
+  }
+}

--- a/packages/core/src/rules/rules/ecma-version-check/types.ts
+++ b/packages/core/src/rules/rules/ecma-version-check/types.ts
@@ -1,3 +1,14 @@
-import type { PluginCheckSyntaxOptions } from '@rsbuild/plugin-check-syntax';
+import type { ecmaVersion as EcmaVersion } from 'acorn';
 
-export type Config = PluginCheckSyntaxOptions;
+type Condition = string | RegExp | ((filepath: string) => boolean);
+type CheckSyntaxExclude = Condition | Condition[];
+type SyntaxErrorKey = 'source' | 'output' | 'reason' | 'code';
+
+export type Config = {
+  targets?: string[];
+  exclude?: CheckSyntaxExclude;
+  excludeOutput?: CheckSyntaxExclude;
+  excludeErrorMessage?: RegExp | RegExp[];
+  excludeErrorLogs?: SyntaxErrorKey[];
+  ecmaVersion?: EcmaVersion;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -590,9 +590,6 @@ importers:
       '@babel/code-frame':
         specifier: 7.26.2
         version: 7.26.2
-      '@rsbuild/plugin-check-syntax':
-        specifier: 'catalog:'
-        version: 1.6.1(@rsbuild/core@2.1.9)
       '@rsdoctor/client':
         specifier: workspace:*
         version: link:../client
@@ -617,6 +614,9 @@ importers:
       browserslist-load-config:
         specifier: ^1.0.3
         version: 1.0.3
+      caniuse-lite:
+        specifier: ^1.0.30001792
+        version: 1.0.30001792
       connect:
         specifier: 3.7.0
         version: 3.7.0
@@ -632,9 +632,6 @@ importers:
       get-port:
         specifier: 5.1.1
         version: 5.1.1
-      json-stream-stringify:
-        specifier: 3.0.1
-        version: 3.0.1
       launch-editor:
         specifier: ^2.14.1
         version: 2.14.1
@@ -663,6 +660,9 @@ importers:
         specifier: 8.21.1
         version: 8.21.1
     devDependencies:
+      '@rsbuild/plugin-check-syntax':
+        specifier: 'catalog:'
+        version: 1.6.1(@rsbuild/core@2.1.9)
       '@rspack/core':
         specifier: 'catalog:'
         version: 2.1.7(@swc/helpers@0.5.23)
@@ -699,6 +699,9 @@ importers:
       filesize:
         specifier: 'catalog:'
         version: 11.0.22
+      json-stream-stringify:
+        specifier: 3.0.1
+        version: 3.0.1
       string-loader:
         specifier: 0.0.1
         version: 0.0.1
@@ -3583,9 +3586,6 @@ packages:
 
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
-
-  caniuse-lite@1.0.30001762:
-    resolution: {integrity: sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==}
 
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
@@ -9907,7 +9907,7 @@ snapshots:
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.9.11
-      caniuse-lite: 1.0.30001762
+      caniuse-lite: 1.0.30001792
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
@@ -9971,8 +9971,6 @@ snapshots:
       caniuse-lite: 1.0.30001792
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
-
-  caniuse-lite@1.0.30001762: {}
 
   caniuse-lite@1.0.30001792: {}
 


### PR DESCRIPTION
## Summary

This PR reduces `@rsdoctor/core`'s third-party production install footprint by 26.6% (10.61 MB to 7.78 MB) by prebundling `@rsbuild/plugin-check-syntax`, `filesize`, and `json-stream-stringify`.
It keeps `caniuse-lite` as runtime data for dynamic Browserslist queries and replaces the unreachable HTML parser branch because E1004 only scans `.js` and `.bundle` assets.
There is no supported public behavior change; inline scripts in HTML were not part of E1004's existing scan path.