### PR TITLE
refactor: replace picocolors with rslog color

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,12 +32,12 @@
   "dependencies": {
     "@rsdoctor/core": "workspace:*",
     "@rsdoctor/shared": "workspace:*",
-    "ora": "^9.4.1"
+    "ora": "^9.4.1",
+    "rslog": "^2.1.3"
   },
   "devDependencies": {
     "cac": "^7.0.0",
-    "typescript": "catalog:",
-    "picocolors": "catalog:"
+    "typescript": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -6,7 +6,7 @@ import {
   SDK,
 } from '@rsdoctor/shared/types';
 import ora from 'ora';
-import { cyan, red } from 'picocolors';
+import { color } from 'rslog';
 import { Command } from '../types';
 import {
   enhanceCommand,
@@ -41,7 +41,7 @@ example: ${bin} ${Commands.Analyze} --profile "${Constants.RsdoctorOutputManifes
         .option('--port <number>', 'port for Rsdoctor Server');
     },
     async action({ profile, open = true, port, type = SDK.ToDataType.Normal }) {
-      const spinner = ora({ prefixText: cyan(`[${name}]`) }).start(
+      const spinner = ora({ prefixText: color.cyan(`[${name}]`) }).start(
         `start to loading "${profile}"`,
       );
 
@@ -67,7 +67,7 @@ example: ${bin} ${Commands.Analyze} --profile "${Constants.RsdoctorOutputManifes
             (url: string) => loadShardingFileWithSpinner(url, cwd, spinner),
           );
         } catch {
-          spinner.fail(red((error as Error).message));
+          spinner.fail(color.red((error as Error).message));
           throw error;
         }
       }
@@ -108,7 +108,7 @@ example: ${bin} ${Commands.Analyze} --profile "${Constants.RsdoctorOutputManifes
       }
 
       spinner.succeed(
-        `the local url: ${cyan(sdk.server.getClientUrl('homepage'))}`,
+        `the local url: ${color.cyan(sdk.server.getClientUrl('homepage'))}`,
       );
 
       return sdk;

--- a/packages/cli/src/commands/bundle-diff.ts
+++ b/packages/cli/src/commands/bundle-diff.ts
@@ -1,5 +1,5 @@
 import ora from 'ora';
-import { cyan, red } from 'picocolors';
+import { color } from 'rslog';
 import { Command } from '../types';
 import path from 'path';
 import fs from 'fs';
@@ -66,7 +66,7 @@ example: ${bin} ${Commands.BundleDiff} --baseline="x.json" --current="x.json"
     json = false,
     output, // ????
   }) {
-    const spinner = ora({ prefixText: cyan(`[${name}]`) }).start();
+    const spinner = ora({ prefixText: color.cyan(`[${name}]`) }).start();
 
     spinner.text = `loading "${baseline}"`;
     const baselineData = {
@@ -95,7 +95,7 @@ example: ${bin} ${Commands.BundleDiff} --baseline="x.json" --current="x.json"
           (url) => loadShardingFileWithSpinner(url, cwd, spinner),
         );
       } else {
-        spinner.fail(red((error as Error).message));
+        spinner.fail(color.red((error as Error).message));
         throw error;
       }
     }
@@ -127,14 +127,14 @@ example: ${bin} ${Commands.BundleDiff} --baseline="x.json" --current="x.json"
           (url) => loadShardingFileWithSpinner(url, cwd, spinner),
         );
       } else {
-        spinner.fail(red((error as Error).message));
+        spinner.fail(color.red((error as Error).message));
         throw error;
       }
     }
 
     if (json && html) {
       spinner.fail(
-        red(
+        color.red(
           'Options "--json" and "--html" cannot be used together. Please choose one.',
         ),
       );

--- a/packages/cli/src/commands/stats-analyze.ts
+++ b/packages/cli/src/commands/stats-analyze.ts
@@ -5,8 +5,8 @@ import {
   Manifest as ManifestType,
   SDK,
 } from '@rsdoctor/shared/types';
-import { cyan } from 'picocolors';
 import ora from 'ora';
+import { color } from 'rslog';
 import { Commands } from '../constants';
 import { Command } from '../types';
 import { enhanceCommand, readFile } from '../utils';
@@ -51,7 +51,7 @@ export const statsAnalyze: Command<
   },
   async action({ profile, open = true, port, type = SDK.ToDataType.Normal }) {
     const serverPort = coercePort(port);
-    const spinner = ora({ prefixText: cyan(`[${name}]`) }).start(
+    const spinner = ora({ prefixText: color.cyan(`[${name}]`) }).start(
       `start to loading "${profile}"`,
     );
     const statsStrings = await readFile(profile, cwd);
@@ -87,7 +87,7 @@ export const statsAnalyze: Command<
     }
 
     spinner.succeed(
-      `the local url: ${cyan(sdk.server.getClientUrl('homepage'))}`,
+      `the local url: ${color.cyan(sdk.server.getClientUrl('homepage'))}`,
     );
 
     return sdk;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
 import { cac } from 'cac';
-import { red } from 'picocolors';
+import { color } from 'rslog';
 import { Common } from '@rsdoctor/shared/types';
 import { analyze, bundleDiff } from './commands';
 import { Command, CommandContext, GetCommandArgumentsType } from './types';
@@ -48,7 +48,7 @@ function validateRequiredArgs(command: string, args: CommandArgs): void {
   if (isAnalyzeCommand(command)) {
     const analyzeArgs = args as AnalyzeArgs;
     if (!analyzeArgs.profile) {
-      logger.error(red(`❌ Missing required argument: --profile`));
+      logger.error(color.red(`❌ Missing required argument: --profile`));
       logger.info(`💡 Usage: ${bin} ${command} --profile <path>`);
       logger.info(`💡 Use --help to see all available options`);
       process.exit(1);
@@ -59,7 +59,7 @@ function validateRequiredArgs(command: string, args: CommandArgs): void {
     const bundleDiffArgs = args as BundleDiffArgs;
     if (!bundleDiffArgs.current || !bundleDiffArgs.baseline) {
       logger.error(
-        red(`❌ Missing required arguments: --current and --baseline`),
+        color.red(`❌ Missing required arguments: --current and --baseline`),
       );
       logger.info(
         `💡 Usage: ${bin} ${command} --current <path> --baseline <path>`,
@@ -72,7 +72,7 @@ function validateRequiredArgs(command: string, args: CommandArgs): void {
   if (isStatsAnalyzeCommand(command)) {
     const statsAnalyzeArgs = args as StatsAnalyzeArgs;
     if (!statsAnalyzeArgs.profile) {
-      logger.error(red(`❌ Missing required argument: --profile`));
+      logger.error(color.red(`❌ Missing required argument: --profile`));
       logger.info(`💡 Usage: ${bin} ${command} --profile <path>`);
       logger.info(`💡 Use --help to see all available options`);
       process.exit(1);
@@ -86,16 +86,16 @@ function handleCacError(error: Error): void {
 
   if (message.includes('value is missing')) {
     logger.error(
-      red(
+      color.red(
         `❌ Missing required argument. Please provide a value for the option.`,
       ),
     );
     logger.info(`💡 Use --help to see available options`);
   } else if (message.includes('Unknown option')) {
-    logger.error(red(`❌ Unknown option. Please check your command.`));
+    logger.error(color.red(`❌ Unknown option. Please check your command.`));
     logger.info(`💡 Use --help to see available options`);
   } else {
-    logger.error(red(`❌ ${message}`));
+    logger.error(color.red(`❌ ${message}`));
   }
 
   process.exit(1);
@@ -171,7 +171,7 @@ export async function execute(
         await action(args);
       } catch (error) {
         const { message, stack } = error as Error;
-        logger.error(red(stack || message));
+        logger.error(color.red(stack || message));
         process.exit(1);
       }
     });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,6 @@
     "json-stream-stringify": "3.0.1",
     "lines-and-columns": "2.0.4",
     "open": "^11.0.0",
-    "picocolors": "catalog:",
     "raw-body": "3.0.2",
     "rslog": "^2.1.3",
     "semver": "^7.8.5",

--- a/packages/core/src/error/error.ts
+++ b/packages/core/src/error/error.ts
@@ -3,11 +3,16 @@ import { codeFrameColumns } from '@babel/code-frame';
 import { isEqual } from '@rsdoctor/shared/collection';
 import { Lodash } from '@rsdoctor/shared/common-browser';
 import { Err, Rule } from '@rsdoctor/shared/types';
-import { createColors } from 'picocolors';
+import { color } from 'rslog';
 import { transform } from './transform';
 import { insertSpace, toLevel } from './utils';
 
 let id = 1;
+
+const stringify = (text: string | number) => String(text);
+const plainColor = Object.fromEntries(
+  Object.keys(color).map((key) => [key, stringify]),
+) as typeof color;
 
 export class DevToolError extends Error implements Err.DevToolErrorInstance {
   static from(err: unknown, opt?: Err.DevToolErrorParams): DevToolError {
@@ -87,7 +92,7 @@ export class DevToolError extends Error implements Err.DevToolErrorInstance {
     return this._codeFrame;
   }
 
-  private printCodeFrame(print: ReturnType<typeof createColors>) {
+  private printCodeFrame(print: typeof color) {
     const msgs: string[] = [];
     const { _codeFrame: codeFrameOpt, _controller: controller } = this;
 
@@ -180,7 +185,7 @@ export class DevToolError extends Error implements Err.DevToolErrorInstance {
       _controller: controller,
     } = this;
 
-    const print = createColors(!controller.noColor);
+    const print = controller.noColor ? plainColor : color;
 
     const mainColorPrint =
       this._level === Err.ErrorLevel.Error ? print.red : print.yellow;

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,5 +1,4 @@
-import c from 'picocolors';
-import { createLogger, logger } from 'rslog';
+import { color, createLogger, logger } from 'rslog';
 import { Constants } from '@rsdoctor/shared/types';
 
 /**
@@ -18,29 +17,29 @@ const rsdoctorLogger = createLogger();
 
 rsdoctorLogger.override({
   log: (message) => {
-    console.log(`${c.green('[RSDOCTOR LOG]')} ${message}`);
+    console.log(`${color.green('[RSDOCTOR LOG]')} ${message}`);
   },
   info: (message) => {
-    console.log(`${c.yellow('[RSDOCTOR INFO]')} ${message}`);
+    console.log(`${color.yellow('[RSDOCTOR INFO]')} ${message}`);
   },
   warn: (message) => {
-    console.warn(`${c.yellow('[RSDOCTOR WARN]')} ${message}`);
+    console.warn(`${color.yellow('[RSDOCTOR WARN]')} ${message}`);
   },
   start: (message) => {
-    console.log(`${c.green('[RSDOCTOR START]')} ${message}`);
+    console.log(`${color.green('[RSDOCTOR START]')} ${message}`);
   },
   ready: (message) => {
-    console.log(`${c.green('[RSDOCTOR READY]')} ${message}`);
+    console.log(`${color.green('[RSDOCTOR READY]')} ${message}`);
   },
   error: (message) => {
-    console.error(`${c.red('[RSDOCTOR ERROR]')} ${message}`);
+    console.error(`${color.red('[RSDOCTOR ERROR]')} ${message}`);
   },
   success: (message) => {
-    console.error(`${c.green('[RSDOCTOR SUCCESS]')} ${message}`);
+    console.error(`${color.green('[RSDOCTOR SUCCESS]')} ${message}`);
   },
   debug: (message) => {
     if (process.env.DEBUG) {
-      console.log(`${c.blue('[RSDOCTOR DEBUG]')} ${message}`);
+      console.log(`${color.blue('[RSDOCTOR DEBUG]')} ${message}`);
     }
   },
 });
@@ -78,4 +77,4 @@ function timeEnd(label: string) {
   _timers.delete(label);
 }
 
-export { time, timeEnd, c as chalk, rsdoctorLogger as logger };
+export { time, timeEnd, color as chalk, rsdoctorLogger as logger };

--- a/packages/core/tests/error/error.test.ts
+++ b/packages/core/tests/error/error.test.ts
@@ -29,4 +29,24 @@ describe('DevToolError', () => {
     expect(createError(7).isSame(createError(7))).toBe(true);
     expect(createError(7).isSame(createError(8))).toBe(false);
   });
+
+  it('disables all styling when noColor is enabled', () => {
+    const error = new DevToolError('title', 'message', {
+      code: 'E001',
+      hint: 'check the config',
+      referenceUrl: 'https://example.com',
+      controller: {
+        noColor: true,
+      },
+    });
+
+    expect(error.toString()).toBe(
+      [
+        '[E001:Error:TITLE] message',
+        '',
+        ' HINT: check the config',
+        ' See: https://example.com',
+      ].join('\n'),
+    );
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,9 +90,6 @@ catalogs:
     path-browserify:
       specifier: 1.0.1
       version: 1.0.1
-    picocolors:
-      specifier: ^1.1.1
-      version: 1.1.1
     react:
       specifier: 19.2.8
       version: 19.2.8
@@ -170,7 +167,7 @@ importers:
         version: 3.9.6
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.1.8(core-js@3.49.0))
+        version: 0.3.4(@rsbuild/core@2.1.7(core-js@3.49.0))
 
   e2e:
     devDependencies:
@@ -448,13 +445,13 @@ importers:
       ora:
         specifier: ^9.4.1
         version: 9.4.1
+      rslog:
+        specifier: ^2.1.3
+        version: 2.1.3
     devDependencies:
       cac:
         specifier: ^7.0.0
         version: 7.0.0
-      picocolors:
-        specifier: 'catalog:'
-        version: 1.1.1
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -647,9 +644,6 @@ importers:
       open:
         specifier: ^11.0.0
         version: 11.0.0
-      picocolors:
-        specifier: 'catalog:'
-        version: 1.1.1
       raw-body:
         specifier: 3.0.2
         version: 3.0.2
@@ -831,6 +825,10 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+
+  packages/shared/tests/graph/fixture: {}
+
+  packages/shared/tests/graph/fixture/index: {}
 
   scripts/test-helper:
     dependencies:
@@ -12771,12 +12769,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.7(core-js@3.49.0)
 
-  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.1.8(core-js@3.49.0)):
+  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.1.7(core-js@3.49.0)):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.17
     optionalDependencies:
-      '@rsbuild/core': 2.1.8(core-js@3.49.0)
+      '@rsbuild/core': 2.1.7(core-js@3.49.0)
 
   rslog@1.3.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,7 +43,6 @@ catalog:
   filesize: ^11.0.22
   fs-extra: ^11.1.1
   path-browserify: 1.0.1
-  picocolors: ^1.1.1
   react: 19.2.8
   react-dom: 19.2.8
   react-error-boundary: ^4.1.2


### PR DESCRIPTION
## Summary

This PR removes Rsdoctor's direct `picocolors` dependency and standardizes terminal styling on `rslog`'s Node.js-based `color` API. It updates Core error and logger output together with CLI messages while preserving `DevToolError`'s `noColor` behavior.

## Related Links

https://github.com/rstackjs/rslog#color