### PR TITLE
test(shared): avoid flaky timestamp boundary assertion

### DIFF
--- a/packages/shared/tests/common/time.test.ts
+++ b/packages/shared/tests/common/time.test.ts
@@ -9,6 +9,8 @@ describe('test src/common/time.ts', () => {
     const start = Date.now();
     const startH = hrtime();
     const delay = 500;
+    // Timer scheduling and timestamp rounding may differ by a few milliseconds.
+    const timerTolerance = 5;
 
     const value = await new Promise((resolve) => {
       setTimeout(() => {
@@ -16,7 +18,7 @@ describe('test src/common/time.ts', () => {
       }, delay);
     });
 
-    expect(value).toBeGreaterThanOrEqual(start + delay);
+    expect(value).toBeGreaterThanOrEqual(start + delay - timerTolerance);
   });
 
   it('toFixedDigits', () => {


### PR DESCRIPTION
## Summary

The shared `getCurrentTimestamp` test can fail in CI when timer scheduling and timestamp rounding place the measured value 1 ms below the nominal 500 ms boundary. This PR adds a 5 ms tolerance while preserving the lower-bound assertion.

## Related Links

https://github.com/web-infra-dev/rsdoctor/pull/1868#issuecomment-5138806253