### PR TITLE
perf(core): use gzip level 6 by default

### DIFF
--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -36,7 +36,7 @@ function isJsonOutputEnv(value: unknown): boolean {
   return value === 'json';
 }
 function normalizeGzipLevel(value: unknown): number {
-  const gzipLevel = value === undefined ? 9 : value;
+  const gzipLevel = value === undefined ? 6 : value;
   assert(
     typeof gzipLevel === 'number' &&
       Number.isInteger(gzipLevel) &&

--- a/packages/core/tests/build/utils/config.test.ts
+++ b/packages/core/tests/build/utils/config.test.ts
@@ -106,7 +106,7 @@ describe('normalizeUserConfig', () => {
   it('should use default supports when not provided', () => {
     const result = normalizeUserConfig();
     expect(result.supports.banner).toEqual(undefined);
-    expect(result.supports.gzip).toEqual({ gzipLevel: 9 });
+    expect(result.supports.gzip).toEqual({ gzipLevel: 6 });
     expect(result.supports.parseBundle).toEqual(true);
   });
 
@@ -116,7 +116,7 @@ describe('normalizeUserConfig', () => {
         gzip: true,
       },
     });
-    expect(result.supports.gzip).toEqual({ gzipLevel: 9 });
+    expect(result.supports.gzip).toEqual({ gzipLevel: 6 });
   });
 
   it('should normalize an empty gzip config with the default level', () => {
@@ -125,7 +125,7 @@ describe('normalizeUserConfig', () => {
         gzip: {},
       },
     });
-    expect(result.supports.gzip).toEqual({ gzipLevel: 9 });
+    expect(result.supports.gzip).toEqual({ gzipLevel: 6 });
   });
 
   it('should respect disabled gzip support', () => {

--- a/packages/core/tests/graph/gzip.test.ts
+++ b/packages/core/tests/graph/gzip.test.ts
@@ -39,7 +39,7 @@ describe('gzip size collection', () => {
       gzip,
     );
 
-    expect(asset.gzipSize).toBe(gzipSync(source, { level: 9 }).length);
+    expect(asset.gzipSize).toBe(gzipSync(source, { level: 6 }).length);
   });
 
   it('uses the configured gzip level for assets', () => {

--- a/packages/document/docs/en/config/options/supports.mdx
+++ b/packages/document/docs/en/config/options/supports.mdx
@@ -83,13 +83,13 @@ Disabling the Parse Bundle capability will only affect the visibility of the Bun
 
 Controls whether Rsdoctor calculates gzip sizes for assets and modules. This calculation only affects the size data in the Rsdoctor report; it does not modify or compress the build output.
 
-Gzip size calculation is enabled by default with a compression level of `9`. Set `gzip` to an object to customize `gzipLevel`, which must be an integer between `0` and `9`:
+Gzip size calculation is enabled by default with a compression level of `6`. Set `gzip` to an object to customize `gzipLevel`, which must be an integer between `0` and `9`:
 
 ```ts
 new RsdoctorRspackPlugin({
   supports: {
     gzip: {
-      gzipLevel: 6,
+      gzipLevel: 9,
     },
   },
 });

--- a/packages/document/docs/zh/config/options/supports.mdx
+++ b/packages/document/docs/zh/config/options/supports.mdx
@@ -82,13 +82,13 @@ chain.plugin('Rsdoctor').use(RsdoctorRspackPlugin, [
 
 控制 Rsdoctor 是否计算 Asset 和 Module 的 gzip 大小。该计算只影响 Rsdoctor 报告中的大小数据，不会修改或压缩构建产物。
 
-gzip 大小计算默认开启，默认压缩级别为 `9`。将 `gzip` 配置为对象可以自定义 `gzipLevel`，其值必须是 `0` 到 `9` 之间的整数：
+gzip 大小计算默认开启，默认压缩级别为 `6`。将 `gzip` 配置为对象可以自定义 `gzipLevel`，其值必须是 `0` 到 `9` 之间的整数：
 
 ```ts
 new RsdoctorRspackPlugin({
   supports: {
     gzip: {
-      gzipLevel: 6,
+      gzipLevel: 9,
     },
   },
 });

--- a/packages/graph/src/gzip.ts
+++ b/packages/graph/src/gzip.ts
@@ -1,6 +1,6 @@
 import { gzipSync } from 'node:zlib';
 
-export const DEFAULT_GZIP_LEVEL = 9;
+export const DEFAULT_GZIP_LEVEL = 6;
 
 export function getGzipSize(
   content: string,

--- a/packages/types/src/plugin/plugin.ts
+++ b/packages/types/src/plugin/plugin.ts
@@ -69,7 +69,7 @@ export type GzipConfig =
       /**
        * Gzip compression level used to calculate asset and module gzip sizes.
        * Must be an integer between 0 and 9.
-       * @default 9
+       * @default 6
        */
       gzipLevel?: number;
     };


### PR DESCRIPTION
## Summary

This PR synchronizes #1877 to v1.x by changing the default gzip level used for report size calculation from 9 to the zlib-standard 6. Explicit `gzipLevel` configuration remains unchanged, reducing default CPU overhead with minimal size impact.

## Related Links

https://github.com/web-infra-dev/rsdoctor/pull/1877