### PR TITLE
fix(mcp): the socket url problem

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/mcp-server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/ai/src/server/socket.ts
+++ b/packages/ai/src/server/socket.ts
@@ -1,8 +1,9 @@
-import { Socket, io } from 'socket.io-client';
+import { io, type Socket } from 'socket.io-client';
 import { logger } from '@rsdoctor/utils/logger';
 import { GlobalConfig } from '@rsdoctor/utils/common';
 
 const map: Record<string, Socket> = {};
+const SOCKET_REQUEST_TIMEOUT_MS = 10_000;
 
 function redactSocketToken(url: string) {
   return url.replace(/([?&]token=)[^&]+/, '$1<redacted>');
@@ -43,10 +44,17 @@ export function getPortFromArgs(): number {
 export function getSocketUrlFromArgs(): string | undefined {
   const args = process.argv.slice(2); // Skip the first two elements
   const socketUrlIndex = args.indexOf('--socket-url');
+  const portIndex = args.indexOf('--port');
   const compilerIndex = args.indexOf('--compiler');
 
   if (socketUrlIndex !== -1 && args[socketUrlIndex + 1]) {
     return args[socketUrlIndex + 1];
+  }
+
+  if (portIndex !== -1 && args[portIndex + 1]) {
+    return GlobalConfig.getMcpServerInfoByPort(
+      parseInt(args[portIndex + 1], 10),
+    ).socketUrl;
   }
 
   return getMcpSocketUrl(
@@ -55,30 +63,43 @@ export function getSocketUrlFromArgs(): string | undefined {
 }
 
 export const getWsUrl = async () => {
-  const args = process.argv.slice(2);
-  const portIndex = args.indexOf('--port');
-  const compilerIndex = args.indexOf('--compiler');
-  const compiler = compilerIndex !== -1 ? args[compilerIndex + 1] : undefined;
+  const socketUrl = getSocketUrlFromArgs();
+  if (socketUrl) {
+    logger.error(`Socket will start on url: ${redactSocketToken(socketUrl)}`);
+    return socketUrl;
+  }
+
   const port = getPortFromArgs();
-  const serverInfo =
-    portIndex !== -1
-      ? GlobalConfig.getMcpServerInfoByPort(port)
-      : GlobalConfig.getMcpServerInfo(compiler);
-  const socketUrl = serverInfo.socketUrl || `ws://localhost:${port}`;
   logger.error(`Socket will start on port: ${port}`);
-  return socketUrl;
+  return `ws://localhost:${port}`;
 };
+
+export async function emitSocketRequest(
+  socket: Socket,
+  api: string,
+  params: object,
+  timeout = SOCKET_REQUEST_TIMEOUT_MS,
+) {
+  return (await socket.timeout(timeout).emitWithAck(api, params)) as {
+    res: unknown;
+  };
+}
 
 export const sendRequest = async (api: string, params = {}) => {
   const url = await getWsUrl();
   const socket = createSocket(url);
   logger.error('[mcp]socket client is started');
-  const res = await new Promise((resolve) => {
-    socket.emit(api, params, (res: any) => {
-      resolve(res.res);
-    });
-  });
-  return res;
+
+  try {
+    const response = await emitSocketRequest(socket, api, params);
+    return response.res;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Rsdoctor request "${api}" failed for ${redactSocketToken(url)}: ${message}. Make sure the Rsdoctor local server is running and the cached MCP address is current.`,
+      { cause: error },
+    );
+  }
 };
 
 export const getMcpPort = (compiler?: string) => {
@@ -86,20 +107,5 @@ export const getMcpPort = (compiler?: string) => {
 };
 
 export const getMcpSocketUrl = (compiler?: string) => {
-  const mcpPortFilePath = GlobalConfig.getMcpConfigPath();
-
-  if (!fs.existsSync(mcpPortFilePath)) {
-    return undefined;
-  }
-
-  const mcpJson = JSON.parse(fs.readFileSync(mcpPortFilePath, 'utf8'));
-
-  if (compiler) {
-    const compilerSocketUrl = mcpJson.socketUrlList?.[compiler];
-    if (compilerSocketUrl) {
-      return compilerSocketUrl;
-    }
-  }
-
-  return mcpJson.socketUrl;
+  return GlobalConfig.getMcpServerInfo(compiler).socketUrl;
 };

--- a/packages/ai/tests/socket.test.ts
+++ b/packages/ai/tests/socket.test.ts
@@ -3,7 +3,8 @@ import os from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, rs } from '@rstest/core';
 import { GlobalConfig } from '@rsdoctor/utils/common';
-import { getWsUrl } from '../src/server/socket';
+import type { Socket } from 'socket.io-client';
+import { emitSocketRequest, getWsUrl } from '../src/server/socket';
 
 describe('server/socket', () => {
   const originalArgv = process.argv;
@@ -29,5 +30,31 @@ describe('server/socket', () => {
     process.argv = ['node', 'rsdoctor-mcp', '--port', '3001'];
 
     await expect(getWsUrl()).resolves.toBe('ws://localhost:3001?token=token-a');
+  });
+
+  it('prefers an explicit socket url', async () => {
+    GlobalConfig.writeMcpPort(3001, 'web', 'token-a');
+    process.argv = [
+      'node',
+      'rsdoctor-mcp',
+      '--socket-url',
+      'ws://localhost:4001?token=explicit-token',
+    ];
+
+    await expect(getWsUrl()).resolves.toBe(
+      'ws://localhost:4001?token=explicit-token',
+    );
+  });
+
+  it('applies a timeout to socket acknowledgements', async () => {
+    const emitWithAck = rs.fn().mockRejectedValue(new Error('timed out'));
+    const timeout = rs.fn().mockReturnValue({ emitWithAck });
+    const socket = { timeout } as unknown as Socket;
+
+    await expect(
+      emitSocketRequest(socket, '/api/test', { value: 1 }, 100),
+    ).rejects.toThrow('timed out');
+    expect(timeout).toHaveBeenCalledWith(100);
+    expect(emitWithAck).toHaveBeenCalledWith('/api/test', { value: 1 });
   });
 });


### PR DESCRIPTION
  ## Summary

  - Fix MCP socket URL resolution by honoring `--socket-url` and resolving configured URLs for `--port` or `--compiler`.
  - Add a 10-second timeout and actionable, token-redacted errors for socket requests.
  - Add tests for explicit URL precedence and acknowledgement timeouts.
  - Bump `@rsdoctor/mcp-server` to `0.1.4`.

  ## Related Links

  None