### PR TITLE
feat(rspack-plugin): support multi-compiler builds automatically

### DIFF
--- a/e2e/cases/doctor-rsbuild/fixtures/multi-entry.js
+++ b/e2e/cases/doctor-rsbuild/fixtures/multi-entry.js
@@ -1,0 +1,1 @@
+export const environment = 'rsbuild';

--- a/e2e/cases/doctor-rsbuild/multi-environments.test.ts
+++ b/e2e/cases/doctor-rsbuild/multi-environments.test.ts
@@ -1,10 +1,24 @@
 import { expect, test } from '@playwright/test';
 import { RsdoctorRspackPlugin } from '@rsdoctor/core';
-import type { Linter } from '@rsdoctor/shared/types';
+import { Constants, type Linter } from '@rsdoctor/shared/types';
 import { createStubRsbuild } from '@scripts/test-helper';
 import { readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+
+function getBriefSeries(html: string) {
+  const marker = `window.${Constants.WINDOW_RSDOCTOR_TAG}.series=`;
+  const start = html.indexOf(marker);
+  const end = html.indexOf('</script>', start);
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  return JSON.parse(html.slice(start + marker.length, end)) as Array<{
+    name: string;
+    path: string;
+  }>;
+}
 
 test('automatically exports isolated reports for Rsbuild environments', async () => {
   const testRoot = path.join(
@@ -126,8 +140,19 @@ test('embeds compiler navigation in brief reports', async () => {
     );
 
     expect(webReport).toContain('.name="web"');
-    expect(webReport).toContain('compilers/node/rsdoctor-report.html');
     expect(nodeReport).toContain('.name="node"');
+    expect(
+      getBriefSeries(webReport).map(({ name, path }) => ({ name, path })),
+    ).toEqual([
+      { name: 'web', path: 'rsdoctor-report.html' },
+      { name: 'node', path: 'compilers/node/rsdoctor-report.html' },
+    ]);
+    expect(
+      getBriefSeries(nodeReport).map(({ name, path }) => ({ name, path })),
+    ).toEqual([
+      { name: 'web', path: '../../rsdoctor-report.html' },
+      { name: 'node', path: 'rsdoctor-report.html' },
+    ]);
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }

--- a/e2e/cases/doctor-rsbuild/multi-environments.test.ts
+++ b/e2e/cases/doctor-rsbuild/multi-environments.test.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '@playwright/test';
+import { RsdoctorRspackPlugin } from '@rsdoctor/core';
+import type { Linter } from '@rsdoctor/shared/types';
+import { createStubRsbuild } from '@scripts/test-helper';
+import { readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+test('automatically exports isolated reports for Rsbuild environments', async () => {
+  const testRoot = path.join(
+    tmpdir(),
+    `rsdoctor-rsbuild-environments-${Date.now()}`,
+  );
+  const reportDir = path.join(testRoot, 'reports');
+  const entry = path.resolve(__dirname, 'fixtures/multi-entry.js');
+  const plugins: RsdoctorRspackPlugin<Linter.ExtendRuleData[]>[] = [];
+
+  try {
+    const rsbuild = await createStubRsbuild({
+      cwd: testRoot,
+      rsbuildConfig: {
+        environments: {
+          web: {
+            source: { entry: { index: entry } },
+            output: { target: 'web' },
+          },
+          node: {
+            source: { entry: { index: entry } },
+            output: { target: 'node' },
+          },
+        },
+        tools: {
+          rspack(_config, { appendPlugins }) {
+            const plugin = new RsdoctorRspackPlugin({
+              disableClientServer: true,
+              output: { reportDir },
+            });
+            plugins.push(plugin);
+            appendPlugins(plugin);
+          },
+        },
+      },
+    });
+
+    await rsbuild.build();
+
+    expect(plugins).toHaveLength(2);
+    expect(plugins.map((plugin) => plugin.sdk.name)).toEqual(['web', 'node']);
+
+    const primaryManifestPath = path.join(
+      reportDir,
+      '.rsdoctor',
+      'manifest.json',
+    );
+    const nodeManifestPath = path.join(
+      reportDir,
+      '.rsdoctor',
+      'compilers',
+      'node',
+      'manifest.json',
+    );
+    const primaryManifest = JSON.parse(
+      await readFile(primaryManifestPath, 'utf-8'),
+    );
+    const nodeManifest = JSON.parse(await readFile(nodeManifestPath, 'utf-8'));
+
+    expect(primaryManifest.name).toBe('web');
+    expect(nodeManifest.name).toBe('node');
+    expect(
+      primaryManifest.series.map(({ name }: { name: string }) => name),
+    ).toEqual(['web', 'node']);
+    expect(nodeManifest.series).toEqual(primaryManifest.series);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test('embeds compiler navigation in brief reports', async () => {
+  const testRoot = path.join(
+    tmpdir(),
+    `rsdoctor-rsbuild-brief-environments-${Date.now()}`,
+  );
+  const reportDir = path.join(testRoot, 'reports');
+  const entry = path.resolve(__dirname, 'fixtures/multi-entry.js');
+
+  try {
+    const rsbuild = await createStubRsbuild({
+      cwd: testRoot,
+      rsbuildConfig: {
+        environments: {
+          web: {
+            source: { entry: { index: entry } },
+            output: { target: 'web' },
+          },
+          node: {
+            source: { entry: { index: entry } },
+            output: { target: 'node' },
+          },
+        },
+        tools: {
+          rspack(_config, { appendPlugins }) {
+            appendPlugins(
+              new RsdoctorRspackPlugin({
+                disableClientServer: true,
+                output: {
+                  mode: 'brief',
+                  reportDir,
+                  options: { type: ['html'] },
+                },
+              }),
+            );
+          },
+        },
+      },
+    });
+
+    await rsbuild.build();
+
+    const webReport = await readFile(
+      path.join(reportDir, 'rsdoctor-report.html'),
+      'utf-8',
+    );
+    const nodeReport = await readFile(
+      path.join(reportDir, 'compilers', 'node', 'rsdoctor-report.html'),
+      'utf-8',
+    );
+
+    expect(webReport).toContain('.name="web"');
+    expect(webReport).toContain('compilers/node/rsdoctor-report.html');
+    expect(nodeReport).toContain('.name="node"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,7 @@ npm run test:cjs     # Test CJS functionality
 - `rspack-banner-minimal/` - Rspack with banner plugin
 - `rspack-layers-minimal/` - Rspack with layer support
 - `rsbuild-minimal/` - Rsbuild with Rsdoctor
+- `rsbuild-environments/` - Rsbuild multi-environment build with Rsdoctor
 
 ## Module System Comparison
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,7 @@ npm run test:cjs     # Test CJS functionality
 - `rspack-banner-minimal/` - Rspack with banner plugin
 - `rspack-layers-minimal/` - Rspack with layer support
 - `rsbuild-minimal/` - Rsbuild with Rsdoctor
+- `rsbuild-environments/` - Rsbuild multi-environment build with Rsdoctor
 
 ## Module System Comparison
 

--- a/examples/rsbuild-environments/README.md
+++ b/examples/rsbuild-environments/README.md
@@ -1,0 +1,19 @@
+# Rsbuild Environments
+
+This example uses [Rsbuild environments](https://rsbuild.rs/config/environments) to build `web` and `node` targets in a single build.
+
+Both environments inherit the same `tools.rspack` configuration and use the regular `RsdoctorRspackPlugin` export. Rsdoctor automatically groups the two compilers into one report and keeps their data separate.
+
+Run the build from the repository root:
+
+```bash
+pnpm --filter @examples/doctor-rsbuild-environments build
+```
+
+The build outputs are written to `dist/web` and `dist/node`. The Rsdoctor data is written to `dist/.rsdoctor`, with non-primary compiler data under `dist/.rsdoctor/compilers/<compiler-name>`.
+
+To build and open the report:
+
+```bash
+pnpm --filter @examples/doctor-rsbuild-environments build:analysis
+```

--- a/examples/rsbuild-environments/package.json
+++ b/examples/rsbuild-environments/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@examples/doctor-rsbuild-environments",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rsbuild build",
+    "build:analysis": "ENABLE_CLIENT_SERVER=true rsbuild build"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "catalog:",
+    "@rsdoctor/core": "workspace:*"
+  }
+}

--- a/examples/rsbuild-environments/rsbuild.config.ts
+++ b/examples/rsbuild-environments/rsbuild.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig } from '@rsbuild/core';
+import { RsdoctorRspackPlugin } from '@rsdoctor/core';
+
+export default defineConfig({
+  tools: {
+    rspack: (_config, { appendPlugins }) => {
+      appendPlugins(
+        new RsdoctorRspackPlugin({
+          disableClientServer: !process.env.ENABLE_CLIENT_SERVER,
+          output: {
+            reportDir: './dist',
+          },
+        }),
+      );
+    },
+  },
+  environments: {
+    web: {
+      source: {
+        entry: {
+          web: './src/web.js',
+        },
+      },
+      output: {
+        target: 'web',
+        distPath: {
+          root: 'dist/web',
+        },
+        filenameHash: false,
+      },
+    },
+    node: {
+      source: {
+        entry: {
+          node: './src/node.js',
+        },
+      },
+      output: {
+        target: 'node',
+        distPath: {
+          root: 'dist/node',
+        },
+        filenameHash: false,
+      },
+    },
+  },
+});

--- a/examples/rsbuild-environments/src/node.js
+++ b/examples/rsbuild-environments/src/node.js
@@ -1,0 +1,3 @@
+export const getEnvironmentName = () => 'node';
+
+console.log(`Rsdoctor ${getEnvironmentName()} environment`);

--- a/examples/rsbuild-environments/src/web.js
+++ b/examples/rsbuild-environments/src/web.js
@@ -1,0 +1,5 @@
+const root = document.querySelector('#root');
+
+if (root) {
+  root.textContent = 'Rsdoctor web environment';
+}

--- a/packages/client/src/components/Layout/builder-select.tsx
+++ b/packages/client/src/components/Layout/builder-select.tsx
@@ -1,8 +1,8 @@
 import { Select, Divider, Typography, Space } from 'antd';
 import React, { useState, useEffect } from 'react';
-import { Manifest } from '@rsdoctor/shared/types';
+import { Constants, Manifest } from '@rsdoctor/shared/types';
 import TotalSizeSvg from '../../common/svg/total-size.svg';
-import { fetchManifest, changeOrigin } from '../../utils';
+import { changeOrigin, fetchManifest, getSharingUrl } from '../../utils';
 import Icon from '@ant-design/icons';
 
 export const BuilderSelect: React.FC = () => {
@@ -12,6 +12,18 @@ export const BuilderSelect: React.FC = () => {
   );
 
   useEffect(() => {
+    const briefData = window[Constants.WINDOW_RSDOCTOR_TAG] as
+      | {
+          name?: string;
+          series?: Manifest.RsdoctorManifestSeriesData[];
+        }
+      | undefined;
+    if (briefData?.name && briefData.series?.length) {
+      setBuildName(briefData.name);
+      setSeries(briefData.series);
+      return;
+    }
+
     fetchManifest().then(({ name, series }) => {
       if (name) {
         setBuildName(name);
@@ -44,8 +56,12 @@ export const BuilderSelect: React.FC = () => {
             if (item) {
               if (item.origin) {
                 location.href = changeOrigin(item.origin);
+              } else if (item.path) {
+                location.href = item.path.endsWith('.html')
+                  ? item.path
+                  : getSharingUrl(item.path);
               } else {
-                console.error('No RsdoctorManifestSeriesData.origin');
+                console.error('No Rsdoctor compiler report location');
               }
             }
           }}

--- a/packages/client/src/components/Layout/builder-select.tsx
+++ b/packages/client/src/components/Layout/builder-select.tsx
@@ -58,7 +58,7 @@ export const BuilderSelect: React.FC = () => {
                 location.href = changeOrigin(item.origin);
               } else if (item.path) {
                 location.href = item.path.endsWith('.html')
-                  ? item.path
+                  ? new URL(item.path, location.href).href
                   : getSharingUrl(item.path);
               } else {
                 console.error('No Rsdoctor compiler report location');

--- a/packages/client/src/components/Layout/builder-select.tsx
+++ b/packages/client/src/components/Layout/builder-select.tsx
@@ -1,8 +1,8 @@
 import { Select, Divider, Typography, Space, Tag } from 'antd';
 import React, { useState, useEffect } from 'react';
-import { Manifest } from '@rsdoctor/shared/types';
+import { Constants, Manifest } from '@rsdoctor/shared/types';
 import TotalSizeSvg from '../../common/svg/total-size.svg';
-import { fetchManifest, changeOrigin } from '../../utils';
+import { changeOrigin, fetchManifest, getSharingUrl } from '../../utils';
 import Icon from '@ant-design/icons';
 
 export const BuilderSelect: React.FC = () => {
@@ -12,6 +12,18 @@ export const BuilderSelect: React.FC = () => {
   );
 
   useEffect(() => {
+    const briefData = window[Constants.WINDOW_RSDOCTOR_TAG] as
+      | {
+          name?: string;
+          series?: Manifest.RsdoctorManifestSeriesData[];
+        }
+      | undefined;
+    if (briefData?.name && briefData.series?.length) {
+      setBuildName(briefData.name);
+      setSeries(briefData.series);
+      return;
+    }
+
     fetchManifest().then(({ name, series }) => {
       if (name) {
         setBuildName(name);
@@ -44,8 +56,12 @@ export const BuilderSelect: React.FC = () => {
             if (item) {
               if (item.origin) {
                 location.href = changeOrigin(item.origin);
+              } else if (item.path) {
+                location.href = item.path.endsWith('.html')
+                  ? item.path
+                  : getSharingUrl(item.path);
               } else {
-                console.error('No RsdoctorManifestSeriesData.origin');
+                console.error('No Rsdoctor compiler report location');
               }
             }
           }}

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -129,6 +129,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     printLog = { serverUrls: true },
     mode = undefined,
     brief = undefined,
+    multiCompiler = true,
   } = normalizedConfig;
   const supports = {
     ...getDefaultSupports(),
@@ -153,6 +154,10 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     ...userServer,
   };
   assert(typeof server.port === 'undefined' || typeof server.port === 'number');
+  assert(
+    typeof multiCompiler === 'boolean' ||
+      (typeof multiCompiler === 'object' && multiCompiler !== null),
+  );
   if (typeof server.port === 'undefined' && typeof port !== 'undefined') {
     server.port = port;
   }
@@ -215,6 +220,11 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     port,
     server,
     printLog,
+    multiCompiler: {
+      enabled: multiCompiler !== false,
+      group:
+        typeof multiCompiler === 'object' ? multiCompiler.group : undefined,
+    },
   };
 
   // Add deprecation warning for compressData

--- a/packages/core/src/inner-plugins/utils/sdk.ts
+++ b/packages/core/src/inner-plugins/utils/sdk.ts
@@ -12,7 +12,14 @@ export function setSDK(t: SDK.RsdoctorBuilderSDKInstance) {
   if (!globalThis.__rsdoctor_sdks__) {
     globalThis.__rsdoctor_sdks__ = [];
   }
-  globalThis.__rsdoctor_sdks__!.push(t);
+  const sameNameIndex = globalThis.__rsdoctor_sdks__.findIndex(
+    (sdk) => sdk.name === t.name,
+  );
+  if (sameNameIndex >= 0) {
+    globalThis.__rsdoctor_sdks__[sameNameIndex] = t;
+  } else if (!globalThis.__rsdoctor_sdks__.includes(t)) {
+    globalThis.__rsdoctor_sdks__.push(t);
+  }
   globalThis.__rsdoctor_sdk__ = t;
 }
 

--- a/packages/core/src/inner-plugins/utils/sdk.ts
+++ b/packages/core/src/inner-plugins/utils/sdk.ts
@@ -19,7 +19,12 @@ export function registerSDK(
   if (!globalThis.__rsdoctor_sdks__) {
     globalThis.__rsdoctor_sdks__ = [];
   }
-  if (!globalThis.__rsdoctor_sdks__.includes(t)) {
+  const sameNameIndex = globalThis.__rsdoctor_sdks__.findIndex(
+    (sdk) => sdk.name === t.name,
+  );
+  if (sameNameIndex >= 0) {
+    globalThis.__rsdoctor_sdks__[sameNameIndex] = t;
+  } else if (!globalThis.__rsdoctor_sdks__.includes(t)) {
     globalThis.__rsdoctor_sdks__.push(t);
   }
   if (asDefault) {

--- a/packages/core/src/rspack-plugin/multiple.ts
+++ b/packages/core/src/rspack-plugin/multiple.ts
@@ -1,61 +1,15 @@
+import type { Linter } from '@rsdoctor/shared/types';
 import type { RsdoctorMultiplePluginOptions } from '../types';
-import { RsdoctorPrimarySDK, RsdoctorSDKController } from '../sdk';
-import { SDK, type Linter, type Plugin } from '@rsdoctor/shared/types';
-
-import { normalizeUserConfig } from '../inner-plugins';
 import { RsdoctorRspackPlugin } from './plugin';
 
-let globalController: RsdoctorSDKController | undefined;
-
+/**
+ * @deprecated Use {@link RsdoctorRspackPlugin}. Multi-compiler builds are now
+ * detected and isolated automatically.
+ */
 export class RsdoctorRspackMultiplePlugin<
   Rules extends Linter.ExtendRuleData[],
 > extends RsdoctorRspackPlugin<Rules> {
-  // @ts-expect-error
-  private controller: RsdoctorSDKController;
-
   constructor(options: RsdoctorMultiplePluginOptions<Rules> = {}) {
-    const controller = (() => {
-      if (globalController) {
-        return globalController;
-      }
-      const controller = new RsdoctorSDKController();
-      globalController = controller;
-      return controller;
-    })();
-
-    const normallizedOptions = normalizeUserConfig<Rules>(options);
-
-    const instance = controller.createSlave({
-      name: options.name || 'Builder',
-      stage: options.stage,
-      extraConfig: {
-        innerClientPath: normallizedOptions.innerClientPath,
-        printLog: normallizedOptions.printLog,
-        server: normallizedOptions.server,
-        mode: normallizedOptions.output.mode
-          ? normallizedOptions.output.mode
-          : undefined,
-        brief:
-          normallizedOptions.output.mode === SDK.IMode[SDK.IMode.brief]
-            ? normallizedOptions.output.options || undefined
-            : undefined,
-      },
-      type: normallizedOptions.output.reportCodeType,
-    });
-
-    super({
-      ...options,
-      sdkInstance: instance,
-    });
-    this.controller = controller;
-  }
-
-  apply(compiler: Plugin.BaseCompilerType<'rspack'>) {
-    if ('dependencies' in compiler.options) {
-      (this.sdk as RsdoctorPrimarySDK).dependencies =
-        compiler.options.dependencies;
-    }
-
-    super.apply(compiler);
+    super(options);
   }
 }

--- a/packages/core/src/rspack-plugin/multiple.ts
+++ b/packages/core/src/rspack-plugin/multiple.ts
@@ -1,60 +1,15 @@
+import type { Linter } from '@rsdoctor/shared/types';
 import type { RsdoctorMultiplePluginOptions } from '../types';
-import { RsdoctorPrimarySDK, RsdoctorSDKController } from '../sdk';
-import { SDK, type Linter, type Plugin } from '@rsdoctor/shared/types';
-
-import { normalizeUserConfig } from '../inner-plugins';
 import { RsdoctorRspackPlugin } from './plugin';
 
-let globalController: RsdoctorSDKController | undefined;
-
+/**
+ * @deprecated Use {@link RsdoctorRspackPlugin}. Multi-compiler builds are now
+ * detected and isolated automatically.
+ */
 export class RsdoctorRspackMultiplePlugin<
   Rules extends Linter.ExtendRuleData[],
 > extends RsdoctorRspackPlugin<Rules> {
   constructor(options: RsdoctorMultiplePluginOptions<Rules> = {}) {
-    const controller = (() => {
-      if (globalController) {
-        return globalController;
-      }
-      const controller = new RsdoctorSDKController();
-      globalController = controller;
-      return controller;
-    })();
-
-    const normallizedOptions = normalizeUserConfig<Rules>(options);
-
-    const instance = controller.createSlave({
-      name: options.name || 'Builder',
-      stage: options.stage,
-      extraConfig: {
-        innerClientPath: normallizedOptions.innerClientPath,
-        printLog: normallizedOptions.printLog,
-        server: normallizedOptions.server,
-        mode: normallizedOptions.output.mode
-          ? normallizedOptions.output.mode
-          : undefined,
-        brief:
-          normallizedOptions.output.mode === SDK.IMode[SDK.IMode.brief]
-            ? normallizedOptions.output.options || undefined
-            : undefined,
-        features: {
-          treeShaking: normallizedOptions.features.treeShaking,
-        },
-      },
-      type: normallizedOptions.output.reportCodeType,
-    });
-
-    super({
-      ...options,
-      sdkInstance: instance,
-    });
-  }
-
-  apply(compiler: Plugin.BaseCompilerType<'rspack'>) {
-    if ('dependencies' in compiler.options) {
-      (this.sdk as RsdoctorPrimarySDK).dependencies =
-        compiler.options.dependencies;
-    }
-
-    super.apply(compiler);
+    super(options);
   }
 }

--- a/packages/core/src/rspack-plugin/plugin.ts
+++ b/packages/core/src/rspack-plugin/plugin.ts
@@ -417,7 +417,9 @@ export class RsdoctorRspackPlugin<
 
   private getOutputDir(compiler: Plugin.BaseCompilerType<'rspack'>) {
     return path.resolve(
-      this.options.output.reportDir || compiler.outputPath,
+      this.options.output.reportDir ||
+        compiler.options.output?.path ||
+        compiler.outputPath,
       this.options.output.mode === SDK.IMode[SDK.IMode.brief]
         ? ''
         : `./${Constants.RsdoctorOutputFolder}`,

--- a/packages/core/src/rspack-plugin/plugin.ts
+++ b/packages/core/src/rspack-plugin/plugin.ts
@@ -1,6 +1,7 @@
 import { Loader as BuildUtilLoader } from '../build-utils';
 import {
   ensureModulesChunksGraphFn,
+  handleBriefModeReport,
   InternalBundlePlugin,
   InternalErrorReporterPlugin,
   InternalLoaderPlugin,
@@ -9,52 +10,92 @@ import {
   InternalRulesPlugin,
   InternalSummaryPlugin,
   normalizeRspackUserOptions,
-  setSDK,
-  handleBriefModeReport,
   processCompilerConfig,
+  setSDK,
 } from '../inner-plugins';
+import { getRspackNativePlugin } from '../inner-plugins/plugins/rspack';
+import { logger, time, timeEnd } from '../logger';
+import { findRoot, RsdoctorPrimarySDK, RsdoctorSDKController } from '../sdk';
 import type {
   RsdoctorRspackPluginInstance,
   RsdoctorRspackPluginOptions,
   RsdoctorRspackPluginOptionsNormalized,
 } from '../types';
-import { findRoot, RsdoctorPrimarySDK, RsdoctorSDK } from '../sdk';
+import { Loader } from '@rsdoctor/shared/common-browser';
+import { ModuleGraph } from '@rsdoctor/shared/graph';
 import {
   Constants,
+  Config,
   Linter,
   Manifest,
   Manifest as ManifestType,
   Plugin,
   SDK,
 } from '@rsdoctor/shared/types';
-import path from 'path';
-import { Loader } from '@rsdoctor/shared/common-browser';
-import { ModuleGraph } from '@rsdoctor/shared/graph';
+import path from 'node:path';
 import { pluginTapName, pluginTapPostOptions, pkg } from './constants';
-import { logger, time, timeEnd } from '../logger';
-import { getRspackNativePlugin } from '../inner-plugins/plugins/rspack';
+import { acquireBuildSession, type RsdoctorBuildSessionLease } from './session';
 
 // Static flag to ensure greet message is only printed once per process
 let hasGreeted = false;
+
+class RsdoctorCompilerContext implements RsdoctorRspackPluginInstance<
+  Linter.ExtendRuleData[]
+> {
+  public readonly name = pluginTapName;
+
+  public readonly isRsdoctorPlugin = true;
+
+  public readonly modulesGraph = new ModuleGraph() as SDK.ModuleGraphInstance;
+
+  public bootstrapTask?: Promise<unknown>;
+
+  public applied = false;
+
+  constructor(
+    public readonly sdk: SDK.RsdoctorBuilderSDKInstance,
+    public readonly options: RsdoctorRspackPluginOptionsNormalized<
+      Linter.ExtendRuleData[]
+    >,
+  ) {}
+
+  apply() {}
+
+  ensureModulesChunksGraphApplied(compiler: Plugin.BaseCompilerType<'rspack'>) {
+    ensureModulesChunksGraphFn(
+      compiler,
+      this as unknown as RsdoctorRspackPluginInstance<Linter.ExtendRuleData[]>,
+    );
+  }
+}
 
 export class RsdoctorRspackPlugin<
   Rules extends Linter.ExtendRuleData[],
 > implements RsdoctorRspackPluginInstance<Rules> {
   public readonly name = pluginTapName;
 
-  public readonly sdk: SDK.RsdoctorBuilderSDKInstance | RsdoctorPrimarySDK;
+  public readonly isRsdoctorPlugin = true;
 
-  public readonly isRsdoctorPlugin: boolean;
+  public readonly options: RsdoctorRspackPluginOptionsNormalized<Rules>;
 
-  public _bootstrapTask!: Promise<unknown>;
+  public readonly outsideInstance: boolean;
 
-  protected browserIsOpened = false;
+  private readonly defaultName: string;
 
-  public modulesGraph: SDK.ModuleGraphInstance;
+  private readonly defaultStage?: number;
 
-  public options: RsdoctorRspackPluginOptionsNormalized<Rules>;
+  private readonly controller?: RsdoctorSDKController;
 
-  public outsideInstance: boolean;
+  private readonly sessionLease?: RsdoctorBuildSessionLease;
+
+  private readonly primaryContext: RsdoctorCompilerContext;
+
+  private readonly compilerContexts = new WeakMap<
+    Plugin.BaseCompilerType<'rspack'>,
+    RsdoctorCompilerContext
+  >();
+
+  private appliedCompilerCount = 0;
 
   constructor(options?: RsdoctorRspackPluginOptions<Rules>) {
     this.options = normalizeRspackUserOptions<Rules>(
@@ -64,37 +105,64 @@ export class RsdoctorRspackPlugin<
         },
       }),
     );
-    const { port, server, output, innerClientPath, printLog, sdkInstance } =
-      this.options;
+    this.outsideInstance = Boolean(this.options.sdkInstance);
 
-    this.sdk =
-      this.options.sdkInstance ??
-      new RsdoctorSDK({
-        port,
-        name: pluginTapName,
-        root: process.cwd(),
-        type: output.reportCodeType,
-        config: {
-          innerClientPath,
-          printLog,
-          server,
-          mode: output.mode ? output.mode : undefined,
-          brief:
-            output.mode === SDK.IMode[SDK.IMode.brief]
-              ? output.options || undefined
-              : undefined,
-          features: { treeShaking: this.options.features.treeShaking },
-        },
-      });
-    this.outsideInstance = Boolean(sdkInstance);
-    this.modulesGraph = new ModuleGraph() as SDK.ModuleGraphInstance;
-    this.isRsdoctorPlugin = true;
+    const compatibilityOptions = options as
+      | (RsdoctorRspackPluginOptions<Rules> & {
+          name?: string;
+          stage?: number;
+        })
+      | undefined;
+    this.defaultName = compatibilityOptions?.name || pluginTapName;
+    this.defaultStage = compatibilityOptions?.stage;
+
+    if (this.options.sdkInstance) {
+      this.primaryContext = new RsdoctorCompilerContext(
+        this.options.sdkInstance,
+        this.options as unknown as RsdoctorRspackPluginOptionsNormalized<
+          Linter.ExtendRuleData[]
+        >,
+      );
+      return;
+    }
+
+    this.sessionLease = acquireBuildSession(this.options);
+    this.controller = this.sessionLease.controller;
+    this.primaryContext = this.createCompilerContext(this.defaultStage);
+  }
+
+  public get sdk() {
+    return this.primaryContext.sdk;
+  }
+
+  public get modulesGraph() {
+    return this.primaryContext.modulesGraph;
+  }
+
+  public get _bootstrapTask() {
+    return this.primaryContext.bootstrapTask!;
+  }
+
+  public getCompilerSDK(name: string) {
+    if (this.sdk.name === name) {
+      return this.sdk;
+    }
+    if (this.sdk instanceof RsdoctorPrimarySDK) {
+      return this.sdk.parent.slaves.find((sdk) => sdk.name === name);
+    }
+    return undefined;
   }
 
   // avoid hint error from ts type validation
   apply(compiler: unknown): unknown;
 
   apply(compiler: Plugin.BaseCompilerType<'rspack'>) {
+    const context = this.getCompilerContext(compiler);
+    if (context.applied) {
+      return;
+    }
+    context.applied = true;
+
     time('RsdoctorRspackPlugin.apply');
     try {
       if (!hasGreeted && !compiler.isChild()) {
@@ -103,72 +171,86 @@ export class RsdoctorRspackPlugin<
         \nRsdoctor v${pkg.version}\n`);
       }
 
-      // bootstrap sdk in apply()
-      // Avoid creating different sdk instances when config generators recreate plugin instances.
-      if (!this._bootstrapTask) {
-        this._bootstrapTask = this.sdk.bootstrap();
+      this.releasePendingSessionOnRun(compiler);
+
+      if (!context.bootstrapTask) {
+        context.bootstrapTask = context.sdk.bootstrap();
       }
 
-      if (compiler.options.name) {
-        this.sdk.setName(compiler.options.name);
+      const compilerName =
+        compiler.name ||
+        compiler.options.name ||
+        (this.appliedCompilerCount === 1
+          ? this.defaultName
+          : `${this.defaultName}-${this.appliedCompilerCount}`);
+      context.sdk.setName(compilerName);
+
+      if (context.sdk instanceof RsdoctorPrimarySDK) {
+        if ('dependencies' in compiler.options) {
+          context.sdk.dependencies = compiler.options.dependencies;
+        }
+        context.sdk.parent.registerSlave(context.sdk);
+        context.sdk.parent.setOutputDir(
+          context.sdk,
+          this.getOutputDir(compiler),
+        );
+        if (this.options.output.mode === SDK.IMode[SDK.IMode.brief]) {
+          context.sdk.reportFileName = this.getBriefReportFileName();
+        }
       }
 
-      setSDK(this.sdk);
+      setSDK(context.sdk);
 
-      compiler.hooks.afterPlugins.tap(
-        pluginTapPostOptions,
-        this.afterPlugins.bind(this, compiler),
+      compiler.hooks.afterPlugins.tap(pluginTapPostOptions, () =>
+        this.afterPlugins(compiler, context),
       );
       compiler.hooks.done.tapPromise(
         {
           ...pluginTapPostOptions,
           stage: pluginTapPostOptions.stage! + 100,
         },
-        this.done.bind(this, compiler),
+        () => this.done(compiler, context),
       );
 
       // TODO: to fix the TypeError: Type instantiation is excessively deep and possibly infinite.
       // @ts-ignore
-      new InternalSummaryPlugin<Plugin.BaseCompilerType<'rspack'>>(this).apply(
-        compiler,
-      );
+      new InternalSummaryPlugin<Plugin.BaseCompilerType<'rspack'>>(
+        context,
+      ).apply(compiler);
 
       if (this.options.features.loader) {
         new BuildUtilLoader.ProbeLoaderPlugin().apply(compiler);
-        // add loader page to client
-        this.sdk.addClientRoutes([
+        context.sdk.addClientRoutes([
           Manifest.RsdoctorManifestClientRoutes.Loaders,
         ]);
 
         if (!Loader.isVue(compiler)) {
           new InternalLoaderPlugin<Plugin.BaseCompilerType<'rspack'>>(
-            this,
+            context,
           ).apply(compiler);
         }
       }
 
       if (this.options.features.plugins) {
         new InternalPluginsPlugin<Plugin.BaseCompilerType<'rspack'>>(
-          this,
+          context,
         ).apply(compiler);
       }
 
       if (this.options.features.bundle) {
-        new InternalBundlePlugin<Plugin.BaseCompilerType<'rspack'>>(this).apply(
-          compiler,
-        );
+        new InternalBundlePlugin<Plugin.BaseCompilerType<'rspack'>>(
+          context,
+        ).apply(compiler);
       }
 
       if (this.options.features.resolver) {
         new InternalResolverPlugin<Plugin.BaseCompilerType<'rspack'>>(
-          this,
+          context,
         ).apply(compiler);
       }
 
-      new InternalRulesPlugin(this).apply(compiler);
-
-      // Keep bundler diagnostics reporting separate from Rsdoctor lint messages.
-      new InternalErrorReporterPlugin(this).apply(compiler);
+      new InternalRulesPlugin(context).apply(compiler);
+      new InternalErrorReporterPlugin(context).apply(compiler);
 
       const RsdoctorRspackNativePlugin = getRspackNativePlugin(compiler);
       logger.debug('[RspackNativePlugin] Enabled');
@@ -185,22 +267,19 @@ export class RsdoctorRspackPlugin<
     }
   }
 
-  /**
-   * @description Generate ModuleGraph and ChunkGraph from the Rspack native plugin.
-   * @param {Compiler} compiler
-   * @return {*}
-   * @memberof RsdoctorRspackPlugin
-   */
   public ensureModulesChunksGraphApplied(
     compiler: Plugin.BaseCompilerType<'rspack'>,
   ) {
-    ensureModulesChunksGraphFn(compiler, this);
+    this.getCompilerContext(compiler).ensureModulesChunksGraphApplied(compiler);
   }
 
-  public afterPlugins = (compiler: Plugin.BaseCompilerType<'rspack'>): void => {
+  public afterPlugins = (
+    compiler: Plugin.BaseCompilerType<'rspack'>,
+    context = this.getCompilerContext(compiler),
+  ): void => {
     time('RsdoctorRspackPlugin.afterPlugins');
     try {
-      this.getRspackConfig(compiler);
+      this.getRspackConfig(compiler, context);
     } finally {
       timeEnd('RsdoctorRspackPlugin.afterPlugins');
     }
@@ -208,48 +287,39 @@ export class RsdoctorRspackPlugin<
 
   public done = async (
     compiler: Plugin.BaseCompilerType<'rspack'>,
+    context = this.getCompilerContext(compiler),
   ): Promise<void> => {
     time('RsdoctorRspackPlugin.done');
     try {
       logger.debug('[RsdoctorRspackPlugin] bootstrap(start) in done()');
-      await this.sdk.bootstrap();
+      await context.bootstrapTask;
       logger.debug('[RsdoctorRspackPlugin] bootstrap(end) in done()');
 
-      this.sdk.addClientRoutes([
+      context.sdk.addClientRoutes([
         ManifestType.RsdoctorManifestClientRoutes.Overall,
       ]);
 
-      if (this.outsideInstance && 'parent' in this.sdk) {
-        this.sdk.parent.master.setOutputDir(
-          path.resolve(
-            this.options.output.reportDir || compiler.outputPath,
-            this.options.output.mode === SDK.IMode[SDK.IMode.brief]
-              ? ''
-              : `./${Constants.RsdoctorOutputFolder}`,
-          ),
+      if (context.sdk instanceof RsdoctorPrimarySDK) {
+        context.sdk.setOutputDir(
+          context.sdk.parent.getCompilerOutputDir(context.sdk),
         );
+      } else {
+        context.sdk.setOutputDir(this.getOutputDir(compiler));
       }
 
-      this.sdk.setOutputDir(
-        path.resolve(
-          this.options.output.reportDir || compiler.outputPath,
-          this.options.output.mode === SDK.IMode[SDK.IMode.brief]
-            ? ''
-            : `./${Constants.RsdoctorOutputFolder}`,
-        ),
-      );
-      await this.sdk.writeStore();
-      if (!this.options.disableClientServer) {
-        // If it's brief mode, open the static report page instead of the local server page.
+      await context.sdk.writeStore();
+
+      const isPrimaryCompiler =
+        !(context.sdk instanceof RsdoctorPrimarySDK) || context.sdk.isMaster;
+      if (!this.options.disableClientServer && isPrimaryCompiler) {
         if (this.options.output.mode === SDK.IMode[SDK.IMode.brief]) {
-          // Use extracted common function to handle brief mode
           await handleBriefModeReport(
-            this.sdk,
+            context.sdk,
             this.options,
             this.options.disableClientServer,
           );
         } else {
-          await this.sdk.server.openClientPage('homepage');
+          await context.sdk.server.openClientPage('homepage');
         }
       }
 
@@ -260,25 +330,25 @@ export class RsdoctorRspackPlugin<
           this.options.output.options.type.length === 1 &&
           this.options.output.options.type[0] === 'json')
       ) {
-        await this.sdk.dispose();
+        await context.sdk.dispose();
       }
     } finally {
       timeEnd('RsdoctorRspackPlugin.done');
     }
   };
 
-  public getRspackConfig(compiler: Plugin.BaseCompilerType<'rspack'>) {
+  public getRspackConfig(
+    compiler: Plugin.BaseCompilerType<'rspack'>,
+    context = this.getCompilerContext(compiler),
+  ) {
     time('RsdoctorRspackPlugin.getRspackConfig');
     try {
       if (compiler.isChild()) return;
 
-      // Use extracted common function to process configuration
       const configuration = processCompilerConfig(compiler.options);
-
       const { rspackVersion } = compiler.rspack;
 
-      // Save Rspack configuration to sdk.
-      this.sdk.reportConfiguration({
+      context.sdk.reportConfiguration({
         name: 'rspack',
         version: rspackVersion || 'unknown',
         config: configuration,
@@ -287,5 +357,90 @@ export class RsdoctorRspackPlugin<
     } finally {
       timeEnd('RsdoctorRspackPlugin.getRspackConfig');
     }
+  }
+
+  private createCompilerContext(stage?: number) {
+    const controller = this.controller!;
+    const { output, innerClientPath, printLog, server, features } =
+      this.options;
+    const sdk = controller.createSlave({
+      name: this.defaultName,
+      stage,
+      extraConfig: {
+        innerClientPath,
+        printLog,
+        server,
+        mode: output.mode || undefined,
+        brief:
+          output.mode === SDK.IMode[SDK.IMode.brief]
+            ? output.options || undefined
+            : undefined,
+        features: { treeShaking: features.treeShaking },
+      },
+      type: output.reportCodeType,
+    });
+    return new RsdoctorCompilerContext(
+      sdk,
+      this.options as unknown as RsdoctorRspackPluginOptionsNormalized<
+        Linter.ExtendRuleData[]
+      >,
+    );
+  }
+
+  private getCompilerContext(compiler: Plugin.BaseCompilerType<'rspack'>) {
+    const existing = this.compilerContexts.get(compiler);
+    if (existing) {
+      return existing;
+    }
+
+    let context: RsdoctorCompilerContext;
+    if (this.appliedCompilerCount === 0) {
+      context = this.primaryContext;
+    } else {
+      if (!this.controller) {
+        throw new Error(
+          '[RsdoctorRspackPlugin] A fixed sdkInstance cannot be shared by multiple compilers. Create one plugin instance per compiler with a separate sdkInstance.',
+        );
+      }
+      if (!this.options.multiCompiler.enabled) {
+        throw new Error(
+          '[RsdoctorRspackPlugin] This plugin instance was applied to multiple compilers while multiCompiler is disabled.',
+        );
+      }
+      context = this.createCompilerContext();
+    }
+
+    this.appliedCompilerCount += 1;
+    this.compilerContexts.set(compiler, context);
+    return context;
+  }
+
+  private getOutputDir(compiler: Plugin.BaseCompilerType<'rspack'>) {
+    return path.resolve(
+      this.options.output.reportDir || compiler.outputPath,
+      this.options.output.mode === SDK.IMode[SDK.IMode.brief]
+        ? ''
+        : `./${Constants.RsdoctorOutputFolder}`,
+    );
+  }
+
+  private getBriefReportFileName() {
+    const options = this.options.output.options as Config.BriefModeOptions;
+    if (options.type?.includes('html')) {
+      return options.htmlOptions?.reportHtmlName || 'rsdoctor-report.html';
+    }
+    return options.jsonOptions?.fileName || 'rsdoctor-data.json';
+  }
+
+  private releasePendingSessionOnRun(
+    compiler: Plugin.BaseCompilerType<'rspack'>,
+  ) {
+    if (!this.sessionLease) {
+      return;
+    }
+
+    const release = this.sessionLease.release;
+    compiler.hooks.beforeRun.tap(pluginTapName, release);
+    compiler.hooks.watchRun.tap(pluginTapName, release);
   }
 }

--- a/packages/core/src/rspack-plugin/plugin.ts
+++ b/packages/core/src/rspack-plugin/plugin.ts
@@ -1,6 +1,7 @@
 import { Loader as BuildUtilLoader } from '../build-utils';
 import {
   ensureModulesChunksGraphFn,
+  handleBriefModeReport,
   InternalBundlePlugin,
   InternalErrorReporterPlugin,
   InternalLoaderPlugin,
@@ -9,57 +10,93 @@ import {
   InternalRulesPlugin,
   InternalSummaryPlugin,
   normalizeRspackUserOptions,
+  processCompilerConfig,
   registerSDK,
   setSDK,
-  handleBriefModeReport,
-  processCompilerConfig,
 } from '../inner-plugins';
+import { getRspackNativePlugin } from '../inner-plugins/plugins/rspack';
+import { logger, time, timeEnd } from '../logger';
+import { findRoot, RsdoctorPrimarySDK, RsdoctorSDKController } from '../sdk';
 import type {
   RsdoctorRspackPluginInstance,
   RsdoctorRspackPluginOptions,
   RsdoctorRspackPluginOptionsNormalized,
 } from '../types';
-import { findRoot, RsdoctorPrimarySDK, RsdoctorSDKController } from '../sdk';
+import { Loader } from '@rsdoctor/shared/common-browser';
+import { ModuleGraph } from '@rsdoctor/shared/graph';
 import {
   Constants,
+  Config,
   Linter,
   Manifest,
   Manifest as ManifestType,
   Plugin,
   SDK,
 } from '@rsdoctor/shared/types';
-import path from 'path';
-import { Loader } from '@rsdoctor/shared/common-browser';
-import { ModuleGraph } from '@rsdoctor/shared/graph';
+import path from 'node:path';
 import { pluginTapName, pluginTapPostOptions, pkg } from './constants';
-import { logger, time, timeEnd } from '../logger';
-import { getRspackNativePlugin } from '../inner-plugins/plugins/rspack';
+import { acquireBuildSession, type RsdoctorBuildSessionLease } from './session';
 
 // Static flag to ensure greet message is only printed once per process
 let hasGreeted = false;
+
+class RsdoctorCompilerContext implements RsdoctorRspackPluginInstance<
+  Linter.ExtendRuleData[]
+> {
+  public readonly name = pluginTapName;
+
+  public readonly isRsdoctorPlugin = true;
+
+  public readonly modulesGraph = new ModuleGraph() as SDK.ModuleGraphInstance;
+
+  public bootstrapTask?: Promise<unknown>;
+
+  public applied = false;
+
+  constructor(
+    public readonly sdk: SDK.RsdoctorBuilderSDKInstance,
+    public readonly options: RsdoctorRspackPluginOptionsNormalized<
+      Linter.ExtendRuleData[]
+    >,
+  ) {}
+
+  apply() {}
+
+  ensureModulesChunksGraphApplied(compiler: Plugin.BaseCompilerType<'rspack'>) {
+    ensureModulesChunksGraphFn(
+      compiler,
+      this as unknown as RsdoctorRspackPluginInstance<Linter.ExtendRuleData[]>,
+    );
+  }
+}
 
 export class RsdoctorRspackPlugin<
   Rules extends Linter.ExtendRuleData[],
 > implements RsdoctorRspackPluginInstance<Rules> {
   public readonly name = pluginTapName;
 
-  public readonly sdk: SDK.RsdoctorBuilderSDKInstance;
+  public readonly isRsdoctorPlugin = true;
 
-  public readonly isRsdoctorPlugin: boolean;
+  public readonly options: RsdoctorRspackPluginOptionsNormalized<Rules>;
 
-  public _bootstrapTask!: Promise<unknown>;
-
-  protected browserIsOpened = false;
-
-  public modulesGraph: SDK.ModuleGraphInstance;
-
-  public options: RsdoctorRspackPluginOptionsNormalized<Rules>;
-
-  public outsideInstance: boolean;
-
-  protected readonly controller?: RsdoctorSDKController;
+  public readonly outsideInstance: boolean;
 
   private readonly childOptions: RsdoctorRspackPluginOptions<Rules>;
+
+  private readonly defaultName: string;
+
+  private readonly defaultStage?: number;
+
+  private readonly controller?: RsdoctorSDKController;
+
+  private readonly sessionLease?: RsdoctorBuildSessionLease;
+
+  private readonly primaryContext: RsdoctorCompilerContext;
+
+  private readonly compilerContexts = new WeakMap<
+    Plugin.BaseCompilerType<'rspack'>,
+    RsdoctorCompilerContext
+  >();
 
   private readonly childPlugins = new Map<
     string,
@@ -69,6 +106,8 @@ export class RsdoctorRspackPlugin<
     }
   >();
 
+  private appliedCompilerCount = 0;
+
   constructor(options?: RsdoctorRspackPluginOptions<Rules>) {
     this.childOptions = {
       ...options,
@@ -77,46 +116,67 @@ export class RsdoctorRspackPlugin<
       },
     };
     this.options = normalizeRspackUserOptions<Rules>(this.childOptions);
-    const { server, output, innerClientPath, printLog, sdkInstance } =
-      this.options;
+    this.outsideInstance = Boolean(this.options.sdkInstance);
 
-    if (sdkInstance) {
-      this.sdk = sdkInstance;
-      if (sdkInstance instanceof RsdoctorPrimarySDK) {
-        this.controller = sdkInstance.parent;
+    const compatibilityOptions = options as
+      | (RsdoctorRspackPluginOptions<Rules> & {
+          name?: string;
+          stage?: number;
+        })
+      | undefined;
+    this.defaultName = compatibilityOptions?.name || pluginTapName;
+    this.defaultStage = compatibilityOptions?.stage;
+
+    if (this.options.sdkInstance) {
+      if (this.options.sdkInstance instanceof RsdoctorPrimarySDK) {
+        this.controller = this.options.sdkInstance.parent;
       }
-    } else {
-      const controller = new RsdoctorSDKController();
-      this.controller = controller;
-      this.sdk = controller.createSlave({
-        name: pluginTapName,
-        displayName: 'Main compiler',
-        compilerPath: '',
-        isChild: false,
-        stage: 0,
-        type: output.reportCodeType,
-        extraConfig: {
-          innerClientPath,
-          printLog,
-          server,
-          mode: output.mode ? output.mode : undefined,
-          brief:
-            output.mode === SDK.IMode[SDK.IMode.brief]
-              ? output.options || undefined
-              : undefined,
-          features: { treeShaking: this.options.features.treeShaking },
-        },
-      });
+      this.primaryContext = new RsdoctorCompilerContext(
+        this.options.sdkInstance,
+        this.options as unknown as RsdoctorRspackPluginOptionsNormalized<
+          Linter.ExtendRuleData[]
+        >,
+      );
+      return;
     }
-    this.outsideInstance = Boolean(sdkInstance);
-    this.modulesGraph = new ModuleGraph() as SDK.ModuleGraphInstance;
-    this.isRsdoctorPlugin = true;
+
+    this.sessionLease = acquireBuildSession(this.options);
+    this.controller = this.sessionLease.controller;
+    this.primaryContext = this.createCompilerContext(this.defaultStage);
+  }
+
+  public get sdk() {
+    return this.primaryContext.sdk;
+  }
+
+  public get modulesGraph() {
+    return this.primaryContext.modulesGraph;
+  }
+
+  public get _bootstrapTask() {
+    return this.primaryContext.bootstrapTask!;
+  }
+
+  public getCompilerSDK(name: string) {
+    if (this.sdk.name === name) {
+      return this.sdk;
+    }
+    if (this.sdk instanceof RsdoctorPrimarySDK) {
+      return this.sdk.parent.slaves.find((sdk) => sdk.name === name);
+    }
+    return undefined;
   }
 
   // avoid hint error from ts type validation
   apply(compiler: unknown): unknown;
 
   apply(compiler: Plugin.BaseCompilerType<'rspack'>) {
+    const context = this.getCompilerContext(compiler);
+    if (context.applied) {
+      return;
+    }
+    context.applied = true;
+
     time('RsdoctorRspackPlugin.apply');
     try {
       if (!hasGreeted && !compiler.isChild()) {
@@ -125,91 +185,113 @@ export class RsdoctorRspackPlugin<
         \nRsdoctor v${pkg.version}\n`);
       }
 
-      // bootstrap sdk in apply()
-      // Avoid creating different sdk instances when config generators recreate plugin instances.
-      if (!this._bootstrapTask) {
-        this._bootstrapTask = this.sdk.bootstrap();
+      this.releasePendingSessionOnRun(compiler);
+
+      if (!context.bootstrapTask) {
+        context.bootstrapTask = context.sdk.bootstrap();
       }
 
-      if (compiler.options.name && !compiler.isChild()) {
-        this.sdk.setName(compiler.options.name);
+      const compilerName =
+        compiler.name ||
+        compiler.options.name ||
+        (this.appliedCompilerCount === 1
+          ? this.defaultName
+          : `${this.defaultName}-${this.appliedCompilerCount}`);
+      if (!compiler.isChild()) {
+        context.sdk.setName(compilerName);
+      }
+
+      if (context.sdk instanceof RsdoctorPrimarySDK) {
+        if (!compiler.isChild()) {
+          context.sdk.displayName =
+            compiler.name ||
+            compiler.options.name ||
+            (this.appliedCompilerCount === 1 ? 'Main compiler' : compilerName);
+        }
+        if ('dependencies' in compiler.options) {
+          context.sdk.dependencies = compiler.options.dependencies;
+        }
+        context.sdk.parent.registerSlave(context.sdk);
+        context.sdk.parent.setOutputDir(
+          context.sdk,
+          this.getOutputDir(compiler),
+        );
+        if (this.options.output.mode === SDK.IMode[SDK.IMode.brief]) {
+          context.sdk.reportFileName = this.getBriefReportFileName();
+        }
       }
 
       if (compiler.isChild()) {
-        registerSDK(this.sdk);
+        registerSDK(context.sdk);
       } else {
-        setSDK(this.sdk);
+        setSDK(context.sdk);
       }
 
-      this.applyChildCompilerSupport(compiler);
+      this.applyChildCompilerSupport(compiler, context);
 
       if (compiler.isChild()) {
-        this.getRspackConfig(compiler);
+        this.getRspackConfig(compiler, context);
         compiler.hooks.afterCompile.tapPromise(
           {
             ...pluginTapPostOptions,
             stage: pluginTapPostOptions.stage! + 100,
           },
-          this.childDone.bind(this, compiler),
+          () => this.childDone(compiler, context),
         );
       } else {
-        compiler.hooks.afterPlugins.tap(
-          pluginTapPostOptions,
-          this.afterPlugins.bind(this, compiler),
+        compiler.hooks.afterPlugins.tap(pluginTapPostOptions, () =>
+          this.afterPlugins(compiler, context),
         );
         compiler.hooks.done.tapPromise(
           {
             ...pluginTapPostOptions,
             stage: pluginTapPostOptions.stage! + 100,
           },
-          this.done.bind(this, compiler),
+          () => this.done(compiler, context),
         );
       }
 
       // TODO: to fix the TypeError: Type instantiation is excessively deep and possibly infinite.
       // @ts-ignore
-      new InternalSummaryPlugin<Plugin.BaseCompilerType<'rspack'>>(this).apply(
-        compiler,
-      );
+      new InternalSummaryPlugin<Plugin.BaseCompilerType<'rspack'>>(
+        context,
+      ).apply(compiler);
 
       if (this.options.features.loader) {
         if (!compiler.isChild()) {
           new BuildUtilLoader.ProbeLoaderPlugin().apply(compiler);
         }
-        // add loader page to client
-        this.sdk.addClientRoutes([
+        context.sdk.addClientRoutes([
           Manifest.RsdoctorManifestClientRoutes.Loaders,
         ]);
 
         if (!Loader.isVue(compiler)) {
           new InternalLoaderPlugin<Plugin.BaseCompilerType<'rspack'>>(
-            this,
+            context,
           ).apply(compiler);
         }
       }
 
       if (this.options.features.plugins) {
         new InternalPluginsPlugin<Plugin.BaseCompilerType<'rspack'>>(
-          this,
+          context,
         ).apply(compiler);
       }
 
       if (this.options.features.bundle) {
-        new InternalBundlePlugin<Plugin.BaseCompilerType<'rspack'>>(this).apply(
-          compiler,
-        );
+        new InternalBundlePlugin<Plugin.BaseCompilerType<'rspack'>>(
+          context,
+        ).apply(compiler);
       }
 
       if (this.options.features.resolver) {
         new InternalResolverPlugin<Plugin.BaseCompilerType<'rspack'>>(
-          this,
+          context,
         ).apply(compiler);
       }
 
-      new InternalRulesPlugin(this).apply(compiler);
-
-      // Keep bundler diagnostics reporting separate from Rsdoctor lint messages.
-      new InternalErrorReporterPlugin(this).apply(compiler);
+      new InternalRulesPlugin(context).apply(compiler);
+      new InternalErrorReporterPlugin(context).apply(compiler);
 
       const RsdoctorRspackNativePlugin = getRspackNativePlugin(compiler);
       logger.debug('[RspackNativePlugin] Enabled');
@@ -226,26 +308,149 @@ export class RsdoctorRspackPlugin<
     }
   }
 
-  /**
-   * @description Generate ModuleGraph and ChunkGraph from the Rspack native plugin.
-   * @param {Compiler} compiler
-   * @return {*}
-   * @memberof RsdoctorRspackPlugin
-   */
   public ensureModulesChunksGraphApplied(
     compiler: Plugin.BaseCompilerType<'rspack'>,
   ) {
-    ensureModulesChunksGraphFn(compiler, this);
+    this.getCompilerContext(compiler).ensureModulesChunksGraphApplied(compiler);
   }
 
-  public afterPlugins = (compiler: Plugin.BaseCompilerType<'rspack'>): void => {
+  public afterPlugins = (
+    compiler: Plugin.BaseCompilerType<'rspack'>,
+    context = this.getCompilerContext(compiler),
+  ): void => {
     time('RsdoctorRspackPlugin.afterPlugins');
     try {
-      this.getRspackConfig(compiler);
+      this.getRspackConfig(compiler, context);
     } finally {
       timeEnd('RsdoctorRspackPlugin.afterPlugins');
     }
   };
+
+  public done = async (
+    compiler: Plugin.BaseCompilerType<'rspack'>,
+    context = this.getCompilerContext(compiler),
+  ): Promise<void> => {
+    time('RsdoctorRspackPlugin.done');
+    try {
+      logger.debug('[RsdoctorRspackPlugin] bootstrap(start) in done()');
+      await context.bootstrapTask;
+      logger.debug('[RsdoctorRspackPlugin] bootstrap(end) in done()');
+
+      context.sdk.addClientRoutes([
+        ManifestType.RsdoctorManifestClientRoutes.Overall,
+      ]);
+
+      if (context.sdk instanceof RsdoctorPrimarySDK) {
+        context.sdk.setOutputDir(
+          context.sdk.parent.getCompilerOutputDir(context.sdk),
+        );
+      } else {
+        context.sdk.setOutputDir(this.getOutputDir(compiler));
+      }
+
+      await context.sdk.writeStore();
+
+      const isPrimaryCompiler =
+        !(context.sdk instanceof RsdoctorPrimarySDK) || context.sdk.isMaster;
+      if (!this.options.disableClientServer && isPrimaryCompiler) {
+        if (this.options.output.mode === SDK.IMode[SDK.IMode.brief]) {
+          await handleBriefModeReport(
+            context.sdk,
+            this.options,
+            this.options.disableClientServer,
+          );
+        } else {
+          await context.sdk.server.openClientPage('homepage');
+        }
+      }
+
+      if (this.shouldDisposeSDK()) {
+        await context.sdk.dispose();
+      }
+    } finally {
+      timeEnd('RsdoctorRspackPlugin.done');
+    }
+  };
+
+  public getRspackConfig(
+    compiler: Plugin.BaseCompilerType<'rspack'>,
+    context = this.getCompilerContext(compiler),
+  ) {
+    time('RsdoctorRspackPlugin.getRspackConfig');
+    try {
+      const configuration = processCompilerConfig(compiler.options);
+      if (compiler.isChild() && compiler.name) {
+        configuration.name = compiler.name;
+      }
+
+      const { rspackVersion } = compiler.rspack;
+
+      context.sdk.reportConfiguration({
+        name: 'rspack',
+        version: rspackVersion || 'unknown',
+        config: configuration,
+        root: findRoot() || '',
+      });
+    } finally {
+      timeEnd('RsdoctorRspackPlugin.getRspackConfig');
+    }
+  }
+
+  private createCompilerContext(stage?: number) {
+    const controller = this.controller!;
+    const { output, innerClientPath, printLog, server, features } =
+      this.options;
+    const sdk = controller.createSlave({
+      name: this.defaultName,
+      stage,
+      extraConfig: {
+        innerClientPath,
+        printLog,
+        server,
+        mode: output.mode || undefined,
+        brief:
+          output.mode === SDK.IMode[SDK.IMode.brief]
+            ? output.options || undefined
+            : undefined,
+        features: { treeShaking: features.treeShaking },
+      },
+      type: output.reportCodeType,
+    });
+    return new RsdoctorCompilerContext(
+      sdk,
+      this.options as unknown as RsdoctorRspackPluginOptionsNormalized<
+        Linter.ExtendRuleData[]
+      >,
+    );
+  }
+
+  private getCompilerContext(compiler: Plugin.BaseCompilerType<'rspack'>) {
+    const existing = this.compilerContexts.get(compiler);
+    if (existing) {
+      return existing;
+    }
+
+    let context: RsdoctorCompilerContext;
+    if (this.appliedCompilerCount === 0) {
+      context = this.primaryContext;
+    } else {
+      if (!this.controller) {
+        throw new Error(
+          '[RsdoctorRspackPlugin] A fixed sdkInstance cannot be shared by multiple compilers. Create one plugin instance per compiler with a separate sdkInstance.',
+        );
+      }
+      if (!this.options.multiCompiler.enabled) {
+        throw new Error(
+          '[RsdoctorRspackPlugin] This plugin instance was applied to multiple compilers while multiCompiler is disabled.',
+        );
+      }
+      context = this.createCompilerContext();
+    }
+
+    this.appliedCompilerCount += 1;
+    this.compilerContexts.set(compiler, context);
+    return context;
+  }
 
   private getOutputDir(compiler: Plugin.BaseCompilerType<'rspack'>) {
     return path.resolve(
@@ -256,8 +461,17 @@ export class RsdoctorRspackPlugin<
     );
   }
 
+  private getBriefReportFileName() {
+    const options = this.options.output.options as Config.BriefModeOptions;
+    if (options.type?.includes('html')) {
+      return options.htmlOptions?.reportHtmlName || 'rsdoctor-report.html';
+    }
+    return options.jsonOptions?.fileName || 'rsdoctor-data.json';
+  }
+
   private applyChildCompilerSupport(
     compiler: Plugin.BaseCompilerType<'rspack'>,
+    context: RsdoctorCompilerContext,
   ) {
     compiler.hooks.thisCompilation.tap(
       {
@@ -273,6 +487,7 @@ export class RsdoctorRspackPlugin<
               childCompiler as Plugin.BaseCompilerType<'rspack'>,
               compilerName,
               compilerIndex,
+              context,
             );
           },
         );
@@ -285,20 +500,24 @@ export class RsdoctorRspackPlugin<
     childCompiler: Plugin.BaseCompilerType<'rspack'>,
     compilerName: string,
     compilerIndex: number,
+    parentContext: RsdoctorCompilerContext,
   ) {
-    if (!this.controller || !(this.sdk instanceof RsdoctorPrimarySDK)) {
+    if (!(parentContext.sdk instanceof RsdoctorPrimarySDK)) {
       return;
     }
 
+    const parentSDK = parentContext.sdk;
+    const controller = parentSDK.parent;
     const compilerPath =
       childCompiler.compilerPath ||
       `${parentCompiler.compilerPath}${compilerName}|${compilerIndex}|`;
-    const registeredChild = this.childPlugins.get(compilerPath);
+    const childKey = `${parentSDK.id}:${compilerPath}`;
+    const registeredChild = this.childPlugins.get(childKey);
     if (registeredChild?.compiler === childCompiler) {
       return;
     }
 
-    this.controller.master.setOutputDir(this.getOutputDir(parentCompiler));
+    controller.setOutputDir(parentSDK, this.getOutputDir(parentCompiler));
 
     const childSDK = (() => {
       if (registeredChild) {
@@ -310,19 +529,18 @@ export class RsdoctorRspackPlugin<
         `${compilerName}-${compilerIndex}`;
       const displayName =
         childCompiler.name || compilerName || `Child compiler ${compilerIndex}`;
-      const sdk = this.controller!.createSlave({
+      const sdk = controller.createSlave({
         name: `child-${safeCompilerPath}`,
         displayName,
         compilerPath,
         parentCompilerPath: parentCompiler.compilerPath || '',
         isChild: true,
-        stage: this.sdk.stage + (this.controller!.slaves.length + 1) / 1000,
-        extraConfig: this.sdk.extraConfig,
-        type: this.sdk.type,
+        stage: parentSDK.stage + (controller.slaves.length + 1) / 1000,
+        extraConfig: parentSDK.extraConfig,
+        type: parentSDK.type,
       });
-      // Child compilers finish before the main compiler writes its pieces.
-      // Avoid waiting for the main manifest from the child lifecycle.
-      sdk.dependencies = [this.sdk.name];
+      // Child compilers finish before the parent compiler writes its pieces.
+      sdk.dependencies = [parentSDK.name];
       return sdk;
     })();
 
@@ -332,7 +550,7 @@ export class RsdoctorRspackPlugin<
       ...this.childOptions,
       sdkInstance: childSDK,
     });
-    this.childPlugins.set(compilerPath, {
+    this.childPlugins.set(childKey, {
       compiler: childCompiler,
       sdk: childSDK,
     });
@@ -359,86 +577,45 @@ export class RsdoctorRspackPlugin<
 
   private childDone = async (
     compiler: Plugin.BaseCompilerType<'rspack'>,
+    context: RsdoctorCompilerContext,
   ): Promise<void> => {
-    await this.sdk.bootstrap();
-    this.sdk.addClientRoutes([
+    await context.bootstrapTask;
+    context.sdk.addClientRoutes([
       ManifestType.RsdoctorManifestClientRoutes.Overall,
     ]);
-    this.sdk.setOutputDir(this.getOutputDir(compiler));
-    await this.sdk.writeStore();
+    if (context.sdk instanceof RsdoctorPrimarySDK) {
+      context.sdk.setOutputDir(
+        context.sdk.parent.getCompilerOutputDir(context.sdk),
+      );
+    } else {
+      context.sdk.setOutputDir(this.getOutputDir(compiler));
+    }
+    await context.sdk.writeStore();
 
-    if (this.options.disableClientServer) {
-      await this.sdk.dispose();
+    if (this.shouldDisposeSDK()) {
+      await context.sdk.dispose();
     }
   };
 
-  public done = async (
+  private shouldDisposeSDK() {
+    return (
+      this.options.disableClientServer ||
+      (this.options.output.mode === SDK.IMode[SDK.IMode.brief] &&
+        Array.isArray(this.options.output.options?.type) &&
+        this.options.output.options.type.length === 1 &&
+        this.options.output.options.type[0] === 'json')
+    );
+  }
+
+  private releasePendingSessionOnRun(
     compiler: Plugin.BaseCompilerType<'rspack'>,
-  ): Promise<void> => {
-    time('RsdoctorRspackPlugin.done');
-    try {
-      logger.debug('[RsdoctorRspackPlugin] bootstrap(start) in done()');
-      await this.sdk.bootstrap();
-      logger.debug('[RsdoctorRspackPlugin] bootstrap(end) in done()');
-
-      this.sdk.addClientRoutes([
-        ManifestType.RsdoctorManifestClientRoutes.Overall,
-      ]);
-
-      if (this.outsideInstance && this.sdk instanceof RsdoctorPrimarySDK) {
-        this.sdk.parent.master.setOutputDir(this.getOutputDir(compiler));
-      }
-
-      this.sdk.setOutputDir(this.getOutputDir(compiler));
-      await this.sdk.writeStore();
-      if (!this.options.disableClientServer) {
-        // If it's brief mode, open the static report page instead of the local server page.
-        if (this.options.output.mode === SDK.IMode[SDK.IMode.brief]) {
-          // Use extracted common function to handle brief mode
-          await handleBriefModeReport(
-            this.sdk,
-            this.options,
-            this.options.disableClientServer,
-          );
-        } else {
-          await this.sdk.server.openClientPage('homepage');
-        }
-      }
-
-      if (
-        this.options.disableClientServer ||
-        (this.options.output.mode === SDK.IMode[SDK.IMode.brief] &&
-          Array.isArray(this.options.output.options?.type) &&
-          this.options.output.options.type.length === 1 &&
-          this.options.output.options.type[0] === 'json')
-      ) {
-        await this.sdk.dispose();
-      }
-    } finally {
-      timeEnd('RsdoctorRspackPlugin.done');
+  ) {
+    if (!this.sessionLease) {
+      return;
     }
-  };
 
-  public getRspackConfig(compiler: Plugin.BaseCompilerType<'rspack'>) {
-    time('RsdoctorRspackPlugin.getRspackConfig');
-    try {
-      // Use extracted common function to process configuration
-      const configuration = processCompilerConfig(compiler.options);
-      if (compiler.isChild() && compiler.name) {
-        configuration.name = compiler.name;
-      }
-
-      const { rspackVersion } = compiler.rspack;
-
-      // Save Rspack configuration to sdk.
-      this.sdk.reportConfiguration({
-        name: 'rspack',
-        version: rspackVersion || 'unknown',
-        config: configuration,
-        root: findRoot() || '',
-      });
-    } finally {
-      timeEnd('RsdoctorRspackPlugin.getRspackConfig');
-    }
+    const release = this.sessionLease.release;
+    compiler.hooks.beforeRun.tap(pluginTapName, release);
+    compiler.hooks.watchRun.tap(pluginTapName, release);
   }
 }

--- a/packages/core/src/rspack-plugin/plugin.ts
+++ b/packages/core/src/rspack-plugin/plugin.ts
@@ -454,7 +454,9 @@ export class RsdoctorRspackPlugin<
 
   private getOutputDir(compiler: Plugin.BaseCompilerType<'rspack'>) {
     return path.resolve(
-      this.options.output.reportDir || compiler.outputPath,
+      this.options.output.reportDir ||
+        compiler.options.output?.path ||
+        compiler.outputPath,
       this.options.output.mode === SDK.IMode[SDK.IMode.brief]
         ? ''
         : `./${Constants.RsdoctorOutputFolder}`,

--- a/packages/core/src/rspack-plugin/session.ts
+++ b/packages/core/src/rspack-plugin/session.ts
@@ -1,0 +1,83 @@
+import { RsdoctorSDKController } from '../sdk';
+
+export interface RsdoctorBuildSessionOptions {
+  multiCompiler: {
+    enabled: boolean;
+    group?: string;
+  };
+  output: {
+    mode: string;
+    reportDir: string;
+  };
+  server: {
+    port?: number;
+  };
+  port?: number;
+}
+
+interface PendingSession {
+  controller: RsdoctorSDKController;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const pendingSessions = new Map<string, PendingSession>();
+
+function getSessionKey(options: RsdoctorBuildSessionOptions): string {
+  const root = process.cwd();
+  const { group } = options.multiCompiler;
+
+  if (group) {
+    return ['group', root, group].join('\0');
+  }
+
+  return [
+    'auto',
+    root,
+    options.output.mode,
+    options.output.reportDir,
+    options.server.port ?? options.port ?? '',
+  ].join('\0');
+}
+
+export interface RsdoctorBuildSessionLease {
+  controller: RsdoctorSDKController;
+  release(): void;
+}
+
+export function acquireBuildSession(
+  options: RsdoctorBuildSessionOptions,
+): RsdoctorBuildSessionLease {
+  if (!options.multiCompiler.enabled) {
+    return {
+      controller: new RsdoctorSDKController(),
+      release() {},
+    };
+  }
+
+  const key = getSessionKey(options);
+  let session = pendingSessions.get(key);
+
+  if (!session) {
+    const controller = new RsdoctorSDKController();
+    const timer = setTimeout(() => {
+      if (pendingSessions.get(key)?.controller === controller) {
+        pendingSessions.delete(key);
+      }
+    }, 0);
+    timer.unref?.();
+    session = { controller, timer };
+    pendingSessions.set(key, session);
+  }
+
+  const { controller } = session;
+  return {
+    controller,
+    release() {
+      const current = pendingSessions.get(key);
+      if (current?.controller === controller) {
+        clearTimeout(current.timer);
+        pendingSessions.delete(key);
+      }
+    },
+  };
+}

--- a/packages/core/src/sdk/multiple/controller.ts
+++ b/packages/core/src/sdk/multiple/controller.ts
@@ -1,8 +1,17 @@
 import { Manifest } from '@rsdoctor/shared/types';
+import path from 'node:path';
 import { RsdoctorPrimarySDK } from './primary';
 
 export class RsdoctorSDKController {
   readonly slaves: RsdoctorPrimarySDK[] = [];
+
+  private readonly activeSlaves = new Set<RsdoctorPrimarySDK>();
+
+  private outputDir = '';
+
+  private outputOwner?: RsdoctorPrimarySDK;
+
+  private refreshManifestTask = Promise.resolve();
 
   public root = '';
 
@@ -11,22 +20,57 @@ export class RsdoctorSDKController {
   }
 
   get master() {
-    return this.slaves[0];
+    return this.getActiveSlaves()[0];
+  }
+
+  get isMultiple() {
+    return this.activeSlaves.size > 1;
   }
 
   getLastSdk() {
     return this.slaves[this.slaves.length - 1];
   }
 
-  hasName(name: string) {
-    return Boolean(this.slaves.find((item) => item.name === name));
+  hasName(name: string, exclude?: RsdoctorPrimarySDK) {
+    return Boolean(
+      this.slaves.find((item) => item !== exclude && item.name === name),
+    );
+  }
+
+  registerSlave(slave: RsdoctorPrimarySDK) {
+    this.activeSlaves.add(slave);
+  }
+
+  setOutputDir(slave: RsdoctorPrimarySDK, outputDir: string) {
+    if (slave === this.master && slave !== this.outputOwner) {
+      this.outputDir = outputDir;
+      this.outputOwner = slave;
+      slave.setOutputDir(outputDir);
+    }
+  }
+
+  getCompilerOutputDir(slave: RsdoctorPrimarySDK) {
+    if (slave === this.master) {
+      return this.outputDir || slave.outputDir;
+    }
+
+    const name =
+      slave.name.replace(/[^a-zA-Z0-9_$-]+/g, '-').replace(/^-+|-+$/g, '') ||
+      `compiler-${slave.id}`;
+    return path.join(
+      this.outputDir || this.master?.outputDir || slave.outputDir,
+      'compilers',
+      name,
+    );
   }
 
   getSeriesData(serverUrl = false) {
-    return this.slaves.map((item) => {
+    return this.getActiveSlaves().map((item) => {
       const data: Manifest.RsdoctorManifestSeriesData = {
         name: item.name,
-        path: item.diskManifestPath,
+        path: item.reportFileName
+          ? path.join(this.getCompilerOutputDir(item), item.reportFileName)
+          : item.diskManifestPath,
         stage: item.stage,
       };
 
@@ -46,7 +90,7 @@ export class RsdoctorSDKController {
   }: Omit<ConstructorParameters<typeof RsdoctorPrimarySDK>[0], 'controller'>) {
     const slave = new RsdoctorPrimarySDK({
       name,
-      stage,
+      stage: typeof stage === 'number' ? stage : this.slaves.length,
       controller: this,
       extraConfig,
       type,
@@ -55,5 +99,22 @@ export class RsdoctorSDKController {
     // sort by stage after create slave sdk.
     this.slaves.sort((a, b) => a.stage - b.stage);
     return slave;
+  }
+
+  refreshManifestSeries() {
+    if (!this.isMultiple) {
+      return Promise.resolve();
+    }
+
+    this.refreshManifestTask = this.refreshManifestTask.then(async () => {
+      for (const slave of this.getActiveSlaves()) {
+        await slave.refreshManifestSeries();
+      }
+    });
+    return this.refreshManifestTask;
+  }
+
+  private getActiveSlaves() {
+    return this.slaves.filter((item) => this.activeSlaves.has(item));
   }
 }

--- a/packages/core/src/sdk/multiple/controller.ts
+++ b/packages/core/src/sdk/multiple/controller.ts
@@ -2,6 +2,13 @@ import { Constants, Manifest } from '@rsdoctor/shared/types';
 import path from 'node:path';
 import { RsdoctorPrimarySDK } from './primary';
 
+function toUrlPath(filePath: string) {
+  return filePath
+    .split(path.sep)
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+}
+
 export class RsdoctorSDKController {
   readonly slaves: RsdoctorPrimarySDK[] = [];
 
@@ -94,6 +101,26 @@ export class RsdoctorSDKController {
 
       return data;
     });
+  }
+
+  getBriefSeriesData(
+    current: RsdoctorPrimarySDK,
+  ): Manifest.RsdoctorManifestSeriesData[] {
+    const currentOutputDir = this.getCompilerOutputDir(current);
+
+    return this.getActiveSlaves().map((item) => ({
+      name: item.name,
+      path: toUrlPath(
+        path.relative(
+          currentOutputDir,
+          path.join(
+            this.getCompilerOutputDir(item),
+            item.reportFileName || 'rsdoctor-report.html',
+          ),
+        ),
+      ),
+      stage: item.stage,
+    }));
   }
 
   createSlave({

--- a/packages/core/src/sdk/multiple/controller.ts
+++ b/packages/core/src/sdk/multiple/controller.ts
@@ -5,6 +5,14 @@ import { RsdoctorPrimarySDK } from './primary';
 export class RsdoctorSDKController {
   readonly slaves: RsdoctorPrimarySDK[] = [];
 
+  private readonly activeSlaves = new Set<RsdoctorPrimarySDK>();
+
+  private outputDir = '';
+
+  private outputOwner?: RsdoctorPrimarySDK;
+
+  private refreshManifestTask = Promise.resolve();
+
   public root = '';
 
   constructor(root = process.cwd()) {
@@ -12,27 +20,68 @@ export class RsdoctorSDKController {
   }
 
   get master() {
-    return this.slaves[0];
+    return this.getActiveSlaves()[0];
+  }
+
+  get isMultiple() {
+    return this.activeSlaves.size > 1;
   }
 
   getLastSdk() {
     return this.slaves[this.slaves.length - 1];
   }
 
-  hasName(name: string, current?: RsdoctorPrimarySDK) {
+  hasName(name: string, exclude?: RsdoctorPrimarySDK) {
     return Boolean(
-      this.slaves.find((item) => item !== current && item.name === name),
+      this.slaves.find((item) => item !== exclude && item.name === name),
     );
   }
 
+  registerSlave(slave: RsdoctorPrimarySDK) {
+    this.activeSlaves.add(slave);
+  }
+
+  setOutputDir(slave: RsdoctorPrimarySDK, outputDir: string) {
+    if (slave === this.master && slave !== this.outputOwner) {
+      this.outputDir = outputDir;
+      this.outputOwner = slave;
+      slave.setOutputDir(outputDir);
+    }
+  }
+
+  getCompilerOutputDir(slave: RsdoctorPrimarySDK) {
+    if (slave === this.master) {
+      return this.outputDir || slave.outputDir;
+    }
+
+    const rootOutputDir =
+      this.outputDir || this.master?.outputDir || slave.outputDir;
+    if (slave.isChild) {
+      return path.join(
+        rootOutputDir,
+        '.slaves',
+        slave.name.replace(/\s+/g, '-'),
+      );
+    }
+
+    const name =
+      slave.name.replace(/[^a-zA-Z0-9_$-]+/g, '-').replace(/^-+|-+$/g, '') ||
+      `compiler-${slave.id}`;
+    return path.join(rootOutputDir, 'compilers', name);
+  }
+
   getSeriesData(serverUrl = false) {
-    return this.slaves.map((item) => {
+    return this.getActiveSlaves().map((item) => {
       const data: Manifest.RsdoctorManifestSeriesData = {
         name: item.name,
         displayName: item.displayName,
-        path:
-          item.diskManifestPath ||
-          path.resolve(item.outputDir, Constants.RsdoctorOutputManifest),
+        path: item.reportFileName
+          ? path.join(this.getCompilerOutputDir(item), item.reportFileName)
+          : item.diskManifestPath ||
+            path.resolve(
+              this.getCompilerOutputDir(item),
+              Constants.RsdoctorOutputManifest,
+            ),
         stage: item.stage,
         compilerPath: item.compilerPath,
         parentCompilerPath: item.parentCompilerPath,
@@ -63,7 +112,7 @@ export class RsdoctorSDKController {
       compilerPath,
       parentCompilerPath,
       isChild,
-      stage,
+      stage: typeof stage === 'number' ? stage : this.slaves.length,
       controller: this,
       extraConfig,
       type,
@@ -72,5 +121,22 @@ export class RsdoctorSDKController {
     // sort by stage after create slave sdk.
     this.slaves.sort((a, b) => a.stage - b.stage);
     return slave;
+  }
+
+  refreshManifestSeries() {
+    if (!this.isMultiple) {
+      return Promise.resolve();
+    }
+
+    this.refreshManifestTask = this.refreshManifestTask.then(async () => {
+      for (const slave of this.getActiveSlaves()) {
+        await slave.refreshManifestSeries();
+      }
+    });
+    return this.refreshManifestTask;
+  }
+
+  private getActiveSlaves() {
+    return this.slaves.filter((item) => this.activeSlaves.has(item));
   }
 }

--- a/packages/core/src/sdk/multiple/primary.ts
+++ b/packages/core/src/sdk/multiple/primary.ts
@@ -151,7 +151,7 @@ export class RsdoctorPrimarySDK
       return result;
     }
 
-    const metadata = `<script>window.${Constants.WINDOW_RSDOCTOR_TAG}.name=${JSON.stringify(this.name)};window.${Constants.WINDOW_RSDOCTOR_TAG}.series=${JSON.stringify(this.parent.getSeriesData())}</script>`;
+    const metadata = `<script>window.${Constants.WINDOW_RSDOCTOR_TAG}.name=${JSON.stringify(this.name)};window.${Constants.WINDOW_RSDOCTOR_TAG}.series=${JSON.stringify(this.parent.getBriefSeriesData(this))}</script>`;
     return result.replace('</body>', `${metadata}</body>`);
   }
 }

--- a/packages/core/src/sdk/multiple/primary.ts
+++ b/packages/core/src/sdk/multiple/primary.ts
@@ -1,5 +1,4 @@
-import path from 'path';
-import { Manifest, SDK } from '@rsdoctor/shared/types';
+import { Constants, Manifest, SDK } from '@rsdoctor/shared/types';
 import { RsdoctorSDK } from '../sdk';
 import { RsdoctorSlaveServer } from './server';
 import type { RsdoctorSDKController } from './controller';
@@ -31,9 +30,7 @@ export class RsdoctorPrimarySDK
 
   public dependencies: Array<string> | undefined;
 
-  private uploadPieces!: Promise<void>;
-
-  private finishUploadPieceSwitch!: () => void;
+  public reportFileName = '';
 
   constructor({
     name,
@@ -57,18 +54,13 @@ export class RsdoctorPrimarySDK
     this.stage = typeof stage === 'number' ? stage : 1;
     this.extraConfig = extraConfig;
     this.parent = controller;
-    this.server = new RsdoctorSlaveServer(this, port, {
-      cors: extraConfig?.server?.cors,
-    });
+    if (lastSdk) {
+      this.server = new RsdoctorSlaveServer(this, port, {
+        cors: extraConfig?.server?.cors,
+      });
+    }
     this.type = type;
     this.setName(name);
-    this.clearSwitch();
-  }
-
-  private clearSwitch() {
-    this.uploadPieces = new Promise<void>((resolve) => {
-      this.finishUploadPieceSwitch = resolve;
-    });
   }
 
   get isMaster() {
@@ -76,39 +68,31 @@ export class RsdoctorPrimarySDK
   }
 
   protected async writePieces(): Promise<void> {
-    const { name, parent, isMaster, outputDir, finishUploadPieceSwitch } = this;
-    this.setOutputDir(
-      isMaster
-        ? outputDir
-        : path.join(
-            parent.master.outputDir,
-            '.slaves',
-            name.replace(/\s+/g, '-'),
-          ),
-    );
+    this.setOutputDir(this.parent.getCompilerOutputDir(this));
     await super.writePieces(this.getStoreData());
-    finishUploadPieceSwitch?.();
   }
 
   protected async writeManifest() {
-    const { parent, cloudData, dependencies } = this;
+    const { parent, cloudData } = this;
 
-    if (!dependencies?.length) {
-      await Promise.all(
-        this.parent.slaves
-          .filter((item) => !item.dependencies?.length)
-          .map((item) => item.uploadPieces),
-      );
-    }
-
-    if (cloudData) {
+    if (cloudData && parent.isMultiple) {
       cloudData.name = this.name;
       cloudData.series = parent.getSeriesData();
     }
 
     const result = await super.writeManifest();
-    this.clearSwitch();
+    await parent.refreshManifestSeries();
     return result;
+  }
+
+  async refreshManifestSeries() {
+    if (!this.parent.isMultiple || !this.cloudData || !this.diskManifestPath) {
+      return;
+    }
+
+    this.cloudData.name = this.name;
+    this.cloudData.series = this.parent.getSeriesData();
+    await super.writeManifest();
   }
 
   getSeriesData(serverUrl = false): Manifest.RsdoctorManifestSeriesData[] {
@@ -116,13 +100,38 @@ export class RsdoctorPrimarySDK
   }
 
   setName(name: string) {
-    this._name = this.parent.hasName(name) ? `${name}-${id}` : name;
+    const baseName = name || `compiler-${this.id}`;
+    if (!this.parent.hasName(baseName, this)) {
+      this._name = baseName;
+      return;
+    }
+
+    let suffix = 2;
+    while (this.parent.hasName(`${baseName}-${suffix}`, this)) {
+      suffix += 1;
+    }
+    this._name = `${baseName}-${suffix}`;
   }
 
   getManifestData(): Manifest.RsdoctorManifestWithShardingFiles {
     const data = super.getManifestData();
-    data.name = this.name;
-    data.series = this.getSeriesData(true);
+    if (this.parent.isMultiple) {
+      data.name = this.name;
+      data.series = this.getSeriesData(true);
+    }
     return data;
+  }
+
+  public addRsdoctorDataToHTML(
+    storeData: SDK.BuilderStoreData,
+    htmlContent: string,
+  ) {
+    const result = super.addRsdoctorDataToHTML(storeData, htmlContent);
+    if (!this.parent.isMultiple) {
+      return result;
+    }
+
+    const metadata = `<script>window.${Constants.WINDOW_RSDOCTOR_TAG}.name=${JSON.stringify(this.name)};window.${Constants.WINDOW_RSDOCTOR_TAG}.series=${JSON.stringify(this.parent.getSeriesData())}</script>`;
+    return result.replace('</body>', `${metadata}</body>`);
   }
 }

--- a/packages/core/src/sdk/multiple/primary.ts
+++ b/packages/core/src/sdk/multiple/primary.ts
@@ -1,5 +1,4 @@
-import path from 'path';
-import { Manifest, SDK } from '@rsdoctor/shared/types';
+import { Constants, Manifest, SDK } from '@rsdoctor/shared/types';
 import { RsdoctorSDK } from '../sdk';
 import { RsdoctorSlaveServer } from './server';
 import type { RsdoctorSDKController } from './controller';
@@ -33,7 +32,7 @@ export class RsdoctorPrimarySDK
 
   public readonly stage: number;
 
-  public readonly displayName: string;
+  public displayName: string;
 
   public readonly compilerPath: string;
 
@@ -43,9 +42,7 @@ export class RsdoctorPrimarySDK
 
   public dependencies: Array<string> | undefined;
 
-  private uploadPieces!: Promise<void>;
-
-  private finishUploadPieceSwitch!: () => void;
+  public reportFileName = '';
 
   constructor({
     name,
@@ -77,69 +74,45 @@ export class RsdoctorPrimarySDK
     this.isChild = Boolean(isChild);
     this.extraConfig = extraConfig;
     this.parent = controller;
-    this.server = new RsdoctorSlaveServer(this, port, {
-      cors: extraConfig?.server?.cors,
-    });
+    if (lastSdk) {
+      this.server = new RsdoctorSlaveServer(this, port, {
+        cors: extraConfig?.server?.cors,
+      });
+    }
     this.type = type;
     this.setName(name);
-    this.clearSwitch();
-  }
-
-  private clearSwitch() {
-    this.uploadPieces = new Promise<void>((resolve) => {
-      this.finishUploadPieceSwitch = resolve;
-    });
   }
 
   get isMaster() {
     return this.parent.master === this;
   }
 
-  private ensureSlaveOutputDir() {
-    if (this.isMaster) {
-      return;
-    }
-
-    this.setOutputDir(
-      path.join(
-        this.parent.master.outputDir,
-        '.slaves',
-        this.name.replace(/\s+/g, '-'),
-      ),
-    );
-  }
-
-  public async writeStore(options?: SDK.WriteStoreOptionsType) {
-    this.ensureSlaveOutputDir();
-    return super.writeStore(options);
-  }
-
   protected async writePieces(): Promise<void> {
-    const { finishUploadPieceSwitch } = this;
-    this.ensureSlaveOutputDir();
+    this.setOutputDir(this.parent.getCompilerOutputDir(this));
     await super.writePieces(this.getStoreData());
-    finishUploadPieceSwitch?.();
   }
 
   protected async writeManifest() {
-    const { parent, cloudData, dependencies } = this;
+    const { parent, cloudData } = this;
 
-    if (!dependencies?.length) {
-      await Promise.all(
-        this.parent.slaves
-          .filter((item) => !item.dependencies?.length)
-          .map((item) => item.uploadPieces),
-      );
-    }
-
-    if (cloudData) {
+    if (cloudData && parent.isMultiple) {
       cloudData.name = this.name;
       cloudData.series = parent.getSeriesData();
     }
 
     const result = await super.writeManifest();
-    this.clearSwitch();
+    await parent.refreshManifestSeries();
     return result;
+  }
+
+  async refreshManifestSeries() {
+    if (!this.parent.isMultiple || !this.cloudData || !this.diskManifestPath) {
+      return;
+    }
+
+    this.cloudData.name = this.name;
+    this.cloudData.series = this.parent.getSeriesData();
+    await super.writeManifest();
   }
 
   getSeriesData(serverUrl = false): Manifest.RsdoctorManifestSeriesData[] {
@@ -147,13 +120,38 @@ export class RsdoctorPrimarySDK
   }
 
   setName(name: string) {
-    this._name = this.parent.hasName(name, this) ? `${name}-${id}` : name;
+    const baseName = name || `compiler-${this.id}`;
+    if (!this.parent.hasName(baseName, this)) {
+      this._name = baseName;
+      return;
+    }
+
+    let suffix = 2;
+    while (this.parent.hasName(`${baseName}-${suffix}`, this)) {
+      suffix += 1;
+    }
+    this._name = `${baseName}-${suffix}`;
   }
 
   getManifestData(): Manifest.RsdoctorManifestWithShardingFiles {
     const data = super.getManifestData();
-    data.name = this.name;
-    data.series = this.getSeriesData(true);
+    if (this.parent.isMultiple) {
+      data.name = this.name;
+      data.series = this.getSeriesData(true);
+    }
     return data;
+  }
+
+  public addRsdoctorDataToHTML(
+    storeData: SDK.BuilderStoreData,
+    htmlContent: string,
+  ) {
+    const result = super.addRsdoctorDataToHTML(storeData, htmlContent);
+    if (!this.parent.isMultiple) {
+      return result;
+    }
+
+    const metadata = `<script>window.${Constants.WINDOW_RSDOCTOR_TAG}.name=${JSON.stringify(this.name)};window.${Constants.WINDOW_RSDOCTOR_TAG}.series=${JSON.stringify(this.parent.getSeriesData())}</script>`;
+    return result.replace('</body>', `${metadata}</body>`);
   }
 }

--- a/packages/core/tests/build/utils/config.test.ts
+++ b/packages/core/tests/build/utils/config.test.ts
@@ -54,6 +54,22 @@ describe('normalizeUserConfig', () => {
     // @ts-ignore
     expect(result.output.compressData).toBe(undefined);
     expect(result.output.mode).toBe('normal');
+    expect(result.multiCompiler).toEqual({
+      enabled: true,
+      group: undefined,
+    });
+  });
+
+  it('should normalize multi-compiler configuration', () => {
+    expect(normalizeUserConfig({ multiCompiler: false }).multiCompiler).toEqual(
+      {
+        enabled: false,
+        group: undefined,
+      },
+    );
+    expect(
+      normalizeUserConfig({ multiCompiler: { group: 'ssr' } }).multiCompiler,
+    ).toEqual({ enabled: true, group: 'ssr' });
   });
 
   it('should handle compressData configuration correctly', () => {

--- a/packages/core/tests/plugins/sdk.test.ts
+++ b/packages/core/tests/plugins/sdk.test.ts
@@ -36,4 +36,24 @@ describe('SDK registry', () => {
 
     expect(getSDK('web')).toBe(slaveSDK);
   });
+
+  it('does not register the same SDK more than once', () => {
+    const sdk = createSDK('web');
+
+    setSDK(sdk);
+    setSDK(sdk);
+
+    expect(globalThis.__rsdoctor_sdks__).toEqual([sdk]);
+  });
+
+  it('replaces a recreated SDK with the same compiler name', () => {
+    const previous = createSDK('web');
+    const current = createSDK('web');
+
+    setSDK(previous);
+    setSDK(current);
+
+    expect(globalThis.__rsdoctor_sdks__).toEqual([current]);
+    expect(getSDK('web')).toBe(current);
+  });
 });

--- a/packages/core/tests/plugins/sdk.test.ts
+++ b/packages/core/tests/plugins/sdk.test.ts
@@ -1,59 +1,52 @@
-import { afterEach, describe, expect, it } from '@rstest/core';
-import type { SDK } from '@rsdoctor/shared/types';
 import { getSDK, setSDK } from '@/inner-plugins/utils/sdk';
+import type { SDK } from '@rsdoctor/shared/types';
+import { afterEach, describe, expect, it } from '@rstest/core';
 
-const createSDK = (name: string) =>
-  ({ name }) as SDK.RsdoctorBuilderSDKInstance;
-
-const createMultipleSDKs = () => {
-  const controller = {
-    slaves: [] as Array<
-      SDK.RsdoctorBuilderSDKInstance & { compilerPath: string }
-    >,
-  };
+function createMultipleSDKs() {
   const createSlave = (name: string, compilerPath = '') =>
     ({
       name,
       compilerPath,
-      parent: controller,
-    }) as unknown as SDK.RsdoctorBuilderSDKInstance & {
-      compilerPath: string;
-    };
+    }) as SDK.RsdoctorBuilderSDKInstance & { compilerPath: string };
   const webSDK = createSlave('web');
   const nodeSDK = createSlave('node');
-  controller.slaves.push(webSDK, nodeSDK);
-
+  const controller = {
+    slaves: [webSDK, nodeSDK],
+  };
+  Object.assign(webSDK, { parent: controller });
+  Object.assign(nodeSDK, { parent: controller });
   return { controller, createSlave, webSDK, nodeSDK };
-};
+}
 
-afterEach(() => {
-  delete globalThis.__rsdoctor_sdk__;
-  delete globalThis.__rsdoctor_sdks__;
-});
+function createSDK(name: string) {
+  return { name } as SDK.RsdoctorBuilderSDKInstance;
+}
 
 describe('SDK registry', () => {
-  it('returns the latest SDK by default and finds named SDKs', () => {
-    const webSDK = createSDK('web');
-    const web1SDK = createSDK('web1');
-
-    setSDK(webSDK);
-    setSDK(web1SDK);
-
-    expect(getSDK()).toBe(web1SDK);
-    expect(getSDK('web')).toBe(webSDK);
-    expect(getSDK('web1')).toBe(web1SDK);
+  afterEach(() => {
+    globalThis.__rsdoctor_sdk__ = undefined;
+    globalThis.__rsdoctor_sdks__ = undefined;
   });
 
-  it('finds named SDKs from a parent SDK', () => {
-    const slaveSDK = createSDK('web');
-    const parentSDK = {
-      name: 'parent',
-      parent: {
-        slaves: [slaveSDK],
-      },
-    } as unknown as SDK.RsdoctorBuilderSDKInstance;
+  it('returns the named SDK instead of the last registered SDK', () => {
+    const webSDK = createSDK('web');
+    const nodeSDK = createSDK('node');
 
-    setSDK(parentSDK);
+    setSDK(webSDK);
+    setSDK(nodeSDK);
+
+    expect(getSDK('web')).toBe(webSDK);
+    expect(getSDK('node')).toBe(nodeSDK);
+  });
+
+  it('finds sibling SDKs from the controller', () => {
+    const rootSDK = createSDK('root');
+    const slaveSDK = createSDK('web');
+    Object.assign(rootSDK, {
+      parent: { slaves: [rootSDK, slaveSDK] },
+    });
+
+    setSDK(rootSDK);
 
     expect(getSDK('web')).toBe(slaveSDK);
   });
@@ -77,5 +70,25 @@ describe('SDK registry', () => {
     setSDK(nodeSDK);
 
     expect(getSDK('web|child|0|')).toBe(childSDK);
+  });
+
+  it('does not register the same SDK more than once', () => {
+    const sdk = createSDK('web');
+
+    setSDK(sdk);
+    setSDK(sdk);
+
+    expect(globalThis.__rsdoctor_sdks__).toEqual([sdk]);
+  });
+
+  it('replaces a recreated SDK with the same compiler name', () => {
+    const previous = createSDK('web');
+    const current = createSDK('web');
+
+    setSDK(previous);
+    setSDK(current);
+
+    expect(globalThis.__rsdoctor_sdks__).toEqual([current]);
+    expect(getSDK('web')).toBe(current);
   });
 });

--- a/packages/core/tests/rspack-plugin/plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/plugin.test.ts
@@ -1,13 +1,14 @@
 import { getSDK } from '@/inner-plugins/utils/sdk';
 import { RsdoctorRspackPlugin } from '@/rspack-plugin';
-import { RsdoctorSDK } from '@/sdk';
+import { RsdoctorPrimarySDK, RsdoctorSDK } from '@/sdk';
 import { rspack } from '@rspack/core';
 import { afterEach, describe, expect, it } from '@rstest/core';
 import { RsdoctorServer } from '@/sdk/server';
 
-afterEach(() => {
+afterEach(async () => {
   delete globalThis.__rsdoctor_sdk__;
   delete globalThis.__rsdoctor_sdks__;
+  await new Promise((resolve) => setTimeout(resolve, 0));
 });
 
 describe('RsdoctorRspackPlugin', () => {
@@ -31,6 +32,82 @@ describe('RsdoctorRspackPlugin', () => {
     expect(web1Plugin.sdk.name).toBe('web1');
     expect(getSDK('web')).toBe(webPlugin.sdk);
     expect(getSDK('web1')).toBe(web1Plugin.sdk);
+  });
+
+  it('automatically groups plugin instances created for multiple compilers', async () => {
+    const webPlugin = new RsdoctorRspackPlugin({
+      disableClientServer: true,
+    });
+    const nodePlugin = new RsdoctorRspackPlugin({
+      disableClientServer: true,
+    });
+
+    rspack({ name: 'web', plugins: [webPlugin] });
+    rspack({ name: 'node', plugins: [nodePlugin] });
+    await Promise.all([webPlugin._bootstrapTask, nodePlugin._bootstrapTask]);
+
+    const webSDK = webPlugin.sdk as RsdoctorPrimarySDK;
+    const nodeSDK = nodePlugin.sdk as RsdoctorPrimarySDK;
+    expect(webSDK.parent).toBe(nodeSDK.parent);
+    expect(webSDK.parent.getSeriesData().map((item) => item.name)).toEqual([
+      'web',
+      'node',
+    ]);
+    expect(getSDK('web')).toBe(webSDK);
+    expect(getSDK('node')).toBe(nodeSDK);
+
+    await Promise.all([webSDK.dispose(), nodeSDK.dispose()]);
+  });
+
+  it('creates isolated compiler contexts when one plugin instance is reused', async () => {
+    const plugin = new RsdoctorRspackPlugin({
+      disableClientServer: true,
+    });
+
+    rspack([
+      { name: 'web', plugins: [plugin] },
+      { name: 'node', plugins: [plugin] },
+    ]);
+    await plugin._bootstrapTask;
+
+    const primarySDK = plugin.sdk as RsdoctorPrimarySDK;
+    expect(primarySDK.parent.getSeriesData().map((item) => item.name)).toEqual([
+      'web',
+      'node',
+    ]);
+    expect(getSDK('web')).toBe(primarySDK);
+    expect(getSDK('node')).not.toBe(primarySDK);
+    expect(plugin.getCompilerSDK('node')).toBe(getSDK('node'));
+
+    await Promise.all(primarySDK.parent.slaves.map((sdk) => sdk.dispose()));
+  });
+
+  it('can disable aggregation for unrelated compiler instances', async () => {
+    const firstPlugin = new RsdoctorRspackPlugin({
+      disableClientServer: true,
+      multiCompiler: false,
+      server: { port: 19120 },
+    });
+    const secondPlugin = new RsdoctorRspackPlugin({
+      disableClientServer: true,
+      multiCompiler: false,
+      server: { port: 19121 },
+    });
+
+    rspack({ name: 'first', plugins: [firstPlugin] });
+    rspack({ name: 'second', plugins: [secondPlugin] });
+    await Promise.all([
+      firstPlugin._bootstrapTask,
+      secondPlugin._bootstrapTask,
+    ]);
+
+    const firstSDK = firstPlugin.sdk as RsdoctorPrimarySDK;
+    const secondSDK = secondPlugin.sdk as RsdoctorPrimarySDK;
+    expect(firstSDK.parent).not.toBe(secondSDK.parent);
+    expect(firstSDK.getManifestData().series).toBeUndefined();
+    expect(secondSDK.getManifestData().series).toBeUndefined();
+
+    await Promise.all([firstSDK.dispose(), secondSDK.dispose()]);
   });
 
   it('keeps the report server when the client server is disabled in CI', () => {

--- a/packages/core/tests/rspack-plugin/plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/plugin.test.ts
@@ -3,6 +3,7 @@ import { RsdoctorRspackPlugin } from '@/rspack-plugin';
 import { RsdoctorPrimarySDK, RsdoctorSDK } from '@/sdk';
 import { rspack } from '@rspack/core';
 import { afterEach, describe, expect, it } from '@rstest/core';
+import path from 'node:path';
 
 afterEach(async () => {
   delete globalThis.__rsdoctor_sdk__;
@@ -56,6 +57,24 @@ describe('RsdoctorRspackPlugin', () => {
     expect(getSDK('node')).toBe(nodeSDK);
 
     await Promise.all([webSDK.dispose(), nodeSDK.dispose()]);
+  });
+
+  it('uses the configured output path before the compiler starts', async () => {
+    const reportDir = path.join(process.cwd(), 'dist', 'brief-report');
+    const plugin = new RsdoctorRspackPlugin({
+      disableClientServer: true,
+      output: { mode: 'brief' },
+    });
+
+    rspack({
+      output: { path: reportDir },
+      plugins: [plugin],
+    });
+    await plugin._bootstrapTask;
+
+    expect(plugin.sdk.outputDir).toBe(reportDir);
+
+    await plugin.sdk.dispose();
   });
 
   it('creates isolated compiler contexts when one plugin instance is reused', async () => {

--- a/packages/core/tests/rspack-plugin/plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/plugin.test.ts
@@ -4,6 +4,7 @@ import { RsdoctorPrimarySDK, RsdoctorSDK } from '@/sdk';
 import { rspack } from '@rspack/core';
 import { afterEach, describe, expect, it } from '@rstest/core';
 import { RsdoctorServer } from '@/sdk/server';
+import path from 'node:path';
 
 afterEach(async () => {
   delete globalThis.__rsdoctor_sdk__;
@@ -57,6 +58,24 @@ describe('RsdoctorRspackPlugin', () => {
     expect(getSDK('node')).toBe(nodeSDK);
 
     await Promise.all([webSDK.dispose(), nodeSDK.dispose()]);
+  });
+
+  it('uses the configured output path before the compiler starts', async () => {
+    const reportDir = path.join(process.cwd(), 'dist', 'brief-report');
+    const plugin = new RsdoctorRspackPlugin({
+      disableClientServer: true,
+      output: { mode: 'brief' },
+    });
+
+    rspack({
+      output: { path: reportDir },
+      plugins: [plugin],
+    });
+    await plugin._bootstrapTask;
+
+    expect(plugin.sdk.outputDir).toBe(reportDir);
+
+    await plugin.sdk.dispose();
   });
 
   it('creates isolated compiler contexts when one plugin instance is reused', async () => {

--- a/packages/core/tests/rspack-plugin/plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/plugin.test.ts
@@ -1,12 +1,13 @@
 import { getSDK } from '@/inner-plugins/utils/sdk';
 import { RsdoctorRspackPlugin } from '@/rspack-plugin';
-import { RsdoctorSDK } from '@/sdk';
+import { RsdoctorPrimarySDK, RsdoctorSDK } from '@/sdk';
 import { rspack } from '@rspack/core';
 import { afterEach, describe, expect, it } from '@rstest/core';
 
-afterEach(() => {
+afterEach(async () => {
   delete globalThis.__rsdoctor_sdk__;
   delete globalThis.__rsdoctor_sdks__;
+  await new Promise((resolve) => setTimeout(resolve, 0));
 });
 
 describe('RsdoctorRspackPlugin', () => {
@@ -30,6 +31,82 @@ describe('RsdoctorRspackPlugin', () => {
     expect(web1Plugin.sdk.name).toBe('web1');
     expect(getSDK('web')).toBe(webPlugin.sdk);
     expect(getSDK('web1')).toBe(web1Plugin.sdk);
+  });
+
+  it('automatically groups plugin instances created for multiple compilers', async () => {
+    const webPlugin = new RsdoctorRspackPlugin({
+      disableClientServer: true,
+    });
+    const nodePlugin = new RsdoctorRspackPlugin({
+      disableClientServer: true,
+    });
+
+    rspack({ name: 'web', plugins: [webPlugin] });
+    rspack({ name: 'node', plugins: [nodePlugin] });
+    await Promise.all([webPlugin._bootstrapTask, nodePlugin._bootstrapTask]);
+
+    const webSDK = webPlugin.sdk as RsdoctorPrimarySDK;
+    const nodeSDK = nodePlugin.sdk as RsdoctorPrimarySDK;
+    expect(webSDK.parent).toBe(nodeSDK.parent);
+    expect(webSDK.parent.getSeriesData().map((item) => item.name)).toEqual([
+      'web',
+      'node',
+    ]);
+    expect(getSDK('web')).toBe(webSDK);
+    expect(getSDK('node')).toBe(nodeSDK);
+
+    await Promise.all([webSDK.dispose(), nodeSDK.dispose()]);
+  });
+
+  it('creates isolated compiler contexts when one plugin instance is reused', async () => {
+    const plugin = new RsdoctorRspackPlugin({
+      disableClientServer: true,
+    });
+
+    rspack([
+      { name: 'web', plugins: [plugin] },
+      { name: 'node', plugins: [plugin] },
+    ]);
+    await plugin._bootstrapTask;
+
+    const primarySDK = plugin.sdk as RsdoctorPrimarySDK;
+    expect(primarySDK.parent.getSeriesData().map((item) => item.name)).toEqual([
+      'web',
+      'node',
+    ]);
+    expect(getSDK('web')).toBe(primarySDK);
+    expect(getSDK('node')).not.toBe(primarySDK);
+    expect(plugin.getCompilerSDK('node')).toBe(getSDK('node'));
+
+    await Promise.all(primarySDK.parent.slaves.map((sdk) => sdk.dispose()));
+  });
+
+  it('can disable aggregation for unrelated compiler instances', async () => {
+    const firstPlugin = new RsdoctorRspackPlugin({
+      disableClientServer: true,
+      multiCompiler: false,
+      server: { port: 19120 },
+    });
+    const secondPlugin = new RsdoctorRspackPlugin({
+      disableClientServer: true,
+      multiCompiler: false,
+      server: { port: 19121 },
+    });
+
+    rspack({ name: 'first', plugins: [firstPlugin] });
+    rspack({ name: 'second', plugins: [secondPlugin] });
+    await Promise.all([
+      firstPlugin._bootstrapTask,
+      secondPlugin._bootstrapTask,
+    ]);
+
+    const firstSDK = firstPlugin.sdk as RsdoctorPrimarySDK;
+    const secondSDK = secondPlugin.sdk as RsdoctorPrimarySDK;
+    expect(firstSDK.parent).not.toBe(secondSDK.parent);
+    expect(firstSDK.getManifestData().series).toBeUndefined();
+    expect(secondSDK.getManifestData().series).toBeUndefined();
+
+    await Promise.all([firstSDK.dispose(), secondSDK.dispose()]);
   });
 
   it('keeps the report server when the client server is disabled in CI', () => {

--- a/packages/document/docs/en/config/options/_meta.json
+++ b/packages/document/docs/en/config/options/_meta.json
@@ -10,5 +10,6 @@
   "supports",
   "brief",
   "mode",
+  "multiCompiler",
   "options-v2"
 ]

--- a/packages/document/docs/en/config/options/multiCompiler.mdx
+++ b/packages/document/docs/en/config/options/multiCompiler.mdx
@@ -1,0 +1,16 @@
+# multiCompiler
+
+- **Type:** `boolean | { group?: string }`
+- **Default:** `true`
+
+`RsdoctorRspackPlugin` automatically detects compilers created during the same startup, creates isolated analysis data for each compiler, and adds a compiler selector to the report. Rsbuild `environments` use their environment names, such as `web` and `node`.
+
+The default compiler keeps the existing `.rsdoctor` output path. Additional compilers are written to `.rsdoctor/compilers/<compilerName>`.
+
+Set this option to `false` when the same process creates unrelated compilers together. You can also explicitly group plugin instances:
+
+```ts
+new RsdoctorRspackPlugin({
+  multiCompiler: { group: 'ssr' },
+});
+```

--- a/packages/document/docs/en/config/options/options.mdx
+++ b/packages/document/docs/en/config/options/options.mdx
@@ -44,6 +44,7 @@ This `Options` object is the configuration for [RsdoctorRspackPlugin](#rsdoctorr
 - [supports](./supports.mdx) - **Feature Support Configuration**: Enable compatibility support for specific build tools, such as BannerPlugin, etc.
 - [brief](./brief.mdx) - **Brief Mode Configuration**: Control the generation of brief mode reports, including HTML filename and whether to generate JSON data files.
 - [mode](./mode.mdx) - **Build Report Data Output Mode**: Select the output mode for reports, supporting normal (normal mode) and brief (brief mode).
+- [multiCompiler](./multiCompiler.mdx) - **Multi-compiler Configuration**: Automatically detect and isolate reports for Rspack MultiCompiler and Rsbuild environments.
 
 ### RsdoctorRspackPluginOptions
 
@@ -51,6 +52,8 @@ This `Options` object is the configuration for [RsdoctorRspackPlugin](#rsdoctorr
 interface RsdoctorRspackPluginOptions<
   Rules extends LinterType.ExtendRuleData[],
 > {
+  multiCompiler?: boolean | { group?: string };
+
   /** Linter configuration */
   linter?: LinterType.Options<Rules, InternalRules>;
 

--- a/packages/document/docs/zh/config/options/_meta.json
+++ b/packages/document/docs/zh/config/options/_meta.json
@@ -10,5 +10,6 @@
   "supports",
   "brief",
   "mode",
+  "multiCompiler",
   "options-v2"
 ]

--- a/packages/document/docs/zh/config/options/multiCompiler.mdx
+++ b/packages/document/docs/zh/config/options/multiCompiler.mdx
@@ -1,0 +1,16 @@
+# multiCompiler
+
+- **类型：** `boolean | { group?: string }`
+- **默认值：** `true`
+
+`RsdoctorRspackPlugin` 默认会自动识别同一次启动中的多个 compiler，为每个 compiler 创建独立的分析数据，并在报告中提供 compiler 切换入口。Rsbuild 的 `environments` 会直接使用 environment 名称，例如 `web`、`node`。
+
+默认 compiler 仍输出到原有的 `.rsdoctor` 目录，其他 compiler 输出到 `.rsdoctor/compilers/<compilerName>`。
+
+如果同一进程会同时创建多个互不相关的 compiler，可以设置为 `false` 来关闭跨插件实例的自动聚合。也可以提供 `group`，显式指定需要聚合的插件实例：
+
+```ts
+new RsdoctorRspackPlugin({
+  multiCompiler: { group: 'ssr' },
+});
+```

--- a/packages/document/docs/zh/config/options/options.mdx
+++ b/packages/document/docs/zh/config/options/options.mdx
@@ -44,6 +44,7 @@ new RsdoctorRspackPlugin({/** RsdoctorRspackPluginOptions */});
 - [supports](./supports.mdx) - **特性支持配置**：启用特定构建工具的兼容性支持，如 BannerPlugin 等
 - [brief](./brief.mdx) - **Brief 模式的配置**：控制简要模式报告的生成，包括 HTML 文件名和是否生成 JSON 数据文件
 - [mode](./mode.mdx) - **构建报告数据输出模式**：选择报告的输出模式，支持 normal（普通模式）和 brief（简要模式）
+- [multiCompiler](./multiCompiler.mdx) - **多编译器配置**：自动识别并隔离 Rspack MultiCompiler 和 Rsbuild environments 的分析报告
 
 ### RsdoctorRspackPluginOptions
 
@@ -51,6 +52,8 @@ new RsdoctorRspackPlugin({/** RsdoctorRspackPluginOptions */});
 interface RsdoctorRspackPluginOptions<
   Rules extends LinterType.ExtendRuleData[],
 > {
+  multiCompiler?: boolean | { group?: string };
+
   linter?: LinterType.Options<Rules, InternalRules>;
 
   /** Rsdoctor 功能开关 */

--- a/packages/shared/src/types/plugin/plugin.ts
+++ b/packages/shared/src/types/plugin/plugin.ts
@@ -47,6 +47,7 @@ export interface RsdoctorPluginOptionsNormalized<
     | 'brief'
     | 'mode'
     | 'server'
+    | 'multiCompiler'
   >
 > {
   features: Common.DeepRequired<RsdoctorRspackPluginFeatures>;
@@ -61,6 +62,10 @@ export interface RsdoctorPluginOptionsNormalized<
   port?: number;
   server: SDK.RsdoctorServerConfig;
   supports: NormalizedSupports;
+  multiCompiler: {
+    enabled: boolean;
+    group?: string;
+  };
 }
 
 export type GzipConfig =
@@ -128,6 +133,18 @@ export type NewReportCodeType =
 export interface RsdoctorRspackPluginOptions<
   Rules extends LinterType.ExtendRuleData[],
 > {
+  /**
+   * Configure automatic multi-compiler aggregation.
+   *
+   * Rsdoctor groups plugin instances created for the same compiler startup by
+   * default. Set this to `false` when multiple unrelated compilers are created
+   * together in the same process, or provide a group name to explicitly group
+   * compiler reports.
+   *
+   * @default true
+   */
+  multiCompiler?: boolean | { group?: string };
+
   /** Checker configuration */
   linter?: LinterType.Options<Rules, InternalRules>;
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,15 @@ importers:
 
   e2e/cases/doctor-rspack/fixtures/loaders/esm: {}
 
+  examples/rsbuild-environments:
+    devDependencies:
+      '@rsbuild/core':
+        specifier: 'catalog:'
+        version: 2.1.10
+      '@rsdoctor/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+
   examples/rsbuild-minimal:
     dependencies:
       react:
@@ -747,7 +756,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 1.5.3(@rsbuild/core@2.1.9)
+        version: 1.5.3(@rsbuild/core@2.1.10)
       '@rsdoctor/core':
         specifier: workspace:*
         version: link:../core
@@ -786,10 +795,10 @@ importers:
         version: 19.1.0(react@19.2.8)
       rsbuild-plugin-google-analytics:
         specifier: ^1.0.6
-        version: 1.0.6(@rsbuild/core@2.1.9)
+        version: 1.0.6(@rsbuild/core@2.1.10)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.3
-        version: 1.1.3(@rsbuild/core@2.1.9)
+        version: 1.1.3(@rsbuild/core@2.1.10)
       rspress-plugin-font-open-sans:
         specifier: ^1.0.4
         version: 1.0.4(@rspress/core@2.0.19(@rspack/core@2.1.8(@swc/helpers@0.5.23))(micromark-util-types@2.0.1)(micromark@4.0.1))
@@ -8549,12 +8558,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.10
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8(@swc/helpers@0.5.23))':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.8(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.9
+      '@rsbuild/core': 2.1.10
     transitivePeerDependencies:
       - '@rspack/core'
 
@@ -8567,15 +8576,6 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8(@swc/helpers@0.5.23))':
-    dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.8(@swc/helpers@0.5.23))(react-refresh@0.18.0)
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rsbuild/core': 2.1.9
-    transitivePeerDependencies:
-      - '@rspack/core'
-
   '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.1.10)':
     dependencies:
       deepmerge: 4.3.1
@@ -8585,16 +8585,6 @@ snapshots:
       sass-embedded: 1.100.0
     optionalDependencies:
       '@rsbuild/core': 2.1.10
-
-  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.1.9)':
-    dependencies:
-      deepmerge: 4.3.1
-      loader-utils: 2.0.4
-      postcss: 8.5.15
-      reduce-configs: 1.1.2
-      sass-embedded: 1.100.0
-    optionalDependencies:
-      '@rsbuild/core': 2.1.9
 
   '@rsbuild/plugin-svgr@2.0.5(@rsbuild/core@2.1.10)(@rspack/core@2.1.8(@swc/helpers@0.5.23))(typescript@7.0.2)':
     dependencies:
@@ -8924,8 +8914,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.7)
-      '@rsbuild/core': 2.1.9
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.8(@swc/helpers@0.5.23))
+      '@rsbuild/core': 2.1.10
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.10)(@rspack/core@2.1.8(@swc/helpers@0.5.23))
       '@rspress/shared': 2.0.15
       '@shikijs/rehype': 4.3.0
       '@types/unist': 3.0.3
@@ -8974,8 +8964,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.8)
-      '@rsbuild/core': 2.1.9
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.8(@swc/helpers@0.5.23))
+      '@rsbuild/core': 2.1.10
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.10)(@rspack/core@2.1.8(@swc/helpers@0.5.23))
       '@rspress/shared': 2.0.19
       '@shikijs/rehype': 4.3.0
       '@types/mdast': 4.0.4
@@ -9042,7 +9032,7 @@ snapshots:
 
   '@rspress/shared@2.0.15':
     dependencies:
-      '@rsbuild/core': 2.1.9
+      '@rsbuild/core': 2.1.10
       '@shikijs/rehype': 4.3.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9051,7 +9041,7 @@ snapshots:
 
   '@rspress/shared@2.0.19':
     dependencies:
-      '@rsbuild/core': 2.1.9
+      '@rsbuild/core': 2.1.10
       '@shikijs/rehype': 4.3.0
       '@types/react': 19.2.17
       mdast-util-mdx-jsx: 3.2.0
@@ -12831,13 +12821,13 @@ snapshots:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.12.3)
       typescript: 7.0.2
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.9):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.10):
     optionalDependencies:
-      '@rsbuild/core': 2.1.9
+      '@rsbuild/core': 2.1.10
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.9):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.10):
     optionalDependencies:
-      '@rsbuild/core': 2.1.9
+      '@rsbuild/core': 2.1.10
 
   rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.1.10):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,15 @@ importers:
 
   e2e/cases/doctor-rspack/fixtures/loaders/esm: {}
 
+  examples/rsbuild-environments:
+    devDependencies:
+      '@rsbuild/core':
+        specifier: 'catalog:'
+        version: 2.1.9
+      '@rsdoctor/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+
   examples/rsbuild-minimal:
     dependencies:
       react:
@@ -732,7 +741,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-sass':
         specifier: 'catalog:'
-        version: 1.5.3(@rsbuild/core@2.1.8)
+        version: 1.5.3(@rsbuild/core@2.1.9)
       '@rsdoctor/core':
         specifier: workspace:*
         version: link:../core
@@ -771,10 +780,10 @@ importers:
         version: 19.1.0(react@19.2.8)
       rsbuild-plugin-google-analytics:
         specifier: ^1.0.6
-        version: 1.0.6(@rsbuild/core@2.1.8)
+        version: 1.0.6(@rsbuild/core@2.1.9)
       rsbuild-plugin-open-graph:
         specifier: ^1.1.3
-        version: 1.1.3(@rsbuild/core@2.1.8)
+        version: 1.1.3(@rsbuild/core@2.1.9)
       rspress-plugin-font-open-sans:
         specifier: ^1.0.4
         version: 1.0.4(@rspress/core@2.0.19(@rspack/core@2.1.7(@swc/helpers@0.5.23))(micromark-util-types@2.0.1)(micromark@4.0.1))
@@ -8536,21 +8545,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.9
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.8)(@rspack/core@2.1.7(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7(@swc/helpers@0.5.23))':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.1.7(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.8
-    transitivePeerDependencies:
-      - '@rspack/core'
-
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.8)(@rspack/core@2.1.7(@swc/helpers@0.5.23))':
-    dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.7(@swc/helpers@0.5.23))(react-refresh@0.18.0)
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rsbuild/core': 2.1.8
+      '@rsbuild/core': 2.1.9
     transitivePeerDependencies:
       - '@rspack/core'
 
@@ -8562,16 +8562,6 @@ snapshots:
       '@rsbuild/core': 2.1.9
     transitivePeerDependencies:
       - '@rspack/core'
-
-  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.1.8)':
-    dependencies:
-      deepmerge: 4.3.1
-      loader-utils: 2.0.4
-      postcss: 8.5.15
-      reduce-configs: 1.1.2
-      sass-embedded: 1.100.0
-    optionalDependencies:
-      '@rsbuild/core': 2.1.8
 
   '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.1.9)':
     dependencies:
@@ -8969,8 +8959,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.7)
-      '@rsbuild/core': 2.1.8
-      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.8)(@rspack/core@2.1.7(@swc/helpers@0.5.23))
+      '@rsbuild/core': 2.1.9
+      '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.1.9)(@rspack/core@2.1.7(@swc/helpers@0.5.23))
       '@rspress/shared': 2.0.15
       '@shikijs/rehype': 4.3.0
       '@types/unist': 3.0.3
@@ -9019,8 +9009,8 @@ snapshots:
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.8)
-      '@rsbuild/core': 2.1.8
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.8)(@rspack/core@2.1.7(@swc/helpers@0.5.23))
+      '@rsbuild/core': 2.1.9
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.9)(@rspack/core@2.1.7(@swc/helpers@0.5.23))
       '@rspress/shared': 2.0.19
       '@shikijs/rehype': 4.3.0
       '@types/mdast': 4.0.4
@@ -9087,7 +9077,7 @@ snapshots:
 
   '@rspress/shared@2.0.15':
     dependencies:
-      '@rsbuild/core': 2.1.8
+      '@rsbuild/core': 2.1.9
       '@shikijs/rehype': 4.3.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9096,7 +9086,7 @@ snapshots:
 
   '@rspress/shared@2.0.19':
     dependencies:
-      '@rsbuild/core': 2.1.8
+      '@rsbuild/core': 2.1.9
       '@shikijs/rehype': 4.3.0
       '@types/react': 19.2.17
       mdast-util-mdx-jsx: 3.2.0
@@ -12890,13 +12880,13 @@ snapshots:
       '@microsoft/api-extractor': 7.58.12(@types/node@24.12.3)
       typescript: 7.0.2
 
-  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.8):
+  rsbuild-plugin-google-analytics@1.0.6(@rsbuild/core@2.1.9):
     optionalDependencies:
-      '@rsbuild/core': 2.1.8
+      '@rsbuild/core': 2.1.9
 
-  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.8):
+  rsbuild-plugin-open-graph@1.1.3(@rsbuild/core@2.1.9):
     optionalDependencies:
-      '@rsbuild/core': 2.1.8
+      '@rsbuild/core': 2.1.9
 
   rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.1.7):
     dependencies:


### PR DESCRIPTION
## Summary

Rsdoctor currently requires consumers to switch to a separate multi-compiler plugin for multi-compiler builds. This PR lets `RsdoctorRspackPlugin` automatically group compilers, isolate their report data, and expose compiler navigation while preserving explicit opt-out controls. It also covers Rsbuild environments and adds a runnable web and Node environments example.

## Related Links
#1710 
- https://rsbuild.rs/config/environments