### PR TITLE
fix(ai): restore MCP loader and chunk queries

### DIFF
--- a/packages/ai/src/server/schemas.ts
+++ b/packages/ai/src/server/schemas.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export const chunkIdSchema = z.string();

--- a/packages/ai/src/server/server.ts
+++ b/packages/ai/src/server/server.ts
@@ -20,6 +20,7 @@ import {
   getPackageInfoByPackageName,
 } from './tools.js';
 import { registerStaticResources } from './resource.js';
+import { chunkIdSchema } from './schemas.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { toolDescriptions } from '../prompt/bundle.js';
 
@@ -46,7 +47,7 @@ server.tool(Tools.GetAllChunks, 'get all chunks', {}, async () => {
 server.tool(
   Tools.GetChunkById,
   'get chunk by id',
-  { chunkId: z.number() },
+  { chunkId: chunkIdSchema },
   async ({ chunkId }) => {
     const res = await getChunkById(chunkId);
     return {

--- a/packages/ai/src/server/tools.ts
+++ b/packages/ai/src/server/tools.ts
@@ -38,7 +38,7 @@ export const getAllChunks = async (): Promise<
   )) as SDK.ServerAPI.InferResponseType<SDK.ServerAPI.API.GetChunkGraphAI>;
 };
 
-export const getChunkById = async (chunkId: number) => {
+export const getChunkById = async (chunkId: string) => {
   const chunk = await sendRequest(SDK.ServerAPI.API.GetChunkByIdAI, {
     chunkId,
   });

--- a/packages/ai/tests/server.test.ts
+++ b/packages/ai/tests/server.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from '@rstest/core';
+import { chunkIdSchema } from '../src/server/schemas';
+
+describe('server/server', () => {
+  it('accepts string chunk ids used by chunk reports', () => {
+    expect(chunkIdSchema.parse('77')).toBe('77');
+    expect(() => chunkIdSchema.parse(77)).toThrow();
+  });
+});

--- a/packages/utils/src/common/loader.ts
+++ b/packages/utils/src/common/loader.ts
@@ -281,13 +281,12 @@ function collectResourceDirectories(
   loaders.forEach((item) => {
     if (item.resource.path.startsWith(root)) {
       const pathParts = item.resource.path
-        .split(root)
-        .slice(1)
-        .join('/')
+        .slice(root.length)
+        .replace(/^\/+/, '')
         .split('/');
       if (pathParts.length >= 2) {
-        const twoLevelDir = pathParts.slice(0, 2).join('/');
-        directories.add(`${root}/${twoLevelDir}`);
+        const normalizedRoot = root.replace(/\/+$/, '');
+        directories.add(`${normalizedRoot}/${pathParts[0]}`);
       }
     } else {
       const pathParts = item.resource.path.split('/');

--- a/packages/utils/tests/common/loader.test.ts
+++ b/packages/utils/tests/common/loader.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from '@rstest/core';
 import { SDK } from '@rsdoctor/types';
 import {
+  getDirectoriesLoaders,
   getLoaderFileDetails,
   getLoaderFileInputAndOutput,
 } from '../../src/common/loader';
@@ -121,5 +122,23 @@ describe('test src/common/loader.ts', () => {
     expect(() => {
       getLoaderFileDetails('/non-existent/file.js', mockLoaderData);
     }).toThrow('"/non-existent/file.js" not match any loader data');
+  });
+
+  it('getDirectoriesLoaders should match loader stats without duplicate separators', () => {
+    const nestedLoaderData: SDK.LoaderData = [
+      {
+        ...mockLoaderData[0],
+        resource: {
+          ...mockLoaderData[0].resource,
+          path: '/test/src/file.js',
+        },
+      },
+    ];
+
+    const result = getDirectoriesLoaders(nestedLoaderData, '/test');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].directory).toBe('/test/src');
+    expect(result[0].stats).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

- Fix `get_loader_times` directory aggregation so loader statistics match resource paths without duplicate separators.
- Accept string chunk IDs in `get_chunk_by_id`, matching Rsdoctor report data.
- Add regression coverage for both MCP queries.

## Related Links

https://github.com/web-infra-dev/rsdoctor/pull/1765#issuecomment-5176094617