### PR TITLE
chore(core): statically import package metadata

### DIFF
--- a/packages/core/src/rspack-plugin/constants.ts
+++ b/packages/core/src/rspack-plugin/constants.ts
@@ -23,4 +23,4 @@ export const internalPluginTapPostOptions = (namespace: string): Tap => ({
   stage: 1000,
 });
 
-export const pkg = packageJson;
+export const pkg: { version: string } = packageJson;

--- a/packages/core/src/rspack-plugin/constants.ts
+++ b/packages/core/src/rspack-plugin/constants.ts
@@ -1,12 +1,5 @@
-import { existsSync } from 'node:fs';
-import { createRequire } from 'node:module';
 import type { Tap } from '@rspack/lite-tapable';
-
-const require = createRequire(import.meta.url);
-const packageJsonPath = existsSync(new URL('../package.json', import.meta.url))
-  ? '../package.json'
-  : '../../package.json';
-const packageJson = require(packageJsonPath) as { version: string };
+import packageJson from '../../package.json';
 
 export const pluginTapName = 'RsdoctorRspackPlugin';
 


### PR DESCRIPTION
## Summary

A future Rslib release may treat `new URL(..., import.meta.url)` as a module dependency, breaking the current package.json lookup. This replaces runtime path detection with a static JSON import to avoid assumptions about source and output paths.

## Related Links

https://github.com/web-infra-dev/rslib/pull/1781