### PR TITLE
fix(sdk): preserve large manifest sharding integrity

### DIFF
--- a/.changeset/fix-large-manifest-sharding.md
+++ b/.changeset/fix-large-manifest-sharding.md
@@ -1,0 +1,6 @@
+---
+'@rsdoctor/sdk': patch
+'@rsdoctor/utils': patch
+---
+
+Fix large manifest serialization so streamed JSON fragments are written as one deflate stream without losing the final fragment or reversing shard batches.

--- a/.changeset/fix-large-manifest-sharding.md
+++ b/.changeset/fix-large-manifest-sharding.md
@@ -3,4 +3,4 @@
 '@rsdoctor/utils': patch
 ---
 
-Fix large manifest serialization so streamed JSON fragments are written as one deflate stream without losing the final fragment or reversing shard batches.
+Fix large manifest serialization so streamed JSON fragments use one continuous deflate/Base64 stream, are written and read with bounded sharding buffers, and do not lose or reorder fragments.

--- a/packages/sdk/src/sdk/sdk/core.ts
+++ b/packages/sdk/src/sdk/sdk/core.ts
@@ -4,6 +4,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 import process from 'node:process';
+import { Readable } from 'node:stream';
+import { createDeflate } from 'node:zlib';
 import { AsyncSeriesHook } from 'tapable';
 import { decycle } from '@rsdoctor/utils/common';
 import { logger } from '@rsdoctor/utils/logger';
@@ -155,19 +157,9 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
       })();
 
       if (Array.isArray(jsonStr)) {
-        // Write chunks sequentially with cumulative file offset so each
-        // chunk's shard files get unique IDs within the shared folder.
-        let fileOffset = 0;
-        for (const str of jsonStr) {
-          const result = await this.writeToFolder(
-            str,
-            outputDir,
-            key,
-            fileOffset,
-          );
-          fileOffset += result.files.length;
-          urlsPromiseList.push(result);
-        }
+        urlsPromiseList.push(
+          this.writeJsonFragmentsToFolder(jsonStr, outputDir, key),
+        );
       } else {
         urlsPromiseList.push(this.writeToFolder(jsonStr, outputDir, key));
       }
@@ -229,7 +221,44 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
     key: string,
     index?: number,
   ): Promise<DataWithUrl> {
-    const sharding = new File.FileSharding(Algorithm.compressText(jsonStr));
+    const compressedText = Algorithm.compressText(jsonStr);
+    if (!compressedText) {
+      throw new Error(`Failed to compress manifest data for "${key}".`);
+    }
+
+    return this.writeEncodedTextToFolder(compressedText, dir, key, index);
+  }
+
+  protected async writeJsonFragmentsToFolder(
+    jsonFragments: string[],
+    dir: string,
+    key: string,
+    index?: number,
+  ): Promise<DataWithUrl> {
+    if (jsonFragments.length === 0) {
+      throw new Error(`Cannot write empty JSON fragments for "${key}".`);
+    }
+
+    const compressedChunks: Buffer[] = [];
+    const compressor = Readable.from(jsonFragments, {
+      objectMode: false,
+    }).pipe(createDeflate());
+
+    for await (const chunk of compressor) {
+      compressedChunks.push(Buffer.from(chunk));
+    }
+
+    const compressedText = Buffer.concat(compressedChunks).toString('base64');
+    return this.writeEncodedTextToFolder(compressedText, dir, key, index);
+  }
+
+  private writeEncodedTextToFolder(
+    encodedText: string,
+    dir: string,
+    key: string,
+    index?: number,
+  ): Promise<DataWithUrl> {
+    const sharding = new File.FileSharding(encodedText);
     const folder = path.resolve(dir, key);
     const writer = sharding.writeStringToFolder(folder, '', index);
     return writer.then((item) => {

--- a/packages/sdk/src/sdk/sdk/core.ts
+++ b/packages/sdk/src/sdk/sdk/core.ts
@@ -1,17 +1,14 @@
 import { Common, Constants, Manifest, SDK } from '@rsdoctor/types';
-import { File, Json, EnvInfo } from '@rsdoctor/utils/build';
+import { EnvInfo, File, Json } from '@rsdoctor/utils/build';
 import fs from 'node:fs';
 import path from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 import process from 'node:process';
-import { Readable } from 'node:stream';
-import { createDeflate } from 'node:zlib';
 import { AsyncSeriesHook } from 'tapable';
 import { decycle } from '@rsdoctor/utils/common';
 import { logger } from '@rsdoctor/utils/logger';
-import { transformDataUrls } from '../utils';
+import { transformDataUrls, writeManifestShards } from '../utils';
 import { RsdoctorSDKOptions, DataWithUrl } from './types';
-import { Algorithm } from '@rsdoctor/utils/common';
 
 export abstract class SDKCore<T extends RsdoctorSDKOptions>
   implements SDK.RsdoctorSDKInstance
@@ -221,12 +218,7 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
     key: string,
     index?: number,
   ): Promise<DataWithUrl> {
-    const compressedText = Algorithm.compressText(jsonStr);
-    if (!compressedText) {
-      throw new Error(`Failed to compress manifest data for "${key}".`);
-    }
-
-    return this.writeEncodedTextToFolder(compressedText, dir, key, index);
+    return this.writeJsonFragmentsToFolder([jsonStr], dir, key, index);
   }
 
   protected async writeJsonFragmentsToFolder(
@@ -239,39 +231,9 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
       throw new Error(`Cannot write empty JSON fragments for "${key}".`);
     }
 
-    const compressedChunks: Buffer[] = [];
-    const compressor = Readable.from(jsonFragments, {
-      objectMode: false,
-    }).pipe(createDeflate());
-
-    for await (const chunk of compressor) {
-      compressedChunks.push(Buffer.from(chunk));
-    }
-
-    const compressedText = Buffer.concat(compressedChunks).toString('base64');
-    return this.writeEncodedTextToFolder(compressedText, dir, key, index);
-  }
-
-  private writeEncodedTextToFolder(
-    encodedText: string,
-    dir: string,
-    key: string,
-    index?: number,
-  ): Promise<DataWithUrl> {
-    const sharding = new File.FileSharding(encodedText);
     const folder = path.resolve(dir, key);
-    const writer = sharding.writeStringToFolder(folder, '', index);
-    return writer.then((item) => {
-      const res: DataWithUrl = {
-        name: key,
-        files: item.map((el) => ({
-          path: path.resolve(folder, el.filename),
-          basename: el.filename,
-          content: el.content,
-        })),
-      };
-      return res;
-    });
+    const files = await writeManifestShards(jsonFragments, folder, { index });
+    return { name: key, files };
   }
 
   public abstract onDataReport(): void | Promise<void>;

--- a/packages/sdk/src/sdk/sdk/types.ts
+++ b/packages/sdk/src/sdk/sdk/types.ts
@@ -6,7 +6,7 @@ export interface DataWithUrl {
     | {
         path: string;
         basename: string;
-        content: Buffer;
+        content?: Buffer;
       }[]
     | string;
 }

--- a/packages/sdk/src/sdk/utils/index.ts
+++ b/packages/sdk/src/sdk/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './constant';
 export * from './base';
 export * from './upload';
+export * from './manifestSharding';

--- a/packages/sdk/src/sdk/utils/manifestSharding.ts
+++ b/packages/sdk/src/sdk/utils/manifestSharding.ts
@@ -1,0 +1,96 @@
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { createDeflate } from 'node:zlib';
+
+export const DEFAULT_MANIFEST_SHARD_SIZE = 10 * 1024 * 1024;
+
+interface WriteManifestShardsOptions {
+  index?: number;
+  shardSize?: number;
+}
+
+export interface ManifestShardFile {
+  path: string;
+  basename: string;
+}
+
+/**
+ * Compress JSON fragments as one deflate stream, encode that stream as one
+ * continuous Base64 value, and write bounded physical shards.
+ */
+export async function writeManifestShards(
+  jsonFragments: string[],
+  folder: string,
+  options: WriteManifestShardsOptions = {},
+): Promise<ManifestShardFile[]> {
+  if (jsonFragments.length === 0) {
+    throw new Error('Cannot write empty JSON fragments.');
+  }
+
+  const { index = 0, shardSize = DEFAULT_MANIFEST_SHARD_SIZE } = options;
+  if (!Number.isSafeInteger(shardSize) || shardSize <= 0) {
+    throw new Error('Manifest shard size must be a positive integer.');
+  }
+
+  await fsp.mkdir(folder, { recursive: true });
+
+  const files: ManifestShardFile[] = [];
+  let shardParts: string[] = [];
+  let shardLength = 0;
+
+  const flushShard = async () => {
+    if (shardLength === 0) return;
+
+    const basename = String(index + files.length);
+    const filePath = path.resolve(folder, basename);
+    await fsp.writeFile(filePath, shardParts.join(''), 'utf8');
+    files.push({ path: filePath, basename });
+    shardParts = [];
+    shardLength = 0;
+  };
+
+  const appendEncodedText = async (encodedText: string) => {
+    let offset = 0;
+    while (offset < encodedText.length) {
+      const length = Math.min(
+        shardSize - shardLength,
+        encodedText.length - offset,
+      );
+      shardParts.push(encodedText.slice(offset, offset + length));
+      shardLength += length;
+      offset += length;
+
+      if (shardLength === shardSize) {
+        await flushShard();
+      }
+    }
+  };
+
+  const compressor = Readable.from(jsonFragments, {
+    objectMode: false,
+  }).pipe(createDeflate());
+  let base64Remainder = Buffer.alloc(0);
+
+  for await (const chunk of compressor) {
+    const compressedChunk = Buffer.from(chunk);
+    const bytes = base64Remainder.length
+      ? Buffer.concat([base64Remainder, compressedChunk])
+      : compressedChunk;
+    const encodableLength = bytes.length - (bytes.length % 3);
+
+    if (encodableLength > 0) {
+      await appendEncodedText(
+        bytes.subarray(0, encodableLength).toString('base64'),
+      );
+    }
+    base64Remainder = Buffer.from(bytes.subarray(encodableLength));
+  }
+
+  if (base64Remainder.length > 0) {
+    await appendEncodedText(base64Remainder.toString('base64'));
+  }
+  await flushShard();
+
+  return files;
+}

--- a/packages/sdk/src/sdk/utils/upload.ts
+++ b/packages/sdk/src/sdk/utils/upload.ts
@@ -4,9 +4,16 @@ export const transformDataUrls = (
   d: DataWithUrl[],
 ): Record<string, string[] | string> => {
   return d.reduce((t: { [key: string]: string[] | string }, item) => {
-    t[item.name] = Array.isArray(item.files)
-      ? item.files.map((e) => e.path).concat(t[item.name] || [])
-      : item.files;
+    if (!Array.isArray(item.files)) {
+      t[item.name] = item.files;
+      return t;
+    }
+
+    const previous = t[item.name];
+    t[item.name] = [
+      ...(Array.isArray(previous) ? previous : []),
+      ...item.files.map((e) => e.path),
+    ];
     return t;
   }, {});
 };

--- a/packages/sdk/tests/sdk/core/write-pieces-sharding.test.ts
+++ b/packages/sdk/tests/sdk/core/write-pieces-sharding.test.ts
@@ -1,19 +1,21 @@
 import path from 'path';
 import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 import zlib from 'node:zlib';
 import { tmpdir } from 'os';
 import { describe, it, expect, afterEach } from '@rstest/core';
 import { File } from '@rsdoctor/utils/build';
+import { Manifest } from '@rsdoctor/utils/common';
 import { createSDK, type MockSDKResponse } from '../../utils';
 
 /**
  * Verify that writePieces (called via saveManifest) correctly shards data
  * to disk with unique file IDs, and that the data is recoverable.
  *
- * Regression: when Json.stringify split large data into multiple chunks,
- * writePieces called writeToFolder with index=N+1 for chunk N. If chunk 0
- * produced shard files 1..10 and chunk 1 started at file 2, files 2..N
- * would be overwritten, making the data unrecoverable.
+ * Regression: when Json.stringify split large data into multiple fragments,
+ * each fragment was compressed independently and written with overlapping
+ * shard IDs. The reader concatenates all shards and inflates them as one
+ * stream, so the data could not be recovered.
  */
 describe('writePieces shard file integrity', () => {
   let target: MockSDKResponse;
@@ -102,9 +104,8 @@ describe('writePieces shard file integrity', () => {
       .readdirSync(loaderDir)
       .sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
 
-    // Json.stringify returns string[], so writePieces goes through the
-    // array branch with cumulative offsets. Even with 1 chunk, this
-    // exercises the for-loop and fileOffset logic.
+    // Json.stringify returns string[], so writePieces uses the shared deflate
+    // stream path. Even one fragment exercises the fallback branch.
     expect(files.length).toBeGreaterThanOrEqual(1);
 
     const uniqueIds = new Set(files);
@@ -121,5 +122,32 @@ describe('writePieces shard file integrity', () => {
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed.length).toBe(1);
     expect(parsed[0].resource.path).toBe('/test/a.ts');
+  });
+
+  it('should write multiple JSON fragments as one deflate stream', async () => {
+    target = await createSDK({ noServer: true });
+    outputDir = path.resolve(tmpdir(), `sharding_fragments_test_${Date.now()}`);
+
+    const graph = { modules: [{ id: 1 }, { id: 2 }] };
+    const fragments = ['{"modules":[', '{"id":1},', '{"id":2}]}'];
+    const writer = target.sdk as unknown as {
+      writeJsonFragmentsToFolder(
+        fragments: string[],
+        dir: string,
+        key: string,
+      ): Promise<{ files: Array<{ path: string }> }>;
+    };
+    const result = await writer.writeJsonFragmentsToFolder(
+      fragments,
+      outputDir,
+      'moduleGraph',
+    );
+    const files = result.files.map(({ path: filePath }) => filePath);
+
+    await expect(
+      Manifest.fetchShardingData(files, (filePath) =>
+        fsp.readFile(filePath, 'utf-8'),
+      ),
+    ).resolves.toStrictEqual(graph);
   });
 });

--- a/packages/sdk/tests/sdk/utils/manifestSharding.test.ts
+++ b/packages/sdk/tests/sdk/utils/manifestSharding.test.ts
@@ -1,0 +1,74 @@
+import { randomBytes } from 'node:crypto';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { inflateSync } from 'node:zlib';
+import { afterEach, describe, expect, it } from '@rstest/core';
+import { File } from '@rsdoctor/utils/build';
+import { writeManifestShards } from '../../../src/sdk/utils';
+
+describe('writeManifestShards', () => {
+  let outputDir: string;
+
+  afterEach(async () => {
+    if (outputDir) await File.fse.remove(outputDir);
+  });
+
+  it('writes one continuous Base64 deflate stream into bounded shards', async () => {
+    outputDir = path.resolve(
+      tmpdir(),
+      `manifest_stream_sharding_${Date.now()}`,
+    );
+    const data = {
+      modules: [
+        {
+          id: 1,
+          source: randomBytes(32 * 1024).toString('base64'),
+        },
+      ],
+    };
+    const jsonText = JSON.stringify(data);
+    const fragmentSize = Math.ceil(jsonText.length / 3);
+    const fragments = Array.from({ length: 3 }, (_, index) =>
+      jsonText.slice(index * fragmentSize, (index + 1) * fragmentSize),
+    ).filter(Boolean);
+
+    const files = await writeManifestShards(fragments, outputDir, {
+      index: 5,
+      // Deliberately not divisible by 3 or 4 to exercise both the deflate
+      // chunk carry and arbitrary physical shard boundaries.
+      shardSize: 1021,
+    });
+    const shardContents = await Promise.all(
+      files.map(({ path: filePath }) => fsp.readFile(filePath, 'utf8')),
+    );
+    const encodedText = shardContents.join('');
+    const restored = JSON.parse(
+      inflateSync(Buffer.from(encodedText, 'base64')).toString('utf8'),
+    );
+
+    expect(files.length).toBeGreaterThan(1);
+    expect(files.map(({ basename }) => basename)).toStrictEqual(
+      files.map((_, index) => String(index + 5)),
+    );
+    expect(
+      shardContents.slice(0, -1).every((text) => text.length === 1021),
+    ).toBe(true);
+    expect(encodedText.slice(0, -2)).not.toContain('=');
+    expect(restored).toStrictEqual(data);
+  });
+
+  it('rejects empty fragments and invalid shard sizes', async () => {
+    outputDir = path.resolve(
+      tmpdir(),
+      `manifest_stream_sharding_invalid_${Date.now()}`,
+    );
+
+    await expect(writeManifestShards([], outputDir)).rejects.toThrow(
+      'Cannot write empty JSON fragments',
+    );
+    await expect(
+      writeManifestShards(['{}'], outputDir, { shardSize: 0 }),
+    ).rejects.toThrow('Manifest shard size must be a positive integer');
+  });
+});

--- a/packages/sdk/tests/sdk/utils/upload.test.ts
+++ b/packages/sdk/tests/sdk/utils/upload.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from '@rstest/core';
+import { transformDataUrls } from '../../../src/sdk/utils';
+
+describe('transformDataUrls', () => {
+  it('preserves the order of multiple batches for the same key', () => {
+    const createFile = (filePath: string) => ({
+      path: filePath,
+      basename: filePath,
+      content: Buffer.from(filePath),
+    });
+
+    const result = transformDataUrls([
+      {
+        name: 'moduleGraph',
+        files: [createFile('/moduleGraph/1'), createFile('/moduleGraph/2')],
+      },
+      {
+        name: 'moduleGraph',
+        files: [createFile('/moduleGraph/3'), createFile('/moduleGraph/4')],
+      },
+    ]);
+
+    expect(result.moduleGraph).toStrictEqual([
+      '/moduleGraph/1',
+      '/moduleGraph/2',
+      '/moduleGraph/3',
+      '/moduleGraph/4',
+    ]);
+  });
+});

--- a/packages/utils/src/build/json.ts
+++ b/packages/utils/src/build/json.ts
@@ -11,6 +11,7 @@ export function stringify<T, P = T extends undefined ? undefined : string>(
   replacer?: (this: any, key: string, value: any) => any,
   space?: string | number,
   cycle?: boolean,
+  chunkSize = maxFileSize,
 ): Promise<P> {
   const jsonList: string[] = [];
   if (json && typeof json === 'object') {
@@ -26,7 +27,7 @@ export function stringify<T, P = T extends undefined ? undefined : string>(
           const lines = chunk.toString().split('\\n');
 
           lines.forEach((line: string | any[]) => {
-            if (currentLength + line.length > maxFileSize) {
+            if (currentLength + line.length > chunkSize) {
               // 超出最大长度，保存当前内容
               jsonList.push(currentContent);
               currentContent = '';
@@ -46,7 +47,7 @@ export function stringify<T, P = T extends undefined ? undefined : string>(
       stream
         .pipe(batchProcessor)
         .on('data', (line: string | any[]) => {
-          if (currentLength + line.length > maxFileSize) {
+          if (currentLength + line.length > chunkSize) {
             //Exceeding the maximum length, closing the current file stream.
             jsonList.push(currentContent);
             currentContent = '';
@@ -59,7 +60,7 @@ export function stringify<T, P = T extends undefined ? undefined : string>(
           }
         })
         .on('end', () => {
-          if (jsonList.length < 1) {
+          if (currentContent.length > 0) {
             jsonList.push(currentContent);
           }
           resolve(jsonList as P);

--- a/packages/utils/src/common/manifest.ts
+++ b/packages/utils/src/common/manifest.ts
@@ -1,6 +1,30 @@
 import { Manifest } from '@rsdoctor/types';
-import { decompressText } from './algorithm';
+import { Buffer } from 'buffer';
+import { Readable } from 'stream';
+import { StringDecoder } from 'string_decoder';
+import { createInflate } from 'zlib';
 import { isRemoteUrl } from './url';
+
+async function* decodeBase64Shards(
+  shardingFiles: string[],
+  fetchImplement: (url: string) => Promise<string>,
+) {
+  let remainder = '';
+
+  for (const url of shardingFiles) {
+    const encodedText = remainder + (await fetchImplement(url));
+    const decodableLength = encodedText.length - (encodedText.length % 4);
+
+    if (decodableLength > 0) {
+      yield Buffer.from(encodedText.slice(0, decodableLength), 'base64');
+    }
+    remainder = encodedText.slice(decodableLength);
+  }
+
+  if (remainder.length > 0) {
+    yield Buffer.from(remainder, 'base64');
+  }
+}
 
 export function isShardingData(data: unknown): data is string[] {
   if (Array.isArray(data) && data.length > 0) {
@@ -16,15 +40,21 @@ export async function fetchShardingData(
   shardingFiles: string[],
   fetchImplement: (url: string) => Promise<string>,
 ) {
-  const res = await Promise.all(
-    shardingFiles.map((url: string) => fetchImplement(url)),
-  );
+  if (shardingFiles.length === 0) return [];
 
-  const strings = res.length === 0 ? [] : res.reduce((t, e) => t + e);
+  const inflater = Readable.from(
+    decodeBase64Shards(shardingFiles, fetchImplement),
+  ).pipe(createInflate());
+  const decoder = new StringDecoder('utf8');
+  const jsonParts: string[] = [];
 
-  return typeof strings === 'object'
-    ? strings
-    : JSON.parse(decompressText(strings));
+  for await (const chunk of inflater) {
+    jsonParts.push(decoder.write(Buffer.from(chunk)));
+  }
+  const finalPart = decoder.end();
+  if (finalPart) jsonParts.push(finalPart);
+
+  return JSON.parse(jsonParts.join(''));
 }
 
 export async function fetchShardingFiles(

--- a/packages/utils/tests/common/manifest.test.ts
+++ b/packages/utils/tests/common/manifest.test.ts
@@ -44,4 +44,31 @@ describe('test src/common/manifest.ts', () => {
       ),
     ).toStrictEqual({ a: 1, b: '2', c: [3, 4], d: true });
   });
+
+  it('decodes arbitrary Base64 and UTF-8 shard boundaries', async () => {
+    const data = {
+      modules: [
+        {
+          id: 1,
+          source: '🙂'.repeat(10000),
+        },
+      ],
+    };
+    const encodedText = Algorithm.compressText(JSON.stringify(data));
+    const shardSizes = [1, 2, 5, 7, 11, 13];
+    const shards: string[] = [];
+    let offset = 0;
+    let shardIndex = 0;
+
+    while (offset < encodedText.length) {
+      const shardSize = shardSizes[shardIndex % shardSizes.length];
+      shards.push(encodedText.slice(offset, offset + shardSize));
+      offset += shardSize;
+      shardIndex += 1;
+    }
+
+    await expect(
+      Manifest.fetchShardingData(shards, async (value) => value),
+    ).resolves.toStrictEqual(data);
+  });
 });

--- a/packages/utils/tests/json.test.ts
+++ b/packages/utils/tests/json.test.ts
@@ -37,5 +37,19 @@ describe('test src/json.ts', () => {
         }),
       ).toMatchSnapshot();
     });
+
+    it('preserves the final content after splitting into multiple chunks', async () => {
+      const data = Array.from({ length: 20 }, (_, index) => index);
+      const chunks = (await Json.stringify(
+        data,
+        undefined,
+        undefined,
+        undefined,
+        10,
+      )) as unknown as string[];
+
+      expect(chunks.length).toBeGreaterThan(1);
+      expect(chunks.join('')).toBe(JSON.stringify(data));
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Fix large manifests becoming unreadable when stream serialization produces multiple JSON fragments.
- Preserve one continuous deflate/Base64 stream while writing and reading bounded shards, retaining final content and shard order.
- Add round-trip coverage for arbitrary Base64, UTF-8, and physical shard boundaries.

## Related Links

None