### PR TITLE
fix(components): use 3:1 overall layout

### DIFF
--- a/.changeset/fix-overall-layout-ratio.md
+++ b/.changeset/fix-overall-layout-ratio.md
@@ -1,0 +1,5 @@
+---
+'@rsdoctor/components': patch
+---
+
+Use a stable 3:1 desktop column ratio on the Overall page while preserving the single-column responsive layout.

--- a/packages/components/src/pages/Overall/index.module.scss
+++ b/packages/components/src/pages/Overall/index.module.scss
@@ -24,6 +24,8 @@
 }
 
 .columns {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(300px, 1fr);
   width: 100%;
   align-items: flex-start;
   gap: 16px;
@@ -34,14 +36,7 @@
   min-width: 0;
 }
 
-.mainColumn {
-  flex: 3 1 0;
-}
-
 .sideColumn {
-  flex: 1 1 320px;
-  min-width: 300px;
-
   :global(.ant-card) {
     background: var(--color-bg-box-subtle);
   }
@@ -55,12 +50,6 @@
 
 @media (max-width: 1200px) {
   .columns {
-    flex-wrap: wrap;
-  }
-
-  .mainColumn,
-  .sideColumn {
-    flex-basis: 100%;
-    width: 100%;
+    grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/packages/components/src/pages/Overall/index.tsx
+++ b/packages/components/src/pages/Overall/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Flex } from 'antd';
 
 import { HelpCenter } from '../../components/Overall/help-center';
 import { BundleAlerts } from '../../components/Alerts';
@@ -24,7 +23,7 @@ const Component: React.FC = () => {
 
   return (
     <div className={style.overall}>
-      <Flex className={style.columns}>
+      <div className={style.columns}>
         <main className={style.mainColumn}>
           <ResponsiveLayout>
             <ProjectOverall
@@ -45,7 +44,7 @@ const Component: React.FC = () => {
             <HelpCenter />
           </ResponsiveLayout>
         </aside>
-      </Flex>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- Fix the Overall page desktop columns rendering at an unintended 1:1 ratio.
- Use a stable 3:1 CSS Grid layout while preserving the single-column responsive breakpoint.

## Related Links

None