### PR TITLE
fix lint for rslint 0.7

### DIFF
--- a/e2e/cases/doctor-rspack/uploader.test.ts
+++ b/e2e/cases/doctor-rspack/uploader.test.ts
@@ -93,6 +93,7 @@ test.describe('Uploader Integration Tests', () => {
         `Failed to read generated Rsdoctor manifest at ${manifestPath}: ${
           error instanceof Error ? error.message : String(error)
         }`,
+        { cause: error },
       );
     }
   });

--- a/packages/agent-cli/src/commands/datasource.ts
+++ b/packages/agent-cli/src/commands/datasource.ts
@@ -131,7 +131,7 @@ export function loadJsonData(filePath: string): RsdoctorData {
     return data;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Failed to load data file: ${message}`);
+    throw new Error(`Failed to load data file: ${message}`, { cause: error });
   }
 }
 

--- a/packages/agent-cli/src/executor.ts
+++ b/packages/agent-cli/src/executor.ts
@@ -63,6 +63,7 @@ export function createRsdoctorCliToolExecutor({
         const message = error instanceof Error ? error.message : String(error);
         throw new Error(
           `Failed to parse JSON output from ${request.toolName}: ${message}`,
+          { cause: error },
         );
       }
     },

--- a/packages/client/src/components/Opener/code.tsx
+++ b/packages/client/src/components/Opener/code.tsx
@@ -24,7 +24,7 @@ interface CodeOpenerProps {
 
 function parseUrl(url: string) {
   const strs = url.split(' ');
-  let res = '';
+  let res: string | undefined;
   if (strs.length === 1) {
     [res] = strs;
   } else {

--- a/packages/core/src/inner-plugins/plugins/sourcemapTool.ts
+++ b/packages/core/src/inner-plugins/plugins/sourcemapTool.ts
@@ -47,7 +47,7 @@ export function bindContextCache(
     if (cache.has(source)) {
       return cache.get(source)!;
     }
-    let resolved = UNASSIGNED;
+    let resolved: string;
 
     if (source.startsWith('file://')) {
       resolved = resolve(context, source.replace(/^file:\/\//, ''));

--- a/packages/shared/src/common/graph/assets.ts
+++ b/packages/shared/src/common/graph/assets.ts
@@ -30,20 +30,18 @@ export function formatAssetName(assetName: string, fileConfig?: string) {
   // - [dir][name].[hash].[ext] -> [dir][name].[ext]
   // - [dir][name]-[hash].[ext] -> [dir][name].[ext]
   const splitFilesList = fileConfig?.split('.');
-  let outputFileTailName = '';
-  let unHashedFileName = assetName;
   if (
     splitFilesList?.length &&
     splitFilesList.length >= 3 &&
     splitFilesList[splitFilesList.length - 2]?.indexOf('[') < 0 &&
     EXT.indexOf(splitFilesList[splitFilesList.length - 1]) > -1
   ) {
-    outputFileTailName = splitFilesList[splitFilesList.length - 2];
+    const outputFileTailName = splitFilesList[splitFilesList.length - 2];
     const _regPattern =
       /(.*)(\.([a-f0-9]{4,32}|[a-zA-Z]*[0-9][a-zA-Z0-9]*))(\.[^.]+){2,}$/;
     const match = assetName.match(_regPattern);
     if (match && match[3].length >= 4 && match[3].length <= 32) {
-      unHashedFileName = match[1];
+      const unHashedFileName = match[1];
       return `${unHashedFileName}.${outputFileTailName}.${assetName.substring(
         assetName.lastIndexOf('.') + 1,
       )}`;
@@ -85,9 +83,7 @@ export function filterAssetsByExtensions(
 }
 
 type FilterFunctionOrExtensions =
-  | string
-  | string[]
-  | ((asset: SDK.AssetData) => boolean);
+  string | string[] | ((asset: SDK.AssetData) => boolean);
 
 function isAssetMatchFilter(
   asset: SDK.AssetData,

--- a/packages/shared/src/common/loader.ts
+++ b/packages/shared/src/common/loader.ts
@@ -63,10 +63,10 @@ export function getLoadersCosts(
     );
 
     const matchSum = _match.length
-      ? _match.reduce((t, c) => (t += c[1] - c[0]), 0)
+      ? _match.reduce((t, c) => t + c[1] - c[0], 0)
       : 0;
     const othersSum = _others.length
-      ? _others.reduce((t, c) => (t += c[1] - c[0]), 0)
+      ? _others.reduce((t, c) => t + c[1] - c[0], 0)
       : 0;
 
     costs += matchSum - othersSum;

--- a/packages/shared/src/graph/transform/chunks/assetsModules.ts
+++ b/packages/shared/src/graph/transform/chunks/assetsModules.ts
@@ -109,13 +109,10 @@ export async function getAssetsModulesData(
     const assets = chunkGraph.getAssets();
     const modules = moduleGraph.getModules();
 
-    // Trying to parse bundle assets and get real module sizes if `bundleDir` is provided
-    let bundlesSources: Record<string, unknown> | null = null;
-    let parsedModules: ParsedModuleSizeData | null = null;
-
     if (bundleDir && assets.length) {
-      bundlesSources = {};
-      parsedModules = {};
+      // Trying to parse bundle assets and get real module sizes if `bundleDir` is provided
+      const bundlesSources: Record<string, unknown> = {};
+      const parsedModules: ParsedModuleSizeData = {};
 
       for (const asset of assets) {
         // If assetsWithoutSourceMap is provided, only parse assets without sourcemap
@@ -147,16 +144,12 @@ export async function getAssetsModulesData(
       }
 
       if (isEmpty(bundlesSources)) {
-        bundlesSources = null;
-        parsedModules = null;
         if (process.env.DEVTOOLS_DEV) {
           logger.warn(
             '\nNo bundles were parsed. Analyzer will show only original module sizes from stats file.\n',
           );
         }
-      }
-
-      if (parsedModules) {
+      } else {
         transformAssetsModulesData(parsedModules, moduleGraph, gzipOptions);
       }
     }

--- a/packages/shared/tests/published-types.test.ts
+++ b/packages/shared/tests/published-types.test.ts
@@ -33,6 +33,7 @@ function runTsc(args: string[], options: ExecFileSyncOptions) {
       ['tsc failed.', result.stdout?.toString(), result.stderr?.toString()]
         .filter(Boolean)
         .join('\n'),
+      { cause: error },
     );
   }
 }


### PR DESCRIPTION
## Summary

Fix lint failures exposed by the `@rslint/core` 0.7 update in #1897.

- preserve caught errors by passing `cause` when wrapping exceptions
- remove useless initial assignments flagged by the new lint rules
- keep the dependency update and lockfile from the Renovate branch unchanged

## Validation

- `npx -y node@24.15.0 $(which pnpm) run lint`
- `npx -y node@24.15.0 $(which pnpm) run check-dependency-version`