### PR TITLE
chore(ci): add package preview releases

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -8,6 +8,7 @@ permissions: {}
 
 jobs:
   publish:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -24,9 +25,6 @@ jobs:
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm run build
 
       - name: Publish Package Previews
         run: pnpm exec pkg-pr-new publish --pnpm --previewVersion --no-template './packages/shared' './packages/client' './packages/core' './packages/cli' './packages/agent-cli'

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,32 @@
+name: Publish Package Previews
+
+on:
+  pull_request:
+    branches: [main, release_*, release-*]
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Publish Package Previews
+        run: pnpm exec pkg-pr-new publish --pnpm --previewVersion --no-template './packages/shared' './packages/client' './packages/core' './packages/cli' './packages/agent-cli'

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "heading-case": "^1.1.4",
     "husky": "^9.1.7",
     "nano-staged": "^1.0.2",
+    "pkg-pr-new": "0.0.87",
     "prettier": "^3.9.6",
     "rsbuild-plugin-publint": "^0.3.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       nano-staged:
         specifier: ^1.0.2
         version: 1.0.2
+      pkg-pr-new:
+        specifier: 0.0.87
+        version: 0.0.87
       prettier:
         specifier: ^3.9.6
         version: 3.9.6
@@ -5169,6 +5172,10 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  pkg-pr-new@0.0.87:
+    resolution: {integrity: sha512-nm+30Py1csXWfyMH1ueQyTR11IZGHS5oW8Qok/MxMwjPx9g1jX3wMRrJf8TgEvNo0a0M4i14T0zQsEPWdZfAhg==}
+    hasBin: true
 
   playwright-core@1.55.1:
     resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
@@ -12007,6 +12014,8 @@ snapshots:
 
   pify@4.0.1:
     optional: true
+
+  pkg-pr-new@0.0.87: {}
 
   playwright-core@1.55.1: {}
 


### PR DESCRIPTION
## Summary

This adds pull-request preview releases for the five consumer-facing Rsdoctor packages, allowing downstream projects to validate changes before an npm release. The workflow builds the monorepo and invokes the lockfile-pinned `pkg-pr-new` CLI once with pnpm catalog support, collision-safe preview versions, no generated template, minimal GitHub token permissions, and no npm credentials.

The `pkg.pr.new` GitHub App must be installed for `web-infra-dev/rsdoctor` before the workflow can publish previews.

## Related Links

- https://github.com/stackblitz-labs/pkg.pr.new#publish-packages