### PR TITLE
perf(core): avoid duplicate SDK bootstrap

### DIFF
--- a/packages/core/src/rspack-plugin/plugin.ts
+++ b/packages/core/src/rspack-plugin/plugin.ts
@@ -334,7 +334,7 @@ export class RsdoctorRspackPlugin<
     try {
       logger.debug('[RsdoctorRspackPlugin] bootstrap(start) in done()');
       const bootstrapTask = this.ensureBootstrap(context);
-      await bootstrapTask;
+      await this.awaitBootstrap(context, bootstrapTask);
       logger.debug('[RsdoctorRspackPlugin] bootstrap(end) in done()');
 
       context.sdk.addClientRoutes([
@@ -466,14 +466,33 @@ export class RsdoctorRspackPlugin<
     return context.bootstrapTask;
   }
 
+  private async awaitBootstrap(
+    context: RsdoctorCompilerContext,
+    bootstrapTask: Promise<void>,
+  ) {
+    try {
+      await bootstrapTask;
+    } catch (error) {
+      this.clearBootstrapTask(context, bootstrapTask);
+      throw error;
+    }
+  }
+
+  private clearBootstrapTask(
+    context: RsdoctorCompilerContext,
+    bootstrapTask: Promise<void>,
+  ) {
+    if (context.bootstrapTask === bootstrapTask) {
+      context.bootstrapTask = undefined;
+    }
+  }
+
   private async disposeSDK(
     context: RsdoctorCompilerContext,
     bootstrapTask: Promise<void>,
   ) {
     await context.sdk.dispose();
-    if (context.bootstrapTask === bootstrapTask) {
-      context.bootstrapTask = undefined;
-    }
+    this.clearBootstrapTask(context, bootstrapTask);
   }
 
   private getOutputDir(compiler: Plugin.BaseCompilerType<'rspack'>) {
@@ -606,7 +625,7 @@ export class RsdoctorRspackPlugin<
     context: RsdoctorCompilerContext,
   ): Promise<void> => {
     const bootstrapTask = this.ensureBootstrap(context);
-    await bootstrapTask;
+    await this.awaitBootstrap(context, bootstrapTask);
     context.sdk.addClientRoutes([
       ManifestType.RsdoctorManifestClientRoutes.Overall,
     ]);

--- a/packages/core/src/rspack-plugin/plugin.ts
+++ b/packages/core/src/rspack-plugin/plugin.ts
@@ -49,7 +49,7 @@ class RsdoctorCompilerContext implements RsdoctorRspackPluginInstance<
 
   public readonly modulesGraph = new ModuleGraph() as SDK.ModuleGraphInstance;
 
-  public bootstrapTask?: Promise<unknown>;
+  public bootstrapTask?: Promise<void>;
 
   public applied = false;
 
@@ -187,9 +187,9 @@ export class RsdoctorRspackPlugin<
 
       this.releasePendingSessionOnRun(compiler);
 
-      if (!context.bootstrapTask) {
-        context.bootstrapTask = context.sdk.bootstrap();
-      }
+      // Bootstrap early so it can run in parallel with compiler setup. The
+      // completion hook awaits the same task instead of starting it again.
+      void this.ensureBootstrap(context);
 
       const compilerName =
         compiler.name ||
@@ -333,7 +333,8 @@ export class RsdoctorRspackPlugin<
     time('RsdoctorRspackPlugin.done');
     try {
       logger.debug('[RsdoctorRspackPlugin] bootstrap(start) in done()');
-      await context.bootstrapTask;
+      const bootstrapTask = this.ensureBootstrap(context);
+      await bootstrapTask;
       logger.debug('[RsdoctorRspackPlugin] bootstrap(end) in done()');
 
       context.sdk.addClientRoutes([
@@ -365,7 +366,7 @@ export class RsdoctorRspackPlugin<
       }
 
       if (this.shouldDisposeSDK()) {
-        await context.sdk.dispose();
+        await this.disposeSDK(context, bootstrapTask);
       }
     } finally {
       timeEnd('RsdoctorRspackPlugin.done');
@@ -450,6 +451,29 @@ export class RsdoctorRspackPlugin<
     this.appliedCompilerCount += 1;
     this.compilerContexts.set(compiler, context);
     return context;
+  }
+
+  private ensureBootstrap(context: RsdoctorCompilerContext): Promise<void> {
+    if (!context.bootstrapTask) {
+      const task = context.sdk.bootstrap();
+      context.bootstrapTask = task;
+
+      // apply() cannot await this task. Mark a possible rejection as handled
+      // until a compiler completion hook propagates the original error.
+      void task.catch(() => {});
+    }
+
+    return context.bootstrapTask;
+  }
+
+  private async disposeSDK(
+    context: RsdoctorCompilerContext,
+    bootstrapTask: Promise<void>,
+  ) {
+    await context.sdk.dispose();
+    if (context.bootstrapTask === bootstrapTask) {
+      context.bootstrapTask = undefined;
+    }
   }
 
   private getOutputDir(compiler: Plugin.BaseCompilerType<'rspack'>) {
@@ -581,7 +605,8 @@ export class RsdoctorRspackPlugin<
     compiler: Plugin.BaseCompilerType<'rspack'>,
     context: RsdoctorCompilerContext,
   ): Promise<void> => {
-    await context.bootstrapTask;
+    const bootstrapTask = this.ensureBootstrap(context);
+    await bootstrapTask;
     context.sdk.addClientRoutes([
       ManifestType.RsdoctorManifestClientRoutes.Overall,
     ]);
@@ -595,7 +620,7 @@ export class RsdoctorRspackPlugin<
     await context.sdk.writeStore();
 
     if (this.shouldDisposeSDK()) {
-      await context.sdk.dispose();
+      await this.disposeSDK(context, bootstrapTask);
     }
   };
 

--- a/packages/core/tests/rspack-plugin/plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/plugin.test.ts
@@ -182,7 +182,7 @@ describe('RsdoctorRspackPlugin', () => {
     await plugin.done(compiler);
     await plugin.done(compiler);
 
-    expect(bootstrap).toHaveBeenCalledTimes(2);
+    expect(bootstrap).toHaveBeenCalledTimes(1);
     expect(dispose).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/core/tests/rspack-plugin/plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/plugin.test.ts
@@ -186,14 +186,17 @@ describe('RsdoctorRspackPlugin', () => {
     expect(dispose).toHaveBeenCalledTimes(2);
   });
 
-  it('propagates the apply bootstrap error without retrying', async () => {
+  it('retries bootstrap on the next build after a failure', async () => {
     const sdk = new RsdoctorSDK({
       name: 'bootstrap-error',
       root: process.cwd(),
       config: { noServer: true },
     });
     const error = new Error('bootstrap failed');
-    const bootstrap = rs.spyOn(sdk, 'bootstrap').mockRejectedValue(error);
+    const bootstrap = rs
+      .spyOn(sdk, 'bootstrap')
+      .mockRejectedValueOnce(error)
+      .mockResolvedValue();
     const writeStore = rs.spyOn(sdk, 'writeStore').mockResolvedValue('');
 
     const plugin = new RsdoctorRspackPlugin({
@@ -203,9 +206,10 @@ describe('RsdoctorRspackPlugin', () => {
     const compiler = rspack({ plugins: [plugin] });
 
     await expect(plugin.done(compiler)).rejects.toBe(error);
+    await plugin.done(compiler);
 
-    expect(bootstrap).toHaveBeenCalledTimes(1);
-    expect(writeStore).not.toHaveBeenCalled();
+    expect(bootstrap).toHaveBeenCalledTimes(2);
+    expect(writeStore).toHaveBeenCalledTimes(1);
   });
 
   it('keeps the report server when the client server is disabled in CI', () => {

--- a/packages/core/tests/rspack-plugin/plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/plugin.test.ts
@@ -173,11 +173,11 @@ describe('RsdoctorRspackPlugin', () => {
     rs.spyOn(sdk, 'writeStore').mockResolvedValue('');
 
     const plugin = new RsdoctorRspackPlugin({
+      disableClientServer: true,
       features: [],
       sdkInstance: sdk,
     });
     const compiler = rspack({ plugins: [plugin] });
-    plugin.options.disableClientServer = true;
 
     await plugin.done(compiler);
     await plugin.done(compiler);

--- a/packages/core/tests/rspack-plugin/plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/plugin.test.ts
@@ -163,27 +163,38 @@ describe('RsdoctorRspackPlugin', () => {
   });
 
   it('restarts the SDK once after done disposes it', async () => {
-    const sdk = new RsdoctorSDK({
-      name: 'bootstrap-after-dispose',
-      root: process.cwd(),
-      config: { noServer: true },
-    });
-    const bootstrap = rs.spyOn(sdk, 'bootstrap').mockResolvedValue();
-    const dispose = rs.spyOn(sdk, 'dispose').mockResolvedValue();
-    rs.spyOn(sdk, 'writeStore').mockResolvedValue('');
+    const originalRSTEST = process.env.RSTEST;
+    delete process.env.RSTEST;
 
-    const plugin = new RsdoctorRspackPlugin({
-      disableClientServer: true,
-      features: [],
-      sdkInstance: sdk,
-    });
-    const compiler = rspack({ plugins: [plugin] });
+    try {
+      const sdk = new RsdoctorSDK({
+        name: 'bootstrap-after-dispose',
+        root: process.cwd(),
+        config: { noServer: true },
+      });
+      const bootstrap = rs.spyOn(sdk, 'bootstrap').mockResolvedValue();
+      const dispose = rs.spyOn(sdk, 'dispose').mockResolvedValue();
+      rs.spyOn(sdk, 'writeStore').mockResolvedValue('');
 
-    await plugin.done(compiler);
-    await plugin.done(compiler);
+      const plugin = new RsdoctorRspackPlugin({
+        disableClientServer: true,
+        features: [],
+        sdkInstance: sdk,
+      });
+      const compiler = rspack({ plugins: [plugin] });
 
-    expect(bootstrap).toHaveBeenCalledTimes(1);
-    expect(dispose).toHaveBeenCalledTimes(2);
+      await plugin.done(compiler);
+      await plugin.done(compiler);
+
+      expect(bootstrap).toHaveBeenCalledTimes(2);
+      expect(dispose).toHaveBeenCalledTimes(2);
+    } finally {
+      if (typeof originalRSTEST === 'undefined') {
+        delete process.env.RSTEST;
+      } else {
+        process.env.RSTEST = originalRSTEST;
+      }
+    }
   });
 
   it('retries bootstrap on the next build after a failure', async () => {

--- a/packages/core/tests/rspack-plugin/plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/plugin.test.ts
@@ -1,12 +1,13 @@
 import { getSDK } from '@/inner-plugins/utils/sdk';
 import { RsdoctorRspackPlugin } from '@/rspack-plugin';
 import { RsdoctorPrimarySDK, RsdoctorSDK } from '@/sdk';
-import { rspack } from '@rspack/core';
-import { afterEach, describe, expect, it } from '@rstest/core';
 import { RsdoctorServer } from '@/sdk/server';
+import { rspack } from '@rspack/core';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import path from 'node:path';
 
 afterEach(async () => {
+  rs.restoreAllMocks();
   delete globalThis.__rsdoctor_sdk__;
   delete globalThis.__rsdoctor_sdks__;
   await new Promise((resolve) => setTimeout(resolve, 0));
@@ -127,6 +128,84 @@ describe('RsdoctorRspackPlugin', () => {
     expect(secondSDK.getManifestData().series).toBeUndefined();
 
     await Promise.all([firstSDK.dispose(), secondSDK.dispose()]);
+  });
+
+  it('bootstraps the SDK only once across apply and done', async () => {
+    const sdk = new RsdoctorSDK({
+      name: 'bootstrap-once',
+      root: process.cwd(),
+      config: { noServer: true },
+    });
+    let resolveBootstrap!: () => void;
+    const bootstrapTask = new Promise<void>((resolve) => {
+      resolveBootstrap = resolve;
+    });
+    const bootstrap = rs.spyOn(sdk, 'bootstrap').mockReturnValue(bootstrapTask);
+    const writeStore = rs.spyOn(sdk, 'writeStore').mockResolvedValue('');
+
+    const plugin = new RsdoctorRspackPlugin({
+      disableClientServer: true,
+      features: [],
+      sdkInstance: sdk,
+    });
+    const compiler = rspack({ plugins: [plugin] });
+
+    const doneTask = plugin.done(compiler);
+    await Promise.resolve();
+
+    expect(bootstrap).toHaveBeenCalledTimes(1);
+    expect(writeStore).not.toHaveBeenCalled();
+
+    resolveBootstrap();
+    await doneTask;
+
+    expect(writeStore).toHaveBeenCalledTimes(1);
+  });
+
+  it('restarts the SDK once after done disposes it', async () => {
+    const sdk = new RsdoctorSDK({
+      name: 'bootstrap-after-dispose',
+      root: process.cwd(),
+      config: { noServer: true },
+    });
+    const bootstrap = rs.spyOn(sdk, 'bootstrap').mockResolvedValue();
+    const dispose = rs.spyOn(sdk, 'dispose').mockResolvedValue();
+    rs.spyOn(sdk, 'writeStore').mockResolvedValue('');
+
+    const plugin = new RsdoctorRspackPlugin({
+      features: [],
+      sdkInstance: sdk,
+    });
+    const compiler = rspack({ plugins: [plugin] });
+    plugin.options.disableClientServer = true;
+
+    await plugin.done(compiler);
+    await plugin.done(compiler);
+
+    expect(bootstrap).toHaveBeenCalledTimes(2);
+    expect(dispose).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates the apply bootstrap error without retrying', async () => {
+    const sdk = new RsdoctorSDK({
+      name: 'bootstrap-error',
+      root: process.cwd(),
+      config: { noServer: true },
+    });
+    const error = new Error('bootstrap failed');
+    const bootstrap = rs.spyOn(sdk, 'bootstrap').mockRejectedValue(error);
+    const writeStore = rs.spyOn(sdk, 'writeStore').mockResolvedValue('');
+
+    const plugin = new RsdoctorRspackPlugin({
+      features: [],
+      sdkInstance: sdk,
+    });
+    const compiler = rspack({ plugins: [plugin] });
+
+    await expect(plugin.done(compiler)).rejects.toBe(error);
+
+    expect(bootstrap).toHaveBeenCalledTimes(1);
+    expect(writeStore).not.toHaveBeenCalled();
   });
 
   it('keeps the report server when the client server is disabled in CI', () => {


### PR DESCRIPTION
## Summary

Rsdoctor starts SDK bootstrap in `apply()`, but compiler completion hooks previously started the same work again. This caused repeated builds to rerun environment and server initialization even when collection features were disabled.

This PR reuses one in-flight bootstrap task across `apply()`, parent `done()`, and child compiler completion, and resets it after a successful SDK dispose. Bootstrap failures still propagate to the current build; once the completion hook observes the rejection, it clears the cached task so the next watch build can retry.

Performance benchmark: 100 generated modules, Rspack 2.1.8, the same compiler built twice, with 1 warmup and 5 measured runs. Values are median `compiler.run()` times.

| Build | Before (double bootstrap) | After (single-flight) | Improvement |
| --- | ---: | ---: | ---: |
| First build | 266.2 ms | 252.1 ms | 14.1 ms (5.3%) |
| Repeated build | 250.9 ms | 14.2 ms | 236.7 ms (94.3%) |

## Related Links

None