### PR TITLE
fix(core): avoid reopening dashboard on rebuild

### DIFF
--- a/packages/core/src/rspack-plugin/plugin.ts
+++ b/packages/core/src/rspack-plugin/plugin.ts
@@ -53,6 +53,8 @@ class RsdoctorCompilerContext implements RsdoctorRspackPluginInstance<
 
   public applied = false;
 
+  public hasOpenedClientAutomatically = false;
+
   constructor(
     public readonly sdk: SDK.RsdoctorBuilderSDKInstance,
     public readonly options: RsdoctorRspackPluginOptionsNormalized<
@@ -352,7 +354,12 @@ export class RsdoctorRspackPlugin<
 
       const isPrimaryCompiler =
         !(context.sdk instanceof RsdoctorPrimarySDK) || context.sdk.isMaster;
-      if (!this.options.disableClientServer && isPrimaryCompiler) {
+      if (
+        !this.options.disableClientServer &&
+        isPrimaryCompiler &&
+        !context.hasOpenedClientAutomatically
+      ) {
+        context.hasOpenedClientAutomatically = true;
         if (this.options.output.mode === SDK.IMode[SDK.IMode.brief]) {
           await handleBriefModeReport(
             context.sdk,

--- a/packages/core/tests/rspack-plugin/plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/plugin.test.ts
@@ -2,7 +2,7 @@ import { getSDK } from '@/inner-plugins/utils/sdk';
 import { RsdoctorRspackPlugin } from '@/rspack-plugin';
 import { RsdoctorPrimarySDK, RsdoctorSDK } from '@/sdk';
 import { rspack } from '@rspack/core';
-import { afterEach, describe, expect, it } from '@rstest/core';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import { RsdoctorServer } from '@/sdk/server';
 import path from 'node:path';
 
@@ -76,6 +76,32 @@ describe('RsdoctorRspackPlugin', () => {
     expect(plugin.sdk.outputDir).toBe(reportDir);
 
     await plugin.sdk.dispose();
+  });
+
+  it('opens the dashboard automatically only once across rebuilds', async () => {
+    const sdk = new RsdoctorSDK({
+      name: 'watch',
+      root: process.cwd(),
+      config: { noServer: true },
+    });
+    const plugin = new RsdoctorRspackPlugin({ sdkInstance: sdk });
+    const compiler = rspack({ name: 'watch', plugins: [plugin] });
+    const openClientPage = rs
+      .spyOn(sdk.server, 'openClientPage')
+      .mockResolvedValue();
+    const writeStore = rs.spyOn(sdk, 'writeStore').mockResolvedValue('');
+
+    await plugin.done(compiler);
+    await plugin.done(compiler);
+
+    expect(writeStore).toHaveBeenCalledTimes(2);
+    expect(openClientPage).toHaveBeenCalledTimes(1);
+
+    await sdk.server.openClientPage('homepage');
+
+    expect(openClientPage).toHaveBeenCalledTimes(2);
+
+    await sdk.dispose();
   });
 
   it('creates isolated compiler contexts when one plugin instance is reused', async () => {


### PR DESCRIPTION
## Summary

- Track automatic dashboard opening for each compiler context so only the first eligible compilation launches the browser; later watch/HMR rebuilds stay quiet while explicit/manual opening remains available.
- Preserve the existing brief, `disableClientServer`, primary-compiler, and multi-compiler behavior, with regression coverage for rebuilds and manual opening.

## Related Links

Fixes #159
Fixes #446