### PR TITLE
fix(core): prevent loader events multiplying across rebuilds

### DIFF
--- a/packages/core/src/build-utils/build/loader/probeLoader.ts
+++ b/packages/core/src/build-utils/build/loader/probeLoader.ts
@@ -17,10 +17,12 @@ const loaderModule: Plugin.LoaderDefinition<ProbeLoaderOptions, object> =
     const code = args[0];
     const _options = this.getOptions();
     const compilation = this._compilation as
-    { compiler?: { compilerPath?: string } } | undefined;
+      { compiler?: { compilerPath?: string } } | undefined;
     const sdk = getSDK(
       compilation?.compiler?.compilerPath || _options.builderName,
     );
+    const targetLoaderIndex =
+      _options.type === 'start' ? this.loaderIndex - 1 : this.loaderIndex + 1;
 
     const loaderData: SDK.ResourceLoaderData = {
       resource: {
@@ -35,7 +37,7 @@ const loaderModule: Plugin.LoaderDefinition<ProbeLoaderOptions, object> =
       loaders: [
         {
           loader: _options.loader,
-          loaderIndex: this.loaderIndex,
+          loaderIndex: targetLoaderIndex,
           path: _options.loader,
           input: _options.type === 'start' ? code : null,
           result: _options.type === 'end' ? code : null,

--- a/packages/core/src/build-utils/build/loader/probeLoaderPlugin.ts
+++ b/packages/core/src/build-utils/build/loader/probeLoaderPlugin.ts
@@ -9,6 +9,8 @@ const BuiltinLightingCssName = 'builtin:lightningcss-loader';
 const ESMLoaderFile = '.mjs';
 
 export class ProbeLoaderPlugin {
+  private readonly instrumentedCompilers = new WeakSet<Plugin.BaseCompiler>();
+
   apply(compiler: Plugin.BaseCompiler) {
     compiler.hooks.beforeRun.tap(
       {
@@ -30,6 +32,8 @@ export class ProbeLoaderPlugin {
   }
 
   private addProbeLoader(compiler: Plugin.BaseCompiler) {
+    if (this.instrumentedCompilers.has(compiler)) return;
+
     let rules = compiler.options.module.rules as Plugin.RuleSetRule[];
 
     if (Loader.isVue(compiler)) {
@@ -38,6 +42,7 @@ export class ProbeLoaderPlugin {
         compiler,
         (r: Plugin.BuildRuleSetRule) => !!r.loader || typeof r === 'string',
       ) as RuleSetRules;
+      this.instrumentedCompilers.add(compiler);
       return;
     }
 
@@ -65,5 +70,6 @@ export class ProbeLoaderPlugin {
         );
       },
     ) as RuleSetRules;
+    this.instrumentedCompilers.add(compiler);
   }
 }

--- a/packages/core/src/sdk/sdk/index.ts
+++ b/packages/core/src/sdk/sdk/index.ts
@@ -255,13 +255,21 @@ export class RsdoctorSDK<
     if (_builtinLoader.startAt) {
       this._loaderStart.push(data);
     } else if (_builtinLoader.endAt) {
-      const matchLoaderStart = this._loaderStart.find(
+      const matchLoaderStartIndex = this._loaderStart.findIndex(
         (e) =>
           e.resource.path === data.resource.path &&
-          e.loaders[0].loader === _builtinLoader.loader,
+          e.resource.queryRaw === data.resource.queryRaw &&
+          e.loaders[0].loader === _builtinLoader.loader &&
+          e.loaders[0].loaderIndex === _builtinLoader.loaderIndex &&
+          e.loaders[0].isPitch === _builtinLoader.isPitch &&
+          e.loaders[0].pid === _builtinLoader.pid,
       );
 
-      if (matchLoaderStart) {
+      if (matchLoaderStartIndex !== -1) {
+        const [matchLoaderStart] = this._loaderStart.splice(
+          matchLoaderStartIndex,
+          1,
+        );
         matchLoaderStart.loaders[0].result = _builtinLoader.result;
         matchLoaderStart.loaders[0].endAt = _builtinLoader.endAt;
         this.reportLoader([matchLoaderStart]);

--- a/packages/core/tests/build/utils/loader/changeBuiltinLoader.test.ts
+++ b/packages/core/tests/build/utils/loader/changeBuiltinLoader.test.ts
@@ -181,8 +181,8 @@ describe('addProbeLoader2Rules', () => {
 });
 
 describe('ProbeLoaderPlugin', () => {
-  it('instruments a compiler only once across watch rebuilds', () => {
-    const watchRunCallbacks: Array<() => void> = [];
+  it('instruments a compiler only once across run and watch rebuilds', () => {
+    const runCallbacks: Array<() => void> = [];
     const compiler = {
       options: {
         name: 'test-compiler',
@@ -191,18 +191,23 @@ describe('ProbeLoaderPlugin', () => {
         },
       },
       hooks: {
-        beforeRun: { tap: rs.fn() },
+        beforeRun: {
+          tap: (_options: unknown, callback: () => void) => {
+            runCallbacks.push(callback);
+          },
+        },
         watchRun: {
           tap: (_options: unknown, callback: () => void) => {
-            watchRunCallbacks.push(callback);
+            runCallbacks.push(callback);
           },
         },
       },
     } as unknown as Plugin.BaseCompiler;
 
     new ProbeLoaderPlugin().apply(compiler);
-    watchRunCallbacks[0]();
-    watchRunCallbacks[0]();
+    runCallbacks[0]();
+    runCallbacks[1]();
+    runCallbacks[1]();
 
     const [rule] = compiler.options.module.rules as Array<{
       use: Array<{ loader: string }>;

--- a/packages/core/tests/build/utils/loader/changeBuiltinLoader.test.ts
+++ b/packages/core/tests/build/utils/loader/changeBuiltinLoader.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect } from '@rstest/core';
+import { describe, expect, it, rs } from '@rstest/core';
 import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { Plugin } from '@rsdoctor/shared/types';
 import { Utils } from '@/build-utils/build';
 import { addProbeLoader2Rules } from '@/build-utils/build/utils';
+import { ProbeLoaderPlugin } from '@/build-utils/build/loader/probeLoaderPlugin';
 
 process.env.DOCTOR_TEST = 'true';
 
@@ -176,5 +177,36 @@ describe('addProbeLoader2Rules', () => {
     expect(result[0].rules[0]).toHaveProperty('use');
     // @ts-ignore
     expect(result[0].rules[0].use).toHaveLength(3);
+  });
+});
+
+describe('ProbeLoaderPlugin', () => {
+  it('instruments a compiler only once across watch rebuilds', () => {
+    const watchRunCallbacks: Array<() => void> = [];
+    const compiler = {
+      options: {
+        name: 'test-compiler',
+        module: {
+          rules: [{ loader: 'builtin:swc-loader' }],
+        },
+      },
+      hooks: {
+        beforeRun: { tap: rs.fn() },
+        watchRun: {
+          tap: (_options: unknown, callback: () => void) => {
+            watchRunCallbacks.push(callback);
+          },
+        },
+      },
+    } as unknown as Plugin.BaseCompiler;
+
+    new ProbeLoaderPlugin().apply(compiler);
+    watchRunCallbacks[0]();
+    watchRunCallbacks[0]();
+
+    const [rule] = compiler.options.module.rules as Array<{
+      use: Array<{ loader: string }>;
+    }>;
+    expect(rule.use).toHaveLength(3);
   });
 });

--- a/packages/core/tests/build/utils/loader/probeLoader.test.ts
+++ b/packages/core/tests/build/utils/loader/probeLoader.test.ts
@@ -19,22 +19,25 @@ describe('probe loader', () => {
       reportLoaderStartOrEnd,
     } as unknown as SDK.RsdoctorBuilderSDKInstance);
 
-    probeLoader.call(
-      {
+    const createContext = (
+      type: ProbeLoaderOptions['type'],
+      loaderIndex: number,
+    ) =>
+      ({
         _module: { layer: 'modern' },
         callback,
         getOptions: () => ({
           builderName: 'web',
           loader: 'builtin:swc-loader',
           options: { jsc: true },
-          type: 'start',
+          type,
         }),
-        loaderIndex: 1,
+        loaderIndex,
         resourcePath: '/project/src/index.ts',
         resourceQuery: '?raw',
-      } as unknown as Plugin.LoaderContext<ProbeLoaderOptions>,
-      'source',
-    );
+      }) as unknown as Plugin.LoaderContext<ProbeLoaderOptions>;
+
+    probeLoader.call(createContext('start', 2), 'source');
 
     expect(reportLoaderStartOrEnd).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -57,5 +60,22 @@ describe('probe loader', () => {
       }),
     );
     expect(callback).toHaveBeenCalledWith(null, 'source');
+
+    reportLoaderStartOrEnd.mockClear();
+    callback.mockClear();
+    probeLoader.call(createContext('end', 0), 'result');
+
+    expect(reportLoaderStartOrEnd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        loaders: [
+          expect.objectContaining({
+            input: null,
+            loaderIndex: 1,
+            result: 'result',
+          }),
+        ],
+      }),
+    );
+    expect(callback).toHaveBeenCalledWith(null, 'result');
   });
 });

--- a/packages/core/tests/sdk/sdk/core/loader-lifecycle.test.ts
+++ b/packages/core/tests/sdk/sdk/core/loader-lifecycle.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it } from '@rstest/core';
+import type { SDK } from '@rsdoctor/shared/types';
+import { createSDK, type MockSDKResponse } from '../../utils';
+
+function createLoaderEvent({
+  type,
+  time,
+  loaderIndex = 0,
+}: {
+  type: 'start' | 'end';
+  time: number;
+  loaderIndex?: number;
+}): SDK.ResourceLoaderData {
+  return {
+    resource: {
+      path: '/src/index.ts',
+      query: {},
+      queryRaw: '',
+      ext: 'ts',
+    },
+    loaders: [
+      {
+        loader: 'builtin:swc-loader',
+        loaderIndex,
+        path: 'builtin:swc-loader',
+        input: type === 'start' ? `input-${time}` : null,
+        result: type === 'end' ? `result-${time}` : null,
+        startAt: type === 'start' ? time : 0,
+        endAt: type === 'end' ? time : 0,
+        options: {},
+        isPitch: false,
+        sync: false,
+        errors: [],
+        pid: process.pid,
+        ppid: process.ppid,
+      },
+    ],
+  };
+}
+
+describe('loader event lifecycle', () => {
+  let target: MockSDKResponse;
+
+  afterEach(async () => {
+    if (target) await target.dispose();
+  });
+
+  it('records one loader transform per rebuild', async () => {
+    target = await createSDK({ noServer: true });
+
+    target.sdk.reportLoaderStartOrEnd(
+      createLoaderEvent({ type: 'start', time: 100 }),
+    );
+    target.sdk.reportLoaderStartOrEnd(
+      createLoaderEvent({ type: 'end', time: 110 }),
+    );
+    target.sdk.reportLoaderStartOrEnd(
+      createLoaderEvent({ type: 'start', time: 200 }),
+    );
+    target.sdk.reportLoaderStartOrEnd(
+      createLoaderEvent({ type: 'end', time: 210 }),
+    );
+
+    const [resource] = target.sdk.getStoreData().loader;
+
+    expect(resource.loaders).toHaveLength(2);
+    expect(resource.loaders).toMatchObject([
+      { startAt: 100, endAt: 110, result: 'result-110' },
+      { startAt: 200, endAt: 210, result: 'result-210' },
+    ]);
+  });
+
+  it('matches repeated loader paths by loader index', async () => {
+    target = await createSDK({ noServer: true });
+
+    target.sdk.reportLoaderStartOrEnd(
+      createLoaderEvent({ type: 'start', time: 100, loaderIndex: 0 }),
+    );
+    target.sdk.reportLoaderStartOrEnd(
+      createLoaderEvent({ type: 'start', time: 101, loaderIndex: 1 }),
+    );
+    target.sdk.reportLoaderStartOrEnd(
+      createLoaderEvent({ type: 'end', time: 111, loaderIndex: 1 }),
+    );
+    target.sdk.reportLoaderStartOrEnd(
+      createLoaderEvent({ type: 'end', time: 120, loaderIndex: 0 }),
+    );
+
+    const [resource] = target.sdk.getStoreData().loader;
+
+    expect(resource.loaders).toMatchObject([
+      { loaderIndex: 0, startAt: 100, endAt: 120 },
+      { loaderIndex: 1, startAt: 101, endAt: 111 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Normalize probe wrapper indexes to the wrapped loader index, then match loader start/end events by resource request, loader index, pitch state, and process.
- Consume a matched start event exactly once so later HMR builds cannot mutate and append the same loader object to itself.
- Add direct regressions for repeated rebuilds and repeated loader paths.

### Kiali dev/HMR proof

Fixture: Kiali frontend, Rsdoctor enabled with loader and gzip support, client server disabled. After the initial compile, `src/app/App.tsx` was touched three times.

| Metric | Before | After |
| --- | ---: | ---: |
| Loader events | 4,440 | 2,452 |
| Duplicate event groups | 801 | 0 |
| Max identical copies | 7 | 1 |
| Loader shard | 13 MB | 7.8 MB |
| Max recorded loader duration | 100,654 ms | 1,603 ms |
| Repeated HMR | 7.08–8.20 s | 6.66–6.94 s |

Both reports contain the same 882 loader resources. Before the fix, all four App.tsx SWC entries referenced the same stale timing; after the fix, they are four distinct transforms.

### Verification

- `pnpm exec rstest run tests/build/utils/loader tests/sdk/sdk/core` (37 passed)
- `pnpm lint`
- `pnpm --filter @rsdoctor/core run build`
- `pnpm exec prettier --check <changed files>`

## Related Links

Closes #1237

Related to #1080 and #1521.