### PR TITLE
perf(core): preserve loader caching with instrumentation

### DIFF
--- a/packages/core/src/inner-plugins/loaders/proxy.ts
+++ b/packages/core/src/inner-plugins/loaders/proxy.ts
@@ -3,10 +3,24 @@ import { Plugin } from '@rsdoctor/shared/types';
 import { Utils as BuildUtils } from '@/build-utils/build';
 import type { ProxyLoaderOptions } from '../../types';
 import {
+  getInternalLoaderOptions,
   getOriginLoaderModule,
   reportLoader,
   shouldSkipLoader,
 } from '../utils';
+
+type CacheAwareLoaderContext = PluginType.LoaderContext<ProxyLoaderOptions> & {
+  addBuildDependency(file: string): void;
+};
+
+function addCacheMarkerDependency(
+  context: PluginType.LoaderContext<ProxyLoaderOptions>,
+) {
+  const { cacheMarkerPath } = getInternalLoaderOptions(context);
+  if (cacheMarkerPath) {
+    (context as CacheAwareLoaderContext).addBuildDependency(cacheMarkerPath);
+  }
+}
 
 const loaderModule: Plugin.LoaderDefinition<ProxyLoaderOptions, object> =
   function (...args) {
@@ -14,6 +28,8 @@ const loaderModule: Plugin.LoaderDefinition<ProxyLoaderOptions, object> =
       this.callback(null, ...args);
       return;
     }
+
+    addCacheMarkerDependency(this);
 
     const mod = getOriginLoaderModule(this);
 
@@ -88,6 +104,8 @@ export const pitch = function (
   if (shouldSkipLoader(this)) {
     return;
   }
+
+  addCacheMarkerDependency(this);
 
   const mod = getOriginLoaderModule(this);
 

--- a/packages/core/src/inner-plugins/loaders/proxy.ts
+++ b/packages/core/src/inner-plugins/loaders/proxy.ts
@@ -15,8 +15,6 @@ const loaderModule: Plugin.LoaderDefinition<ProxyLoaderOptions, object> =
       return;
     }
 
-    this.cacheable(false);
-
     const mod = getOriginLoaderModule(this);
 
     if (mod.default) {
@@ -90,8 +88,6 @@ export const pitch = function (
   if (shouldSkipLoader(this)) {
     return;
   }
-
-  this.cacheable(false);
 
   const mod = getOriginLoaderModule(this);
 

--- a/packages/core/src/inner-plugins/plugins/loader.ts
+++ b/packages/core/src/inner-plugins/plugins/loader.ts
@@ -8,6 +8,9 @@ import type { ProxyLoaderOptions } from '../../types';
 import { time, timeEnd } from '@/logger';
 import { safeCloneDeep } from '../utils/plugin-common';
 import { Loader } from '@rsdoctor/shared/common-browser';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const require = createRequire(import.meta.url);
 
@@ -24,6 +27,8 @@ export class InternalLoaderPlugin<
   T extends Plugin.BaseCompiler,
 > extends InternalBasePlugin<T> {
   public readonly name = 'loader';
+
+  private cacheMarkerPath?: string;
 
   public readonly internalLoaderPath =
     require.resolve('@rsdoctor/core/proxy-loader');
@@ -185,10 +190,12 @@ export class InternalLoaderPlugin<
     compiler: T,
     rules: Plugin.BuildRuleSetRules,
   ): Plugin.BuildRuleSetRule[] {
+    const cacheMarkerPath = this.getCacheMarkerPath(compiler);
     return interceptLoader(
       rules as Plugin.BuildRuleSetRule[],
       this.internalLoaderPath,
       {
+        cacheMarkerPath,
         cwd: compiler.context || process.cwd(),
         host: this.sdk.server.origin,
         skipLoaders: this.options.loaderInterceptorOptions.skipLoaders, // not implement
@@ -196,5 +203,32 @@ export class InternalLoaderPlugin<
       compiler.resolverFactory.get('loader', compiler.options.resolveLoader),
       this.sdk.root,
     );
+  }
+
+  private getCacheMarkerPath(compiler: T) {
+    if (
+      typeof compiler.options.cache !== 'object' ||
+      compiler.options.cache.type !== 'persistent'
+    ) {
+      return undefined;
+    }
+    if (this.cacheMarkerPath) return this.cacheMarkerPath;
+
+    const markerPath = path.join(this.sdk.outputDir, '.loader-cache');
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+
+    let previous = '';
+    try {
+      previous = fs.readFileSync(markerPath, 'utf8');
+    } catch {
+      // The first session has no marker to preserve.
+    }
+    const marker =
+      previous.length < 4096
+        ? `${previous}${randomUUID()}\n`
+        : `${randomUUID()}\n`;
+    fs.writeFileSync(markerPath, marker);
+    this.cacheMarkerPath = markerPath;
+    return markerPath;
   }
 }

--- a/packages/core/src/inner-plugins/plugins/loader.ts
+++ b/packages/core/src/inner-plugins/plugins/loader.ts
@@ -217,17 +217,11 @@ export class InternalLoaderPlugin<
     const markerPath = path.join(this.sdk.outputDir, '.loader-cache');
     fs.mkdirSync(path.dirname(markerPath), { recursive: true });
 
-    let previous = '';
-    try {
-      previous = fs.readFileSync(markerPath, 'utf8');
-    } catch {
-      // The first session has no marker to preserve.
-    }
-    const marker =
-      previous.length < 4096
-        ? `${previous}${randomUUID()}\n`
-        : `${randomUUID()}\n`;
-    fs.writeFileSync(markerPath, marker);
+    const previous = fs.existsSync(markerPath)
+      ? fs.readFileSync(markerPath, 'utf8')
+      : '';
+    const prefix = previous.length < 4096 ? previous : '';
+    fs.writeFileSync(markerPath, `${prefix}${randomUUID()}\n`);
     this.cacheMarkerPath = markerPath;
     return markerPath;
   }

--- a/packages/core/src/types/loader.ts
+++ b/packages/core/src/types/loader.ts
@@ -1,6 +1,11 @@
 import { Loader } from '@rsdoctor/shared/common-browser';
 
 export interface ProxyLoaderInternalOptions {
+  /**
+   * A session marker registered as a loader build dependency so persistent
+   * caches are invalidated when a new Rsdoctor session starts.
+   */
+  cacheMarkerPath?: string;
   cwd: string;
   /**
    * the url host of http server(which used to collect data).

--- a/packages/core/tests/plugins/loader.test.ts
+++ b/packages/core/tests/plugins/loader.test.ts
@@ -2,8 +2,11 @@ import { Loader } from '@rsdoctor/shared/common-browser';
 import { rspack } from '@rspack/core';
 import { describe, it, expect } from '@rstest/core';
 import path from 'path';
-import { ProxyLoaderInternalOptions } from '@/types';
+import fs from 'node:fs';
+import os from 'node:os';
+import type { ProxyLoaderInternalOptions, ProxyLoaderOptions } from '@/types';
 import { interceptLoader } from '@/inner-plugins/utils';
+import { InternalLoaderPlugin } from '@/inner-plugins/plugins/loader';
 
 describe('test src/utils/loader.ts', () => {
   describe('interceptLoader()', () => {
@@ -341,6 +344,55 @@ describe('test src/utils/loader.ts', () => {
           },
         },
       ]);
+    });
+
+    it('rotates the persistent-cache marker between Rsdoctor sessions', () => {
+      const outputDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'rsdoctor-loader-cache-'),
+      );
+      try {
+        const persistentCompiler = rspack({
+          context: exampleWebpackPath,
+          cache: {
+            type: 'persistent',
+            storage: {
+              type: 'filesystem',
+              directory: path.join(outputDir, 'rspack-cache'),
+            },
+          },
+        });
+        const createPlugin = () =>
+          new InternalLoaderPlugin({
+            options: {
+              loaderInterceptorOptions: { skipLoaders: [] },
+            },
+            sdk: {
+              outputDir,
+              root: exampleWebpackPath,
+              server: { origin: 'http://localhost:5100' },
+            },
+          } as any);
+        const rule = [{ test: /\.js$/, loader: babelLoader }];
+        const getCacheMarkerPath = (plugin: InternalLoaderPlugin<any>) => {
+          const [result] = plugin.getInterceptRules(
+            persistentCompiler,
+            rule,
+          ) as Array<{ options: ProxyLoaderOptions }>;
+          return result.options[Loader.LoaderInternalPropertyName]
+            .cacheMarkerPath!;
+        };
+
+        const firstPlugin = createPlugin();
+        const markerPath = getCacheMarkerPath(firstPlugin);
+        const firstMarker = fs.readFileSync(markerPath, 'utf8');
+        expect(getCacheMarkerPath(firstPlugin)).toBe(markerPath);
+        expect(fs.readFileSync(markerPath, 'utf8')).toBe(firstMarker);
+
+        expect(getCacheMarkerPath(createPlugin())).toBe(markerPath);
+        expect(fs.readFileSync(markerPath, 'utf8')).not.toBe(firstMarker);
+      } finally {
+        fs.rmSync(outputDir, { recursive: true, force: true });
+      }
     });
 
     it('builtin:swc-loader test', () => {

--- a/packages/core/tests/plugins/proxyLoader.test.ts
+++ b/packages/core/tests/plugins/proxyLoader.test.ts
@@ -53,6 +53,6 @@ describe('proxy loader cacheability', () => {
 
     expect(normalResult).toBe('source');
     expect(pitchResult).toBe('pitch');
-    expect(cacheable).not.toHaveBeenCalledWith(false);
+    expect(cacheable).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/tests/plugins/proxyLoader.test.ts
+++ b/packages/core/tests/plugins/proxyLoader.test.ts
@@ -1,0 +1,58 @@
+import path from 'node:path';
+import { afterEach, describe, expect, it, rs } from '@rstest/core';
+import { Loader } from '@rsdoctor/shared/common-browser';
+import type { Plugin, SDK } from '@rsdoctor/shared/types';
+import proxyLoader, { pitch } from '@/inner-plugins/loaders/proxy';
+import { setSDK } from '@/inner-plugins/utils/sdk';
+import type { ProxyLoaderOptions } from '@/types';
+
+afterEach(() => {
+  delete globalThis.__rsdoctor_sdk__;
+  delete globalThis.__rsdoctor_sdks__;
+});
+
+describe('proxy loader cacheability', () => {
+  it('preserves caching for normal and pitching loaders', () => {
+    setSDK({
+      name: 'web',
+      reportLoader: rs.fn(),
+      reportSourceMap: rs.fn(),
+    } as unknown as SDK.RsdoctorBuilderSDKInstance);
+
+    const loaderDirectory = path.resolve(__dirname, '../fixtures/loaders');
+    const cacheable = rs.fn();
+    const createContext = (
+      loader: string,
+    ): Plugin.LoaderContext<ProxyLoaderOptions> =>
+      ({
+        _compilation: { name: 'web' },
+        _module: {},
+        cacheable,
+        callback: rs.fn(),
+        getOptions: () => ({
+          [Loader.LoaderInternalPropertyName]: {
+            cwd: loaderDirectory,
+            hasOptions: false,
+            host: 'http://localhost:3000',
+            loader,
+            skipLoaders: [],
+          },
+        }),
+        loaderIndex: 0,
+        resourcePath: '/project/src/index.js',
+        resourceQuery: '',
+      }) as unknown as Plugin.LoaderContext<ProxyLoaderOptions>;
+
+    const normalResult = proxyLoader.call(
+      createContext(path.join(loaderDirectory, 'basic-loader.cjs')),
+      Buffer.from('source'),
+    );
+    const pitchResult = pitch.call(
+      createContext(path.join(loaderDirectory, 'pitch-loader-esm.js')),
+    );
+
+    expect(normalResult).toBe('source');
+    expect(pitchResult).toBe('pitch');
+    expect(cacheable).not.toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/core/tests/plugins/proxyLoader.test.ts
+++ b/packages/core/tests/plugins/proxyLoader.test.ts
@@ -12,7 +12,7 @@ afterEach(() => {
 });
 
 describe('proxy loader cacheability', () => {
-  it('preserves caching for normal and pitching loaders', () => {
+  it('preserves caching and registers the session marker', () => {
     setSDK({
       name: 'web',
       reportLoader: rs.fn(),
@@ -20,6 +20,8 @@ describe('proxy loader cacheability', () => {
     } as unknown as SDK.RsdoctorBuilderSDKInstance);
 
     const loaderDirectory = path.resolve(__dirname, '../fixtures/loaders');
+    const cacheMarkerPath = path.join(loaderDirectory, '.loader-cache');
+    const addBuildDependency = rs.fn();
     const cacheable = rs.fn();
     const createContext = (
       loader: string,
@@ -27,10 +29,12 @@ describe('proxy loader cacheability', () => {
       ({
         _compilation: { name: 'web' },
         _module: {},
+        addBuildDependency,
         cacheable,
         callback: rs.fn(),
         getOptions: () => ({
           [Loader.LoaderInternalPropertyName]: {
+            cacheMarkerPath,
             cwd: loaderDirectory,
             hasOptions: false,
             host: 'http://localhost:3000',
@@ -53,6 +57,8 @@ describe('proxy loader cacheability', () => {
 
     expect(normalResult).toBe('source');
     expect(pitchResult).toBe('pitch');
+    expect(addBuildDependency).toHaveBeenCalledTimes(2);
+    expect(addBuildDependency).toHaveBeenCalledWith(cacheMarkerPath);
     expect(cacheable).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Preserve Rspack/Webpack's default loader cacheability while Rsdoctor instruments normal and pitch loader execution.
- Keep the original loader's own `cacheable(false)` decision intact through the existing execution-context proxy.
- Rotate a bounded session marker and register it as a build dependency so persistent-cache entries are invalidated between separate Rsdoctor sessions and loader data is recollected.
- Add regressions for normal and pitching loader cacheability plus session-marker rotation.

### Kiali dev/HMR proof

Measured on the Kiali frontend with Rsdoctor's client server disabled. Each sample starts the dev compiler and touches `src/app/App.tsx` three times.

| Metric | Stacked base (#1905) | This PR |
| --- | ---: | ---: |
| HMR samples | 6.66s / 6.94s / 6.81s | 5.04s / 5.11s / 5.15s |
| Median HMR | 6.81s | 5.11s (**25% faster**) |
| Loader events | 2,452 | 1,234 (**50% fewer**) |
| CSS loader events | 1,608 | 402 |
| Loader report shard | 7.8 MB | 3.5 MB (**55% smaller**) |
| Total report | 33 MB | 29 MB |

The changed `App.tsx` module still produced four loader events (initial compile plus three edits), while unchanged CSS modules stopped being reprocessed on every rebuild.

### Verification

- `pnpm exec rstest run tests/plugins` — 57 tests passed
- `pnpm lint` — 0 errors and 0 warnings
- `pnpm --filter @rsdoctor/core run build`
- Prettier check on changed files

## Related Links

- Stacked on #1905
- Related to #1080 and #1521
