### PR TITLE
perf(core): skip gzip analysis in watch mode

### DIFF
--- a/packages/core/src/inner-plugins/plugins/bundle.ts
+++ b/packages/core/src/inner-plugins/plugins/bundle.ts
@@ -3,6 +3,7 @@ import type { Assets } from '@rspack/core';
 import { InternalBasePlugin } from './base';
 import { Chunks } from '@rsdoctor/shared/graph';
 import { logger, time, timeEnd } from '@/logger';
+import { getEffectiveGzipConfig } from '../utils/config';
 
 export class InternalBundlePlugin<
   T extends Plugin.BaseCompiler,
@@ -26,12 +27,12 @@ export class InternalBundlePlugin<
       if (compiler.isChild()) {
         compiler.hooks.afterCompile.tapPromise(
           this.tapPreOptions,
-          this.done.bind(this),
+          this.done.bind(this, compiler),
         );
       } else {
         compiler.hooks.done.tapPromise(
           this.tapPreOptions,
-          this.done.bind(this),
+          this.done.bind(this, compiler),
         );
       }
     } finally {
@@ -87,14 +88,17 @@ export class InternalBundlePlugin<
     }
   };
 
-  public done = async (): Promise<void> => {
+  public done = async (compiler: T): Promise<void> => {
     time('InternalBundlePlugin.done');
     try {
       if (this.scheduler.chunkGraph) {
         Chunks.assetsContents(
           this.map,
           this.scheduler.chunkGraph,
-          this.scheduler.options.supports.gzip,
+          getEffectiveGzipConfig(
+            compiler,
+            this.scheduler.options.supports.gzip,
+          ),
         );
       }
 

--- a/packages/core/src/inner-plugins/plugins/ensureModulesChunkGraph.ts
+++ b/packages/core/src/inner-plugins/plugins/ensureModulesChunkGraph.ts
@@ -12,6 +12,7 @@ import {
   type RspackNativeGraphState,
 } from './rspack';
 import { handleAfterEmitAssets } from './sourcemapTool';
+import { getEffectiveGzipConfig } from '../utils/config';
 
 /**
  * Represents a mapping item from a source map.
@@ -121,7 +122,7 @@ async function doneHandler(
    * Optionally parses bundle if enabled in options.
    */
   const shouldParseBundle = _this.options.supports.parseBundle !== false;
-  const gzip = _this.options.supports.gzip;
+  const gzip = getEffectiveGzipConfig(compiler, _this.options.supports.gzip);
   await getModulesInfos(
     compiler,
     _this.modulesGraph,

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -59,6 +59,16 @@ function normalizeGzip(value: unknown): Plugin.NormalizedGzipConfig {
     gzipLevel: normalizeGzipLevel(gzipLevel),
   };
 }
+
+export function getEffectiveGzipConfig(
+  compiler: Pick<Plugin.BaseCompiler, 'watchMode' | 'parentCompilation'>,
+  gzip: Plugin.NormalizedGzipConfig,
+): Plugin.NormalizedGzipConfig {
+  const isWatching =
+    compiler.watchMode || compiler.parentCompilation?.compiler.watchMode;
+  return isWatching ? false : gzip;
+}
+
 function normalizeFeatures(features: any, mode: keyof typeof SDK.IMode) {
   if (Array.isArray(features)) {
     return {

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -60,13 +60,19 @@ function normalizeGzip(value: unknown): Plugin.NormalizedGzipConfig {
   };
 }
 
+export function isCompilerWatching(
+  compiler: Pick<Plugin.BaseCompiler, 'watchMode' | 'parentCompilation'>,
+): boolean {
+  return Boolean(
+    compiler.watchMode || compiler.parentCompilation?.compiler.watchMode,
+  );
+}
+
 export function getEffectiveGzipConfig(
   compiler: Pick<Plugin.BaseCompiler, 'watchMode' | 'parentCompilation'>,
   gzip: Plugin.NormalizedGzipConfig,
 ): Plugin.NormalizedGzipConfig {
-  const isWatching =
-    compiler.watchMode || compiler.parentCompilation?.compiler.watchMode;
-  return isWatching ? false : gzip;
+  return isCompilerWatching(compiler) ? false : gzip;
 }
 
 function normalizeFeatures(features: any, mode: keyof typeof SDK.IMode) {

--- a/packages/core/tests/plugins/bundle.test.ts
+++ b/packages/core/tests/plugins/bundle.test.ts
@@ -44,4 +44,16 @@ describe('InternalBundlePlugin', () => {
       expect(asset.gzipSize).toBe(expectedGzipSize);
     },
   );
+
+  it('clears asset gzip sizes when a compiler switches to watch mode', async () => {
+    const { asset, plugin } = createHarness();
+    const compiler = { watchMode: false } as Plugin.BaseCompiler;
+
+    await plugin.done(compiler);
+    expect(asset.gzipSize).toBeGreaterThan(0);
+
+    compiler.watchMode = true;
+    await plugin.done(compiler);
+    expect(asset.gzipSize).toBeUndefined();
+  });
 });

--- a/packages/core/tests/plugins/bundle.test.ts
+++ b/packages/core/tests/plugins/bundle.test.ts
@@ -1,0 +1,47 @@
+import { gzipSync } from 'node:zlib';
+import { describe, expect, it, rs } from '@rstest/core';
+import { Asset, ChunkGraph } from '@rsdoctor/shared/graph';
+import type { Plugin } from '@rsdoctor/shared/types';
+import { InternalBundlePlugin } from '@/inner-plugins/plugins/bundle';
+
+const source = 'export const value = 1;';
+
+function createHarness() {
+  const chunkGraph = new ChunkGraph();
+  const asset = new Asset('index.js', source.length, [], '');
+  chunkGraph.addAsset(asset);
+
+  const plugin = new InternalBundlePlugin({
+    chunkGraph,
+    options: {
+      supports: {
+        gzip: { gzipLevel: 9 },
+      },
+    },
+    sdk: {
+      addClientRoutes: rs.fn(),
+    },
+  } as any);
+  plugin.map.set('index.js', { content: source });
+
+  return { asset, plugin };
+}
+
+describe('InternalBundlePlugin', () => {
+  it.each([
+    { watchMode: true, expectedGzipSize: undefined },
+    {
+      watchMode: false,
+      expectedGzipSize: gzipSync(source, { level: 9 }).length,
+    },
+  ])(
+    'uses watchMode=$watchMode when calculating asset gzip sizes',
+    async ({ watchMode, expectedGzipSize }) => {
+      const { asset, plugin } = createHarness();
+
+      await plugin.done({ watchMode } as Plugin.BaseCompiler);
+
+      expect(asset.gzipSize).toBe(expectedGzipSize);
+    },
+  );
+});

--- a/packages/core/tests/plugins/bundle.test.ts
+++ b/packages/core/tests/plugins/bundle.test.ts
@@ -29,17 +29,30 @@ function createHarness() {
 
 describe('InternalBundlePlugin', () => {
   it.each([
-    { watchMode: true, expectedGzipSize: undefined },
     {
-      watchMode: false,
+      compiler: { watchMode: true },
+      expectedGzipSize: undefined,
+      mode: 'watch compiler',
+    },
+    {
+      compiler: { watchMode: false },
       expectedGzipSize: gzipSync(source, { level: 9 }).length,
+      mode: 'one-time compiler',
+    },
+    {
+      compiler: {
+        watchMode: false,
+        parentCompilation: { compiler: { watchMode: true } },
+      },
+      expectedGzipSize: undefined,
+      mode: 'child of a watch compiler',
     },
   ])(
-    'uses watchMode=$watchMode when calculating asset gzip sizes',
-    async ({ watchMode, expectedGzipSize }) => {
+    'calculates asset gzip sizes for a $mode',
+    async ({ compiler, expectedGzipSize }) => {
       const { asset, plugin } = createHarness();
 
-      await plugin.done({ watchMode } as Plugin.BaseCompiler);
+      await plugin.done(compiler as unknown as Plugin.BaseCompiler);
 
       expect(asset.gzipSize).toBe(expectedGzipSize);
     },

--- a/packages/core/tests/rspack-plugin/native-plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/native-plugin.test.ts
@@ -1,3 +1,4 @@
+import { gzipSync } from 'node:zlib';
 import { AsyncSeriesHook, SyncHook } from '@rspack/lite-tapable';
 import { describe, expect, it, rs } from '@rstest/core';
 import { ModuleGraph } from '@rsdoctor/shared/graph';
@@ -19,7 +20,7 @@ function createNativeHooks() {
   };
 }
 
-function createHarness() {
+function createHarness(watchMode = false) {
   const nativeHooks = createNativeHooks();
   const compilationHook = new SyncHook<[Plugin.BaseCompilation]>([
     'compilation',
@@ -29,6 +30,7 @@ function createHarness() {
     getCompilationHooks: () => nativeHooks,
   };
   const compiler = {
+    watchMode,
     rspack: {
       experiments: {
         RsdoctorPlugin,
@@ -76,9 +78,31 @@ function createHarness() {
 
   return {
     doneHook,
+    modulesGraph: plugin.modulesGraph,
     nativeHooks,
     reportChunkGraph,
     reportModuleGraph,
+  };
+}
+
+function createNativeModule(
+  data: Partial<Plugin.RspackNativeModule> &
+    Pick<Plugin.RspackNativeModule, 'ukey' | 'identifier' | 'path'>,
+): Plugin.RspackNativeModule {
+  return {
+    isEntry: false,
+    kind: 'normal',
+    layer: undefined,
+    dependencies: [],
+    imported: [],
+    modules: [],
+    belongModules: [],
+    chunks: [],
+    issuerPath: [],
+    bailoutReason: [],
+    sideEffectsLocations: [],
+    exportsType: 'namespace',
+    ...data,
   };
 }
 
@@ -117,6 +141,51 @@ describe('Rspack native graph collection', () => {
     expect(reportModuleGraph).toHaveBeenCalledTimes(1);
     expect(reportChunkGraph).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    { watchMode: true, expectedGzipSize: 0 },
+    {
+      watchMode: false,
+      expectedGzipSize: gzipSync('export const value = 1;', { level: 9 })
+        .length,
+    },
+  ])(
+    'uses watchMode=$watchMode when calculating module gzip sizes',
+    async ({ watchMode, expectedGzipSize }) => {
+      const { doneHook, modulesGraph, nativeHooks } = createHarness(watchMode);
+      const source = 'export const value = 1;';
+
+      nativeHooks.chunkGraph.call({ chunks: [], entrypoints: [] });
+      nativeHooks.moduleGraph.call({
+        modules: [
+          createNativeModule({
+            ukey: 1,
+            identifier: '/src/index.js',
+            path: '/src/index.js',
+          }),
+        ],
+        dependencies: [],
+        chunkModules: [],
+        connectionsOnlyImports: [],
+      });
+      nativeHooks.moduleSources.call({
+        moduleOriginalSources: [
+          {
+            module: 1,
+            source,
+            size: source.length,
+          },
+        ],
+        jsonModuleSizes: [],
+      });
+
+      await doneHook.promise({});
+
+      expect(modulesGraph.getModuleById(1)?.getSize().gzipSize).toBe(
+        expectedGzipSize,
+      );
+    },
+  );
 
   it('fails when native graph hooks do not provide data', async () => {
     const { doneHook } = createHarness();

--- a/packages/core/tests/rspack-plugin/native-plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/native-plugin.test.ts
@@ -77,6 +77,7 @@ function createHarness(watchMode = false) {
   } as unknown as Plugin.BaseCompilation);
 
   return {
+    compiler,
     doneHook,
     modulesGraph: plugin.modulesGraph,
     nativeHooks,
@@ -186,6 +187,38 @@ describe('Rspack native graph collection', () => {
       );
     },
   );
+
+  it('clears module gzip sizes when a compiler switches to watch mode', async () => {
+    const { compiler, doneHook, modulesGraph, nativeHooks } = createHarness();
+    const source = 'export const value = 1;';
+
+    nativeHooks.chunkGraph.call({ chunks: [], entrypoints: [] });
+    nativeHooks.moduleGraph.call({
+      modules: [
+        createNativeModule({
+          ukey: 1,
+          identifier: '/src/index.js',
+          path: '/src/index.js',
+        }),
+      ],
+      dependencies: [],
+      chunkModules: [],
+      connectionsOnlyImports: [],
+    });
+    nativeHooks.moduleSources.call({
+      moduleOriginalSources: [{ module: 1, source, size: source.length }],
+      jsonModuleSizes: [],
+    });
+
+    await doneHook.promise({});
+    expect(modulesGraph.getModuleById(1)?.getSize().gzipSize).toBeGreaterThan(
+      0,
+    );
+
+    compiler.watchMode = true;
+    await doneHook.promise({});
+    expect(modulesGraph.getModuleById(1)?.getSize().gzipSize).toBe(0);
+  });
 
   it('fails when native graph hooks do not provide data', async () => {
     const { doneHook } = createHarness();

--- a/packages/document/docs/en/config/options/supports.mdx
+++ b/packages/document/docs/en/config/options/supports.mdx
@@ -83,6 +83,8 @@ Disabling the Parse Bundle capability will only affect the visibility of the Bun
 
 Controls whether Rsdoctor calculates gzip sizes for assets and modules. This calculation only affects the size data in the Rsdoctor report; it does not modify or compress the build output.
 
+Rsdoctor skips gzip size calculation while the compiler is running in watch mode. Run a one-time build when you need gzip sizes for production bundle analysis.
+
 Gzip size calculation is enabled by default with a compression level of `6`. Set `gzip` to an object to customize `gzipLevel`, which must be an integer between `0` and `9`:
 
 ```ts

--- a/packages/document/docs/zh/config/options/supports.mdx
+++ b/packages/document/docs/zh/config/options/supports.mdx
@@ -82,6 +82,8 @@ chain.plugin('Rsdoctor').use(RsdoctorRspackPlugin, [
 
 控制 Rsdoctor 是否计算 Asset 和 Module 的 gzip 大小。该计算只影响 Rsdoctor 报告中的大小数据，不会修改或压缩构建产物。
 
+当编译器以 watch 模式运行时，Rsdoctor 会跳过 gzip 大小计算。如需分析生产 Bundle 的 gzip 大小，请运行一次性构建。
+
 gzip 大小计算默认开启，默认压缩级别为 `6`。将 `gzip` 配置为对象可以自定义 `gzipLevel`，其值必须是 `0` 到 `9` 之间的整数：
 
 ```ts

--- a/packages/shared/src/graph/transform/chunks/assetsContent.ts
+++ b/packages/shared/src/graph/transform/chunks/assetsContent.ts
@@ -15,7 +15,9 @@ export function assetsContents(
     if (content.length > 0 && asset.size === 0) {
       asset.size = Buffer.byteLength(content, 'utf8');
     }
-    if (COMPRESSIBLE_REGEX.test(asset.path) && gzip !== false) {
+    if (gzip === false) {
+      asset.gzipSize = undefined;
+    } else if (COMPRESSIBLE_REGEX.test(asset.path)) {
       asset.setGzipSize(content, gzip.gzipLevel);
     }
   });

--- a/packages/shared/src/graph/transform/chunks/assetsModules.ts
+++ b/packages/shared/src/graph/transform/chunks/assetsModules.ts
@@ -77,6 +77,12 @@ export async function getAssetsModulesData(
     gzipLevel: opts.gzipLevel,
   };
 
+  if (gzipOptions.gzip === false) {
+    for (const module of moduleGraph.getModules()) {
+      module.setSize({ gzipSize: 0 });
+    }
+  }
+
   // Parse assets with sourcemap using sourcemap data
   if (sourceMapSets.size > 0) {
     time(`Start Parse bundle by sourcemap.`);


### PR DESCRIPTION
## Summary

- Skip Rsdoctor's report-only asset and module gzip calculations while Rspack is in watch mode, including child compilers owned by a watching parent.
- Preserve the configured gzip level for every one-shot build, including development-mode builds.
- Add integration coverage for both native module-graph and bundle-asset gzip paths.
- Document the watch-mode behavior in English and Chinese.

### Kiali dev/HMR proof

Measured on the Kiali frontend with Rsdoctor's client server disabled and gzip left at its default enabled setting. Each sample touches `src/app/App.tsx`.

| Metric | Stacked base (#1906) | This PR |
| --- | ---: | ---: |
| HMR samples | 5.04s / 5.11s / 5.15s | 3.64s / 3.64s / 3.73s |
| Median HMR | 5.11s | 3.64s (**29% faster**) |
| Watch-report nonzero module gzip sizes | 7,949 | 0 |

A control run with `supports.gzip: false` measured 3.70s / 4.23s / 3.96s, confirming the optimized default follows the gzip-off watch path.

### Build-mode proof

A separate one-shot Kiali production build completed successfully in 15.6s and its Rsdoctor report contained:

- 7,988 nonzero module gzip sizes
- 13 nonzero asset gzip sizes

The tests assert exact gzip byte counts at level 9 for non-watch compilers and zero/undefined values for watch compilers.

### Verification

- `pnpm exec rstest run tests/plugins tests/rspack-plugin tests/graph/gzip.test.ts tests/build/utils/config.test.ts` — 142 tests passed
- `pnpm lint` — 0 errors and 0 warnings
- `pnpm --filter @rsdoctor/core run build`
- Prettier and `git diff --check`

## Related Links

- Stacked on #1906
- Related to #1080 and #1521
