### PR TITLE
release: v1.6.2

### DIFF
--- a/.changeset/bright-gzip-sizes.md
+++ b/.changeset/bright-gzip-sizes.md
@@ -1,5 +1,0 @@
----
-'@rsdoctor/components': minor
----
-
-Expose gzip sizes in the bundle overview and treemap controls.

--- a/.changeset/fix-large-manifest-sharding.md
+++ b/.changeset/fix-large-manifest-sharding.md
@@ -1,6 +1,0 @@
----
-'@rsdoctor/sdk': patch
-'@rsdoctor/utils': patch
----
-
-Fix large manifest serialization so streamed JSON fragments use one continuous deflate/Base64 stream, are written and read with bounded sharding buffers, and do not lose or reorder fragments.

--- a/.changeset/fix-overall-layout-ratio.md
+++ b/.changeset/fix-overall-layout-ratio.md
@@ -1,5 +1,0 @@
----
-'@rsdoctor/components': patch
----
-
-Use a stable 3:1 desktop column ratio on the Overall page while preserving the single-column responsive layout.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/cli",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/client",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "main": "dist/index.html",
   "repository": {
     "type": "git",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/components",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "license": "MIT",
   "types": "dist/index.d.ts",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/core",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/docs",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "scripts": {
     "dev": "cross-env RSPRESS_PERSIST_CACHE=false rspress dev",
     "build": "cross-env RSPRESS_PERSIST_CACHE=false rspress build && sh build.sh",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/graph",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/rspack-plugin/package.json
+++ b/packages/rspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/rspack-plugin",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/sdk",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/types",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/utils",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/webpack-plugin",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",


### PR DESCRIPTION
## Summary

Release @rsdoctor/* packages v1.6.2. The independently versioned @rsdoctor/mcp-server package remains at v0.1.5.

## Related Links

https://github.com/web-infra-dev/rsdoctor/releases/tag/v1.6.2