### PR TITLE
refactor(core): remove redundant writeDataJson option

### DIFF
--- a/packages/core/src/inner-plugins/utils/normalize-config.ts
+++ b/packages/core/src/inner-plugins/utils/normalize-config.ts
@@ -36,7 +36,6 @@ export function processBriefHtmlModeConfig(
 ): Config.BriefModeOptions {
   let htmlOptions: Config.BriefConfig = {
     reportHtmlName: undefined,
-    writeDataJson: false,
   };
   let jsonOptions: Config.JsonOptions = {};
   const briefOptions = output?.options || {};
@@ -63,10 +62,6 @@ export function processBriefHtmlModeConfig(
         outputBriefOptions?.reportHtmlName ||
         outputBrief?.reportHtmlName ||
         undefined,
-      writeDataJson:
-        outputBriefOptions?.writeDataJson ||
-        outputBrief?.writeDataJson ||
-        false,
     };
   }
 

--- a/packages/core/tests/build/utils/config.test.ts
+++ b/packages/core/tests/build/utils/config.test.ts
@@ -332,7 +332,6 @@ describe('normalizeUserConfig', () => {
         type: ['json'],
         htmlOptions: {
           reportHtmlName: undefined,
-          writeDataJson: false,
         },
         jsonOptions: {
           fileName: 'rsdoctor-data.json',

--- a/packages/core/tests/plugins/normalize-config.test.ts
+++ b/packages/core/tests/plugins/normalize-config.test.ts
@@ -16,7 +16,6 @@ describe('test src/inner-plugins/utils/normalize-config.ts', () => {
       };
       const brief: Config.BriefConfig = {
         reportHtmlName: 'test.html',
-        writeDataJson: false,
       };
 
       const result = processModeConfigurations('brief', output, brief);
@@ -25,7 +24,6 @@ describe('test src/inner-plugins/utils/normalize-config.ts', () => {
         type: ['html'],
         htmlOptions: {
           reportHtmlName: 'test.html',
-          writeDataJson: false,
         },
         jsonOptions: {},
       });
@@ -53,7 +51,6 @@ describe('test src/inner-plugins/utils/normalize-config.ts', () => {
         type: ['json'],
         htmlOptions: {
           reportHtmlName: undefined,
-          writeDataJson: false,
         },
         jsonOptions: {
           sections: {
@@ -72,7 +69,6 @@ describe('test src/inner-plugins/utils/normalize-config.ts', () => {
           type: ['html', 'json'],
           htmlOptions: {
             reportHtmlName: 'custom.html',
-            writeDataJson: true,
           },
           jsonOptions: {
             sections: {
@@ -90,7 +86,6 @@ describe('test src/inner-plugins/utils/normalize-config.ts', () => {
         type: ['html', 'json'],
         htmlOptions: {
           reportHtmlName: 'custom.html',
-          writeDataJson: true,
         },
         jsonOptions: {
           sections: {
@@ -126,7 +121,6 @@ describe('test src/inner-plugins/utils/normalize-config.ts', () => {
         type: ['html'],
         htmlOptions: {
           reportHtmlName: undefined,
-          writeDataJson: false,
         },
         jsonOptions: {},
       });
@@ -145,7 +139,6 @@ describe('test src/inner-plugins/utils/normalize-config.ts', () => {
         type: ['json'],
         htmlOptions: {
           reportHtmlName: undefined,
-          writeDataJson: false,
         },
         jsonOptions: {
           fileName: 'rsdoctor-data.json',
@@ -178,7 +171,6 @@ describe('test src/inner-plugins/utils/normalize-config.ts', () => {
         type: ['json'],
         htmlOptions: {
           reportHtmlName: undefined,
-          writeDataJson: false,
         },
         jsonOptions: {
           sections: {
@@ -196,7 +188,6 @@ describe('test src/inner-plugins/utils/normalize-config.ts', () => {
           type: ['html', 'json'],
           htmlOptions: {
             reportHtmlName: 'report.html',
-            writeDataJson: true,
           },
           jsonOptions: {
             sections: {
@@ -209,7 +200,6 @@ describe('test src/inner-plugins/utils/normalize-config.ts', () => {
       };
       const brief: Config.BriefConfig = {
         reportHtmlName: 'fallback.html',
-        writeDataJson: false,
       };
 
       const result = processBriefHtmlModeConfig(output, brief);
@@ -218,7 +208,6 @@ describe('test src/inner-plugins/utils/normalize-config.ts', () => {
         type: ['html', 'json'],
         htmlOptions: {
           reportHtmlName: 'report.html', // Should use output.options.htmlOptions first
-          writeDataJson: true,
         },
         jsonOptions: {
           sections: {
@@ -236,19 +225,16 @@ describe('test src/inner-plugins/utils/normalize-config.ts', () => {
           type: ['html'],
           htmlOptions: {
             reportHtmlName: 'priority.html',
-            writeDataJson: true,
           },
         },
       };
       const brief: Config.BriefConfig = {
         reportHtmlName: 'fallback.html',
-        writeDataJson: false,
       };
 
       const result = processBriefHtmlModeConfig(output, brief);
 
       expect(result.htmlOptions?.reportHtmlName).toBe('priority.html');
-      expect(result.htmlOptions?.writeDataJson).toBe(true);
     });
 
     it('should fallback to brief parameter when output.options is not provided', () => {
@@ -259,13 +245,11 @@ describe('test src/inner-plugins/utils/normalize-config.ts', () => {
       };
       const brief: Config.BriefConfig = {
         reportHtmlName: 'fallback.html',
-        writeDataJson: true,
       };
 
       const result = processBriefHtmlModeConfig(output, brief);
 
       expect(result.htmlOptions?.reportHtmlName).toBe('fallback.html');
-      expect(result.htmlOptions?.writeDataJson).toBe(true);
     });
   });
 });

--- a/packages/document/docs/en/config/options/brief.mdx
+++ b/packages/document/docs/en/config/options/brief.mdx
@@ -13,14 +13,12 @@ Deprecated in V2, please use [output.mode: 'brief'](/config/options/output#mode)
 Detailed configuration options for Brief mode are as follows:
 
 - **reportHtmlName:** Configures the filename of the HTML report in Brief mode. The default value is `report-rsdoctor.html`.
-- **writeDataJson:** (Deprecated, please use `output.options.type: ['json', 'html']`, refer to [output.options.type](/config/options/output#options).) By default, Brief mode injects the analysis data directly into the HTML file, so no additional build analysis data files are generated. If you need to generate additional local JSON data files, you need to configure `writeDataJson: true`.
 
 ## briefType
 
 ```ts
 interface BriefConfig {
   reportHtmlName?: string | undefined;
-  writeDataJson: boolean;
 }
 ```
 

--- a/packages/document/docs/en/config/options/output.mdx
+++ b/packages/document/docs/en/config/options/output.mdx
@@ -139,8 +139,6 @@ interface BriefModeOptions {
 interface BriefConfig {
   /** HTML report filename, defaults to report-rsdoctor.html */
   reportHtmlName?: string;
-  /** Whether to additionally generate JSON data files, defaults to false */
-  writeDataJson: boolean;
 }
 
 interface JsonOptions {

--- a/packages/document/docs/zh/config/options/brief.mdx
+++ b/packages/document/docs/zh/config/options/brief.mdx
@@ -13,14 +13,12 @@ V2 中即将废弃，请使用 [output.mode: 'brief'](/config/options/output#mod
 Brief 模式的详细配置选项如下：
 
 - **reportHtmlName:** 配置 Brief 模式下 HTML 报告的文件名称，默认值为 `report-rsdoctor.html`。
-- **writeDataJson:** (已废弃，请使用 `output.options.type: ['json', 'html']`, 参考 [output.options.type](/config/options/output#options)。)默认情况下，Brief 模式会将分析数据直接注入到 HTML 文件中，因此不会额外生成构建分析数据文件。如果需要额外在本地生成 JSON 数据文件，则需要配置 `writeDataJson: true`。
 
 ## briefType
 
 ```ts
 interface BriefConfig {
   reportHtmlName?: string | undefined;
-  writeDataJson: boolean;
 }
 ```
 

--- a/packages/document/docs/zh/config/options/output.mdx
+++ b/packages/document/docs/zh/config/options/output.mdx
@@ -138,8 +138,6 @@ interface BriefModeOptions {
 interface BriefConfig {
   /** HTML 报告文件名，默认为 report-rsdoctor.html */
   reportHtmlName?: string;
-  /** 是否额外生成 JSON 数据文件，默认为 false */
-  writeDataJson: boolean;
 }
 
 interface JsonOptions {

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -1,6 +1,5 @@
 export interface BriefConfig {
   reportHtmlName?: string;
-  writeDataJson: boolean;
 }
 
 /**
@@ -100,6 +99,4 @@ export type IOutput<T extends 'brief' | 'normal'> = T extends 'brief'
     : BriefModeConfig | NormalModeConfig | OutputBaseConfig;
 
 export type NewReportCodeType =
-  | 'noModuleSource'
-  | 'noAssetsAndModuleSource'
-  | 'noCode';
+  'noModuleSource' | 'noAssetsAndModuleSource' | 'noCode';


### PR DESCRIPTION
## Summary

`writeDataJson` duplicates `output.options.type` and is no longer read when reports are generated. This PR removes the option from the public type and configuration normalization; use `type: ['html', 'json']` to generate both formats.

## Related Links

None