### PR TITLE
fix(core): restore Browserslist fallback for E1004

### DIFF
--- a/packages/core/src/rules/rules/ecma-version-check/index.ts
+++ b/packages/core/src/rules/rules/ecma-version-check/index.ts
@@ -21,8 +21,15 @@ function isExcludedOutput(
 
   return conditions.some((condition) => {
     if (typeof condition === 'function') return condition(filepath);
-    if (typeof condition === 'string') return filepath.startsWith(condition);
-    return condition.test(normalizedPath);
+    if (typeof condition === 'string') {
+      return normalizedPath.startsWith(condition.replace(/\\/g, '/'));
+    }
+
+    const lastIndex = condition.lastIndex;
+    condition.lastIndex = 0;
+    const isExcluded = condition.test(normalizedPath);
+    condition.lastIndex = lastIndex;
+    return isExcluded;
   });
 }
 
@@ -55,12 +62,14 @@ export const rule: Linter.RuleData<Config, typeof title> = defineRule<
         ecmaVersion,
       } = ruleConfig;
       const hasEcmaVersion = typeof ecmaVersion !== 'undefined';
+      const buildConfig = configs[0]?.config;
+      const context = buildConfig?.context || root;
       const finalTargets =
         targets ??
         (hasEcmaVersion
           ? []
           : loadConfig({
-              path: root,
+              path: context,
               env: 'production',
             })) ??
         [];
@@ -68,8 +77,6 @@ export const rule: Linter.RuleData<Config, typeof title> = defineRule<
       // Explicitly passing an empty targets array keeps the rule disabled.
       if (!finalTargets.length && !hasEcmaVersion) return;
 
-      const buildConfig = configs[0]?.config;
-      const context = buildConfig?.context || root;
       const outputDir = buildConfig?.output?.path || path.resolve(root, 'dist');
       const checkSyntax = new CheckSyntax({
         exclude,

--- a/packages/core/src/rules/rules/ecma-version-check/index.ts
+++ b/packages/core/src/rules/rules/ecma-version-check/index.ts
@@ -3,12 +3,28 @@ import { CheckSyntax } from '@rsbuild/plugin-check-syntax';
 import { loadConfig } from 'browserslist-load-config';
 
 import { defineRule } from '../../rule';
-import { Config } from './types';
+import type { Config } from './types';
 
 import { Linter } from '@rsdoctor/shared/types';
 export type { Config } from './types';
 
 const title = 'ecma-version-check';
+
+function isExcludedOutput(
+  filepath: string,
+  exclude: Config['excludeOutput'],
+): boolean {
+  if (!exclude) return false;
+
+  const conditions = Array.isArray(exclude) ? exclude : [exclude];
+  const normalizedPath = filepath.replace(/\\/g, '/');
+
+  return conditions.some((condition) => {
+    if (typeof condition === 'function') return condition(filepath);
+    if (typeof condition === 'string') return filepath.startsWith(condition);
+    return condition.test(normalizedPath);
+  });
+}
 
 export const rule: Linter.RuleData<Config, typeof title> = defineRule<
   typeof title,
@@ -22,53 +38,64 @@ export const rule: Linter.RuleData<Config, typeof title> = defineRule<
       severity: Linter.Severity.Warn,
       defaultConfig: {
         ecmaVersion: undefined,
-        targets: [],
       },
     },
     async check({ chunkGraph, report, ruleConfig, root, configs }) {
-      for (const asset of chunkGraph.getAssets()) {
-        if (
-          path.extname(asset.path) !== '.js' &&
-          path.extname(asset.path) !== '.bundle'
-        ) {
-          continue;
-        }
+      const assets = chunkGraph.getAssets().filter((asset) => {
+        const extension = path.extname(asset.path);
+        return extension === '.js' || extension === '.bundle';
+      });
+      if (!assets.length) return;
 
-        const browserslistConfig = loadConfig({
-          path: root,
-          env: 'production',
-        });
-        const { exclude, excludeOutput, targets, ecmaVersion } = ruleConfig;
-        const finalTargets = targets || browserslistConfig || [];
-        // disable check syntax
-        if (!finalTargets.length && !ecmaVersion) {
-          return;
-        }
+      const {
+        exclude,
+        excludeErrorMessage,
+        excludeOutput,
+        targets,
+        ecmaVersion,
+      } = ruleConfig;
+      const hasEcmaVersion = typeof ecmaVersion !== 'undefined';
+      const finalTargets =
+        targets ??
+        (hasEcmaVersion
+          ? []
+          : loadConfig({
+              path: root,
+              env: 'production',
+            })) ??
+        [];
 
-        const buildConfig = configs[0]?.config;
-        const context = buildConfig?.context || root;
-        const checkSyntax = new CheckSyntax({
-          exclude,
-          excludeOutput,
-          ecmaVersion,
-          rootPath: context,
-          targets: finalTargets,
-        });
+      // Explicitly passing an empty targets array keeps the rule disabled.
+      if (!finalTargets.length && !hasEcmaVersion) return;
 
-        const outputDir =
-          buildConfig?.output?.path || path.resolve(root, 'dist');
+      const buildConfig = configs[0]?.config;
+      const context = buildConfig?.context || root;
+      const outputDir = buildConfig?.output?.path || path.resolve(root, 'dist');
+      const checkSyntax = new CheckSyntax({
+        exclude,
+        excludeErrorMessage,
+        excludeOutput,
+        ecmaVersion,
+        rootPath: context,
+        targets: finalTargets,
+      });
+
+      for (const asset of assets) {
         const assetPath = path.resolve(outputDir, asset.path);
+        if (isExcludedOutput(assetPath, excludeOutput)) continue;
+
         await checkSyntax.check(assetPath, asset.content);
-        checkSyntax.errors.forEach((err) => {
-          report({
-            message: `Found syntax that does not match "ecmaVersion <= ${checkSyntax.ecmaVersion}"`,
-            detail: {
-              error: err,
-              type: 'link',
-            },
-          });
-        });
       }
+
+      checkSyntax.errors.forEach((err) => {
+        report({
+          message: `Found syntax that does not match "ecmaVersion <= ${checkSyntax.ecmaVersion}"`,
+          detail: {
+            error: err,
+            type: 'link',
+          },
+        });
+      });
     },
   };
 });

--- a/packages/core/tests/rules/ecma-version-check.test.ts
+++ b/packages/core/tests/rules/ecma-version-check.test.ts
@@ -37,6 +37,7 @@ async function runRule(
     { path: 'main.js', content: 'const main = 1;' },
     { path: 'async.bundle', content: 'const asyncChunk = 1;' },
   ],
+  context = root,
 ) {
   const reports: unknown[] = [];
 
@@ -47,7 +48,7 @@ async function runRule(
     configs: [
       {
         config: {
-          context: root,
+          context,
           output: { path: outputPath },
         },
       },
@@ -82,6 +83,19 @@ describe('ecma-version-check rule', () => {
     expect(mocks.options).toHaveLength(1);
     expect(mocks.options[0].targets).toEqual(['ie 11']);
     expect(mocks.check).toHaveBeenCalledTimes(2);
+  });
+
+  it('resolves project Browserslist from the build context', async () => {
+    const context = path.join(root, 'packages/app');
+    mocks.loadConfig.mockReturnValue(['ie 11']);
+
+    await runRule({}, undefined, context);
+
+    expect(mocks.loadConfig).toHaveBeenCalledWith({
+      path: context,
+      env: 'production',
+    });
+    expect(mocks.options[0].rootPath).toBe(context);
   });
 
   it('uses explicit targets without loading project Browserslist', async () => {
@@ -139,5 +153,26 @@ describe('ecma-version-check rule', () => {
       path.join(outputPath, 'async.bundle'),
       'const asyncChunk = 1;',
     );
+  });
+
+  it('normalizes string output exclusions', async () => {
+    await runRule(
+      {
+        ecmaVersion: 5,
+        excludeOutput: `${outputPath}/nested/`,
+      },
+      [{ path: 'nested\\main.js', content: 'const main = 1;' }],
+    );
+
+    expect(mocks.check).not.toHaveBeenCalled();
+  });
+
+  it('resets stateful output exclusion regular expressions', async () => {
+    const excludeOutput = /dist\/.*\.(?:js|bundle)$/g;
+
+    await runRule({ ecmaVersion: 5, excludeOutput });
+
+    expect(mocks.check).not.toHaveBeenCalled();
+    expect(excludeOutput.lastIndex).toBe(0);
   });
 });

--- a/packages/core/tests/rules/ecma-version-check.test.ts
+++ b/packages/core/tests/rules/ecma-version-check.test.ts
@@ -1,0 +1,143 @@
+import path from 'node:path';
+import { beforeEach, describe, expect, it, rs } from '@rstest/core';
+
+const mocks = rs.hoisted(() => ({
+  check: rs.fn(async () => {}),
+  loadConfig: rs.fn(),
+  options: [] as Record<string, unknown>[],
+}));
+
+rs.mock('browserslist-load-config', () => ({
+  loadConfig: mocks.loadConfig,
+}));
+
+rs.mock('@rsbuild/plugin-check-syntax', () => ({
+  CheckSyntax: class {
+    errors: unknown[] = [];
+    ecmaVersion: number;
+
+    constructor(options: Record<string, unknown>) {
+      mocks.options.push(options);
+      this.ecmaVersion = (options.ecmaVersion as number | undefined) ?? 5;
+    }
+
+    check = mocks.check;
+  },
+}));
+
+import type { Config } from '../../src/rules/rules/ecma-version-check';
+import { rule } from '../../src/rules/rules/ecma-version-check';
+
+const root = path.resolve('/project');
+const outputPath = path.join(root, 'dist');
+
+async function runRule(
+  ruleConfig: Config,
+  assets = [
+    { path: 'main.js', content: 'const main = 1;' },
+    { path: 'async.bundle', content: 'const asyncChunk = 1;' },
+  ],
+) {
+  const reports: unknown[] = [];
+
+  await rule.check({
+    chunkGraph: {
+      getAssets: () => assets,
+    },
+    configs: [
+      {
+        config: {
+          context: root,
+          output: { path: outputPath },
+        },
+      },
+    ],
+    report: (data: unknown) => reports.push(data),
+    root,
+    ruleConfig,
+  } as any);
+
+  return reports;
+}
+
+beforeEach(() => {
+  mocks.check.mockReset();
+  mocks.check.mockResolvedValue(undefined);
+  mocks.loadConfig.mockReset();
+  mocks.options.length = 0;
+});
+
+describe('ecma-version-check rule', () => {
+  it('falls back to the project Browserslist and resolves it once', async () => {
+    mocks.loadConfig.mockReturnValue(['ie 11']);
+
+    await runRule(rule.meta.defaultConfig);
+
+    expect(rule.meta.defaultConfig.targets).toBeUndefined();
+    expect(mocks.loadConfig).toHaveBeenCalledTimes(1);
+    expect(mocks.loadConfig).toHaveBeenCalledWith({
+      path: root,
+      env: 'production',
+    });
+    expect(mocks.options).toHaveLength(1);
+    expect(mocks.options[0].targets).toEqual(['ie 11']);
+    expect(mocks.check).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses explicit targets without loading project Browserslist', async () => {
+    await runRule({ targets: ['chrome >= 80'] });
+
+    expect(mocks.loadConfig).not.toHaveBeenCalled();
+    expect(mocks.options[0].targets).toEqual(['chrome >= 80']);
+    expect(mocks.check).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses an explicit ECMAScript version without loading Browserslist', async () => {
+    await runRule({ ecmaVersion: 2019 });
+
+    expect(mocks.loadConfig).not.toHaveBeenCalled();
+    expect(mocks.options[0].ecmaVersion).toBe(2019);
+    expect(mocks.check).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves an explicit empty targets array as disabled', async () => {
+    await runRule({ targets: [] });
+
+    expect(mocks.loadConfig).not.toHaveBeenCalled();
+    expect(mocks.options).toHaveLength(0);
+    expect(mocks.check).not.toHaveBeenCalled();
+  });
+
+  it('skips the rule when neither targets nor ecmaVersion can be resolved', async () => {
+    mocks.loadConfig.mockReturnValue(undefined);
+
+    await runRule({});
+
+    expect(mocks.loadConfig).toHaveBeenCalledTimes(1);
+    expect(mocks.options).toHaveLength(0);
+    expect(mocks.check).not.toHaveBeenCalled();
+  });
+
+  it('does not resolve Browserslist when there are no JavaScript assets', async () => {
+    await runRule({}, [{ path: 'styles.css', content: '.root {}' }]);
+
+    expect(mocks.loadConfig).not.toHaveBeenCalled();
+    expect(mocks.options).toHaveLength(0);
+  });
+
+  it('applies output exclusions and forwards error-message exclusions', async () => {
+    const excludeErrorMessage = /optional chaining/;
+    await runRule({
+      ecmaVersion: 5,
+      excludeErrorMessage,
+      excludeOutput: (filepath) => filepath.endsWith('main.js'),
+    });
+
+    expect(mocks.options[0].excludeErrorMessage).toBe(excludeErrorMessage);
+    expect(mocks.check).toHaveBeenCalledTimes(1);
+    expect(mocks.check).toHaveBeenCalledWith(
+      path.join(outputPath, 'async.bundle'),
+      'const asyncChunk = 1;',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes E1004 silently skipping syntax checks when a project relies on its Browserslist configuration. It preserves explicit empty `targets` as the opt-out behavior, resolves Browserslist once per check, reuses one syntax checker across assets, and makes output and error-message exclusions effective.