### PR TITLE
perf(core): speed up report writes in watch mode

### DIFF
--- a/packages/core/src/rspack-plugin/plugin.ts
+++ b/packages/core/src/rspack-plugin/plugin.ts
@@ -36,6 +36,7 @@ import {
 import path from 'node:path';
 import { pluginTapName, pluginTapPostOptions, pkg } from './constants';
 import { acquireBuildSession, type RsdoctorBuildSessionLease } from './session';
+import { getWriteStoreOptions } from './writeStore';
 
 // Static flag to ensure greet message is only printed once per process
 let hasGreeted = false;
@@ -351,7 +352,7 @@ export class RsdoctorRspackPlugin<
         context.sdk.setOutputDir(this.getOutputDir(compiler));
       }
 
-      await context.sdk.writeStore();
+      await context.sdk.writeStore(getWriteStoreOptions(compiler));
 
       const isPrimaryCompiler =
         !(context.sdk instanceof RsdoctorPrimarySDK) || context.sdk.isMaster;
@@ -643,7 +644,7 @@ export class RsdoctorRspackPlugin<
     } else {
       context.sdk.setOutputDir(this.getOutputDir(compiler));
     }
-    await context.sdk.writeStore();
+    await context.sdk.writeStore(getWriteStoreOptions(compiler));
 
     if (this.shouldDisposeSDK()) {
       await this.disposeSDK(context, bootstrapTask);

--- a/packages/core/src/rspack-plugin/writeStore.ts
+++ b/packages/core/src/rspack-plugin/writeStore.ts
@@ -1,0 +1,13 @@
+import type { Plugin, SDK } from '@rsdoctor/shared/types';
+
+// Favor zlib's fastest mode while report shards are rewritten after each HMR.
+const watchCompressionLevel = 1;
+
+export function getWriteStoreOptions(
+  compiler: Pick<Plugin.BaseCompiler, 'watchMode' | 'parentCompilation'>,
+): SDK.WriteStoreOptionsType | undefined {
+  const isWatching =
+    compiler.watchMode || compiler.parentCompilation?.compiler.watchMode;
+
+  return isWatching ? { compressionLevel: watchCompressionLevel } : undefined;
+}

--- a/packages/core/src/rspack-plugin/writeStore.ts
+++ b/packages/core/src/rspack-plugin/writeStore.ts
@@ -1,13 +1,13 @@
 import type { Plugin, SDK } from '@rsdoctor/shared/types';
+import { isCompilerWatching } from '../inner-plugins/utils/config';
 
 // Favor zlib's fastest mode while report shards are rewritten after each HMR.
-const watchCompressionLevel = 1;
+const watchWriteStoreOptions: SDK.WriteStoreOptionsType = {
+  compressionLevel: 1,
+};
 
 export function getWriteStoreOptions(
   compiler: Pick<Plugin.BaseCompiler, 'watchMode' | 'parentCompilation'>,
 ): SDK.WriteStoreOptionsType | undefined {
-  const isWatching =
-    compiler.watchMode || compiler.parentCompilation?.compiler.watchMode;
-
-  return isWatching ? { compressionLevel: watchCompressionLevel } : undefined;
+  return isCompilerWatching(compiler) ? watchWriteStoreOptions : undefined;
 }

--- a/packages/core/src/sdk/multiple/primary.ts
+++ b/packages/core/src/sdk/multiple/primary.ts
@@ -1,4 +1,4 @@
-import { Constants, Manifest, SDK } from '@rsdoctor/shared/types';
+import { Common, Constants, Manifest, SDK } from '@rsdoctor/shared/types';
 import { RsdoctorSDK } from '../sdk';
 import { RsdoctorSlaveServer } from './server';
 import type { RsdoctorSDKController } from './controller';
@@ -87,9 +87,12 @@ export class RsdoctorPrimarySDK
     return this.parent.master === this;
   }
 
-  protected async writePieces(): Promise<void> {
+  protected async writePieces(
+    _storeData: Common.PlainObject,
+    options?: SDK.WriteStoreOptionsType,
+  ): Promise<void> {
     this.setOutputDir(this.parent.getCompilerOutputDir(this));
-    await super.writePieces(this.getStoreData());
+    await super.writePieces(this.getStoreData(), options);
   }
 
   protected async writeManifest() {

--- a/packages/core/src/sdk/sdk/core.ts
+++ b/packages/core/src/sdk/sdk/core.ts
@@ -122,7 +122,7 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
   /** Upload analysis data pieces */
   protected async writePieces(
     storeData: Common.PlainObject,
-    _options?: SDK.WriteStoreOptionsType,
+    options?: SDK.WriteStoreOptionsType,
   ) {
     const { outputDir } = this;
     const manifest = path.resolve(outputDir, Constants.RsdoctorOutputManifest);
@@ -164,12 +164,21 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
             outputDir,
             key,
             fileOffset,
+            options?.compressionLevel,
           );
           fileOffset += result.files.length;
           urlsPromiseList.push(result);
         }
       } else {
-        urlsPromiseList.push(this.writeToFolder(jsonStr, outputDir, key));
+        urlsPromiseList.push(
+          this.writeToFolder(
+            jsonStr,
+            outputDir,
+            key,
+            undefined,
+            options?.compressionLevel,
+          ),
+        );
       }
     }
 
@@ -228,8 +237,11 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
     dir: string,
     key: string,
     index?: number,
+    compressionLevel?: number,
   ): Promise<DataWithUrl> {
-    const sharding = new File.FileSharding(Algorithm.compressText(jsonStr));
+    const sharding = new File.FileSharding(
+      Algorithm.compressText(jsonStr, compressionLevel),
+    );
     const folder = path.resolve(dir, key);
     const writer = sharding.writeStringToFolder(folder, '', index);
     return writer.then((item) => {

--- a/packages/core/src/sdk/sdk/core.ts
+++ b/packages/core/src/sdk/sdk/core.ts
@@ -131,6 +131,7 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
     await File.fse.ensureDir(outputDir);
 
     const urlsPromiseList: (Promise<DataWithUrl> | DataWithUrl)[] = [];
+    const compressionLevel = options?.compressionLevel;
 
     for (const key of Object.keys(storeData)) {
       const data = storeData[key];
@@ -164,7 +165,7 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
             outputDir,
             key,
             fileOffset,
-            options?.compressionLevel,
+            compressionLevel,
           );
           fileOffset += result.files.length;
           urlsPromiseList.push(result);
@@ -176,7 +177,7 @@ export abstract class SDKCore<T extends RsdoctorSDKOptions>
             outputDir,
             key,
             undefined,
-            options?.compressionLevel,
+            compressionLevel,
           ),
         );
       }

--- a/packages/core/tests/rspack-plugin/plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/plugin.test.ts
@@ -2,9 +2,11 @@ import { getSDK } from '@/inner-plugins/utils/sdk';
 import { RsdoctorRspackPlugin } from '@/rspack-plugin';
 import { RsdoctorPrimarySDK, RsdoctorSDK } from '@/sdk';
 import { RsdoctorServer } from '@/sdk/server';
+import type { Plugin } from '@rsdoctor/shared/types';
 import { rspack } from '@rspack/core';
 import { afterEach, describe, expect, it, rs } from '@rstest/core';
 import path from 'node:path';
+import { getWriteStoreOptions } from '@/rspack-plugin/writeStore';
 
 afterEach(async () => {
   rs.restoreAllMocks();
@@ -14,6 +16,29 @@ afterEach(async () => {
 });
 
 describe('RsdoctorRspackPlugin', () => {
+  it('uses faster report compression only in watch mode', () => {
+    expect(
+      getWriteStoreOptions({
+        watchMode: true,
+        parentCompilation: undefined,
+      }),
+    ).toEqual({ compressionLevel: 1 });
+    expect(
+      getWriteStoreOptions({
+        watchMode: false,
+        parentCompilation: undefined,
+      }),
+    ).toBeUndefined();
+    expect(
+      getWriteStoreOptions({
+        watchMode: false,
+        parentCompilation: {
+          compiler: { watchMode: true },
+        } as Plugin.BaseCompilation,
+      }),
+    ).toEqual({ compressionLevel: 1 });
+  });
+
   it('registers SDKs by compiler name', async () => {
     const createPlugin = () =>
       new RsdoctorRspackPlugin({

--- a/packages/core/tests/rspack-plugin/plugin.test.ts
+++ b/packages/core/tests/rspack-plugin/plugin.test.ts
@@ -39,6 +39,26 @@ describe('RsdoctorRspackPlugin', () => {
     ).toEqual({ compressionLevel: 1 });
   });
 
+  it('uses faster report compression when writing watch reports', async () => {
+    const sdk = new RsdoctorSDK({
+      name: 'watch-write',
+      root: process.cwd(),
+      config: { noServer: true },
+    });
+    const plugin = new RsdoctorRspackPlugin({
+      disableClientServer: true,
+      features: [],
+      sdkInstance: sdk,
+    });
+    const compiler = rspack({ plugins: [plugin] });
+    compiler.watchMode = true;
+    const writeStore = rs.spyOn(sdk, 'writeStore').mockResolvedValue('');
+
+    await plugin.done(compiler);
+
+    expect(writeStore).toHaveBeenCalledWith({ compressionLevel: 1 });
+  });
+
   it('registers SDKs by compiler name', async () => {
     const createPlugin = () =>
       new RsdoctorRspackPlugin({

--- a/packages/core/tests/sdk/sdk/core/write-pieces-sharding.test.ts
+++ b/packages/core/tests/sdk/sdk/core/write-pieces-sharding.test.ts
@@ -122,4 +122,38 @@ describe('writePieces shard file integrity', () => {
     expect(parsed.length).toBe(1);
     expect(parsed[0].resource.path).toBe('/test/a.ts');
   });
+
+  it('honors the requested shard compression level', async () => {
+    target = await createSDK({ noServer: true });
+    const uncompressedDir = path.resolve(
+      tmpdir(),
+      `sharding_level_0_${Date.now()}`,
+    );
+    const compressedDir = path.resolve(
+      tmpdir(),
+      `sharding_level_9_${Date.now()}`,
+    );
+    const data = { moduleCodeMap: { source: 'a'.repeat(100_000) } };
+    const shardSize = (dir: string) =>
+      fs
+        .readdirSync(path.join(dir, 'moduleCodeMap'))
+        .reduce(
+          (total, file) =>
+            total + fs.statSync(path.join(dir, 'moduleCodeMap', file)).size,
+          0,
+        );
+
+    try {
+      target.sdk.setOutputDir(uncompressedDir);
+      await target.sdk.saveManifest(data, { compressionLevel: 0 });
+
+      target.sdk.setOutputDir(compressedDir);
+      await target.sdk.saveManifest(data, { compressionLevel: 9 });
+
+      expect(shardSize(compressedDir)).toBeLessThan(shardSize(uncompressedDir));
+    } finally {
+      await File.fse.remove(uncompressedDir);
+      await File.fse.remove(compressedDir);
+    }
+  });
 });

--- a/packages/shared/src/common/algorithm.ts
+++ b/packages/shared/src/common/algorithm.ts
@@ -25,6 +25,17 @@ export function mergeIntervals(intervals: [number, number][]) {
 }
 
 export function compressText(input: string, compressionLevel?: number): string {
+  if (
+    compressionLevel !== undefined &&
+    (!Number.isInteger(compressionLevel) ||
+      compressionLevel < 0 ||
+      compressionLevel > 9)
+  ) {
+    throw new RangeError(
+      '`compressionLevel` must be an integer between 0 and 9.',
+    );
+  }
+
   try {
     return deflateSync(
       input,

--- a/packages/shared/src/common/algorithm.ts
+++ b/packages/shared/src/common/algorithm.ts
@@ -39,9 +39,7 @@ export function compressText(input: string, compressionLevel?: number): string {
   try {
     return deflateSync(
       input,
-      typeof compressionLevel === 'number'
-        ? { level: compressionLevel }
-        : undefined,
+      compressionLevel === undefined ? undefined : { level: compressionLevel },
     ).toString('base64');
   } catch {
     return '';

--- a/packages/shared/src/common/algorithm.ts
+++ b/packages/shared/src/common/algorithm.ts
@@ -24,9 +24,14 @@ export function mergeIntervals(intervals: [number, number][]) {
   return result;
 }
 
-export function compressText(input: string): string {
+export function compressText(input: string, compressionLevel?: number): string {
   try {
-    return deflateSync(input).toString('base64');
+    return deflateSync(
+      input,
+      typeof compressionLevel === 'number'
+        ? { level: compressionLevel }
+        : undefined,
+    ).toString('base64');
   } catch {
     return '';
   }

--- a/packages/shared/src/types/sdk/instance.ts
+++ b/packages/shared/src/types/sdk/instance.ts
@@ -19,8 +19,15 @@ import { EmoCheckData } from '../emo';
 import { SummaryData } from './summary';
 import { ConfigData } from './config';
 
-// rslint-disable-next-line @typescript-eslint/no-empty-object-type
-export type WriteStoreOptionsType = {};
+export type WriteStoreOptionsType = {
+  /**
+   * The zlib compression level used for report shards.
+   * Accepts values from 0 to 9.
+   *
+   * @default 6
+   */
+  compressionLevel?: number;
+};
 
 export enum IMode {
   brief = 'brief',

--- a/packages/shared/tests/common/algorithm.test.ts
+++ b/packages/shared/tests/common/algorithm.test.ts
@@ -38,6 +38,12 @@ describe('test src/common/algorithm.ts', () => {
     );
   });
 
+  it('rejects invalid compression levels', () => {
+    [-1, 10, 1.5, Number.NaN, Number.POSITIVE_INFINITY].forEach((level) => {
+      expect(() => Algorithm.compressText('hello', level)).toThrow(RangeError);
+    });
+  });
+
   it('random', () => {
     [
       [0, 10],

--- a/packages/shared/tests/common/algorithm.test.ts
+++ b/packages/shared/tests/common/algorithm.test.ts
@@ -38,11 +38,12 @@ describe('test src/common/algorithm.ts', () => {
     );
   });
 
-  it('rejects invalid compression levels', () => {
-    [-1, 10, 1.5, Number.NaN, Number.POSITIVE_INFINITY].forEach((level) => {
+  it.each([-1, 10, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid compression level %s',
+    (level) => {
       expect(() => Algorithm.compressText('hello', level)).toThrow(RangeError);
-    });
-  });
+    },
+  );
 
   it('random', () => {
     [


### PR DESCRIPTION
## Summary

Rsdoctor recompresses large report shards after every HMR, making synchronous zlib work the dominant report-write cost on large applications. This PR uses zlib level 1 only while the compiler is watching, while production builds retain the default level 6 and child compilers inherit the parent watch mode.

On repeated Kiali HMR runs, writePieces dropped from 3.57–3.58s to 2.03–2.06s (about 43%, saving roughly 1.54s per update); the four dominant compressed shards were about 26% larger in watch mode.

## Related Links

- Stacked on #1908
