### PR TITLE
perf(client): lazy load report routes and charts

### DIFF
--- a/e2e/cases/doctor-rspack/brief.test.ts
+++ b/e2e/cases/doctor-rspack/brief.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import { compileByRspack } from '@scripts/test-helper';
 import path from 'path';
 import fs from 'fs';
+import { pathToFileURL } from 'node:url';
 import { createRsdoctorPlugin } from './test-utils';
 
 async function rspackCompile(compile: typeof compileByRspack) {
@@ -63,36 +64,48 @@ test('rspack brief mode', async ({ page }) => {
   await rspackCompile(compileByRspack);
 
   const reportPath = path.join(__dirname, './dist/brief/rsdoctor-report.html');
+  const chunkFailures: string[] = [];
+
+  page.on('pageerror', (error) => {
+    if (
+      /ChunkLoadError|Loading (?:CSS )?chunk|CSS_CHUNK_LOAD_FAILED/i.test(
+        error.message,
+      )
+    ) {
+      chunkFailures.push(error.message);
+    }
+  });
+  page.on('requestfailed', (request) => {
+    if (/\/resource\/(?:js|css)\/async\//.test(request.url())) {
+      chunkFailures.push(request.url());
+    }
+  });
 
   fileExists(reportPath);
 
   // Navigate to a URL
-  await page.goto(`file:///${reportPath}`);
+  await page.goto(pathToFileURL(reportPath).href);
 
   // Perform actions on the page
   const title = await page.title();
   expect(title).toBe('Rsdoctor');
 
-  const titleContent = 'Bundle Overall';
+  await expect(page.getByText('Bundle Overall').first()).toBeVisible();
+  await expect(page.getByText('Compile Analysis').first()).toBeVisible();
+  await expect(page.getByText('Bundle Size').first()).toBeVisible();
 
-  const bundleTitleExists = await page
-    .locator(`text=${titleContent}`)
-    .first()
-    .isVisible();
+  for (const [route, text] of [
+    ['/bundle/size', 'Tree Graph'],
+    ['/loaders/overall', 'Loader Timeline'],
+    ['/plugins', 'Plugins Overall'],
+  ]) {
+    await page.evaluate((nextRoute) => {
+      window.location.hash = nextRoute;
+    }, route);
+    await expect(page.getByText(text).first()).toBeVisible();
+  }
 
-  const compileTabExists = await page
-    .locator(`text='Compile Analysis'`)
-    .first()
-    .isVisible();
-
-  const bundleTabExists = await page
-    .locator(`text='Bundle Size'`)
-    .first()
-    .isVisible();
-
-  expect(bundleTitleExists).toBe(true);
-  expect(compileTabExists).toBe(true);
-  expect(bundleTabExists).toBe(true);
+  expect(chunkFailures).toEqual([]);
 });
 
 async function fileExists(filePath: string) {

--- a/packages/cli/src/commands/bundle-diff.ts
+++ b/packages/cli/src/commands/bundle-diff.ts
@@ -16,7 +16,11 @@ import {
   Constants,
 } from '@rsdoctor/shared/types';
 import { Algorithm, Graph, Manifest } from '@rsdoctor/shared/common-browser';
-import { resolveClientDiffHtmlPath, RsdoctorSDK } from '@rsdoctor/core';
+import {
+  inlineClientAssets,
+  resolveClientDiffHtmlPath,
+  RsdoctorSDK,
+} from '@rsdoctor/core';
 
 interface Options {
   current: string;
@@ -228,65 +232,7 @@ example: ${bin} ${Commands.BundleDiff} --baseline="x.json" --current="x.json"
       spinner.text = 'Generating standalone HTML file...';
 
       const clientHtmlPath = resolveClientDiffHtmlPath();
-      let htmlContent = fs.readFileSync(clientHtmlPath, 'utf-8');
-      const basePath = path.dirname(clientHtmlPath);
-
-      // Extract and inline scripts and styles
-      const scriptSrcs = Array.from(
-        htmlContent.matchAll(
-          /<script[^>]+src=["']([^"']+)["'][^>]*><\/script>/g,
-        ),
-        (m) => m[1],
-      );
-      const cssHrefs = Array.from(
-        htmlContent.matchAll(/<link\s+href=["'](.+?)["']\s+rel="stylesheet">/g),
-        (m) => m[1],
-      );
-
-      htmlContent = htmlContent.replace(
-        /<script\s+.*?src=["'].*?["']><\/script>/g,
-        '',
-      );
-      htmlContent = htmlContent.replace(
-        /<link\s+.*?rel=["']stylesheet["'].*?>/g,
-        '',
-      );
-
-      // Inline scripts
-      const inlinedScripts = scriptSrcs
-        .map((src) => {
-          const scriptPath = path.resolve(basePath, src);
-          try {
-            const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
-            return `<script>${scriptContent}</script>`;
-          } catch (error) {
-            console.error(`Could not read script at ${scriptPath}:`, error);
-            return '';
-          }
-        })
-        .join('');
-
-      // Inline styles
-      const inlinedStyles = cssHrefs
-        .map((href) => {
-          const cssPath = path.resolve(basePath, href);
-          try {
-            const cssContent = fs.readFileSync(cssPath, 'utf-8');
-            return `<style>${cssContent}</style>`;
-          } catch (error) {
-            console.error(`Could not read CSS at ${cssPath}:`, error);
-            return '';
-          }
-        })
-        .join('');
-
-      // Add inlined resources
-      const index = htmlContent.indexOf('</body>');
-      htmlContent =
-        htmlContent.slice(0, index) +
-        inlinedStyles +
-        inlinedScripts +
-        htmlContent.slice(index);
+      let htmlContent = inlineClientAssets(clientHtmlPath, 'diff');
 
       // Add compressed data
       const baselineCompressText = Algorithm.compressText(

--- a/packages/client/rsbuild.config.ts
+++ b/packages/client/rsbuild.config.ts
@@ -88,6 +88,10 @@ export default defineConfig(({ env }) => {
         ? OFFICIAL_PREVIEW_PUBLIC_PATH?.replace(/\/resource$/, '') || './'
         : './',
       cleanDistPath: IS_PRODUCTION,
+      manifest: {
+        filename: 'rsdoctor-client-manifest.json',
+        prefix: false,
+      },
       sourceMap: IS_PRODUCTION
         ? false
         : {
@@ -104,9 +108,9 @@ export default defineConfig(({ env }) => {
         splitChunks: {
           cacheGroups: {
             monaco: {
-              test: /node_modules\/monaco-editor\/*/,
+              test: /[\\/]node_modules[\\/](?:monaco-editor|@monaco-editor[\\/]react)[\\/]/,
               name: 'monaco',
-              chunks: (chunk) => chunk.name === 'index',
+              chunks: 'all',
               maxSize: 1000000,
               minSize: 500000,
             },

--- a/packages/client/src/DiffRouter.tsx
+++ b/packages/client/src/DiffRouter.tsx
@@ -1,12 +1,21 @@
-import React from 'react';
+import { Skeleton } from 'antd';
+import React, { lazy, Suspense } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { BundleDiff } from './pages';
+import { route as bundleDiffRoute } from './pages/Resources/BundleDiff/constants';
+
+const BundleDiffPage = lazy(() =>
+  import('./pages/Resources/BundleDiff').then(({ Page }) => ({
+    default: Page,
+  })),
+);
 
 export function DiffRouter(): React.ReactElement {
   return (
-    <Routes>
-      <Route path="/" element={<BundleDiff.Page />} />
-      <Route path={BundleDiff.route} element={<BundleDiff.Page />} />
-    </Routes>
+    <Suspense fallback={<Skeleton active />}>
+      <Routes>
+        <Route path="/" element={<BundleDiffPage />} />
+        <Route path={bundleDiffRoute} element={<BundleDiffPage />} />
+      </Routes>
+    </Suspense>
   );
 }

--- a/packages/client/src/components/Charts/common.tsx
+++ b/packages/client/src/components/Charts/common.tsx
@@ -1,14 +1,19 @@
 import { SDK } from '@rsdoctor/shared/types';
-import { Alert, Typography } from 'antd';
-import React, { useEffect, useRef, useState } from 'react';
+import { Alert, Skeleton, Typography } from 'antd';
+import React, { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { useTheme } from '../../utils';
-import { TimelineCom } from './TimelineCharts';
 
 import './loader.scss';
 import './tooltips.scss';
 import { DurationMetric, ITraceEventData, Metric } from './types';
 import { formatterForPlugins, processTrans } from './utils';
 import { ChartTypes } from './constants';
+
+const TimelineCom = lazy(() =>
+  import('./TimelineCharts').then(({ TimelineCom }) => ({
+    default: TimelineCom,
+  })),
+);
 
 export interface CommonChartProps {
   summary: SDK.SummaryData;
@@ -54,11 +59,13 @@ export const CommonExecutionsChart: React.FC<{
       ref={ref}
       style={{ width: '100%' }}
     >
-      <TimelineCom
-        pluginsData={data}
-        formatterFn={formatterForPlugins}
-        chartType={type}
-      />
+      <Suspense fallback={<Skeleton active />}>
+        <TimelineCom
+          pluginsData={data}
+          formatterFn={formatterForPlugins}
+          chartType={type}
+        />
+      </Suspense>
     </div>
   );
 };

--- a/packages/client/src/components/Charts/loader.tsx
+++ b/packages/client/src/components/Charts/loader.tsx
@@ -1,4 +1,6 @@
 import React, {
+  lazy,
+  Suspense,
   useCallback,
   useMemo,
   useRef,
@@ -6,12 +8,11 @@ import React, {
   useState,
 } from 'react';
 import { groupBy } from '@rsdoctor/shared/collection';
-import { Empty } from 'antd';
+import { Empty, Skeleton } from 'antd';
 import './loader.scss';
 import { useTheme } from 'src/utils/manifest';
 import { findLoaderTotalTiming } from 'src/utils/loader';
 import { beautifyPath } from 'src/utils/file';
-import { TimelineCom } from './TimelineCharts';
 import { ChartProps, DurationMetric } from './types';
 import {
   renderTotalLoadersTooltip,
@@ -19,6 +20,13 @@ import {
   useDebounceHook,
 } from './utils';
 import { ChartTypes } from './constants';
+
+const TimelineCom = lazy(() =>
+  import('./TimelineCharts').then(({ TimelineCom }) => ({
+    default: TimelineCom,
+  })),
+);
+
 let startTimestamp = 0;
 let endTimestamp = 0;
 
@@ -95,12 +103,14 @@ export const LoaderExecutionsChart: React.FC<ChartProps> = ({
           ref={ref}
           style={{ width: '100%' }}
         >
-          <TimelineCom
-            loaderData={durationMetricData}
-            formatterFn={formatterForLoader}
-            chartType={ChartTypes.Loader}
-            exts={{ startTimestamp, endTimestamp }}
-          />
+          <Suspense fallback={<Skeleton active />}>
+            <TimelineCom
+              loaderData={durationMetricData}
+              formatterFn={formatterForLoader}
+              chartType={ChartTypes.Loader}
+              exts={{ startTimestamp, endTimestamp }}
+            />
+          </Suspense>
         </div>
       ) : (
         <Empty />

--- a/packages/client/src/components/Layout/menus.tsx
+++ b/packages/client/src/components/Layout/menus.tsx
@@ -10,7 +10,12 @@ import { Menu, MenuProps } from 'antd';
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Size } from '../../constants';
+import * as BundleSize from '../../pages/BundleSize/constants';
+import * as LoaderFiles from '../../pages/Loaders/Analysis/constants';
+import * as LoaderTimeline from '../../pages/Loaders/Overall/constants';
+import * as ModuleResolve from '../../pages/ModuleResolve/constants';
 import * as OverallConstants from '../../pages/Overall/constants';
+import * as PluginsAnalyze from '../../pages/Plugins/constants';
 import {
   useI18n,
   hasBundle,
@@ -25,13 +30,6 @@ import CompileAnalysisActive from 'src/common/svg/navbar/compile-analysis-active
 import CompileAnalysisInActive from 'src/common/svg/navbar/compile-analysis-inactive.svg';
 import BundleSizeActive from 'src/common/svg/navbar/bundle-size-active.svg';
 import BundleSizeInActive from 'src/common/svg/navbar/bundle-size-inactive.svg';
-import {
-  BundleSize,
-  LoaderFiles,
-  PluginsAnalyze,
-  ModuleResolve,
-  LoaderTimeline,
-} from 'src/pages';
 import { CompileName } from './constants';
 import styles from './header.module.scss';
 

--- a/packages/client/src/components/index.ts
+++ b/packages/client/src/components/index.ts
@@ -2,7 +2,6 @@ export * from './Alerts';
 export * from './Badge';
 export * from './base';
 export * from './Card';
-export { TimelineCom } from './Charts/TimelineCharts';
 export * from './Form/keyword';
 export * from './Layout';
 export * from './Manifest';

--- a/packages/client/src/router.tsx
+++ b/packages/client/src/router.tsx
@@ -1,59 +1,96 @@
-import React from 'react';
+import { Skeleton } from 'antd';
+import React, { lazy, Suspense } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import {
-  Overall,
-  BundleSize,
-  LoaderFiles,
-  PluginsAnalyze,
-  ModuleResolve,
-  LoaderTimeline,
-  RuleIndex,
-  TreeShaking,
-  BundleDiff,
-  Uploader,
-} from './pages';
+
+import { route as bundleSizeRoute } from './pages/BundleSize/constants';
+import { route as loaderFilesRoute } from './pages/Loaders/Analysis/constants';
+import { route as loaderTimelineRoute } from './pages/Loaders/Overall/constants';
+import { route as moduleResolveRoute } from './pages/ModuleResolve/constants';
+import { route as overallRoute } from './pages/Overall/constants';
+import { route as pluginsAnalyzeRoute } from './pages/Plugins/constants';
+import { route as bundleDiffRoute } from './pages/Resources/BundleDiff/constants';
+import { route as ruleIndexRoute } from './pages/Resources/RuleIndex/constants';
+import { route as treeShakingRoute } from './pages/TreeShaking/constants';
+import { route as uploaderRoute } from './pages/Uploader/constants';
+
+const OverallPage = lazy(() =>
+  import('./pages/Overall').then(({ Page }) => ({ default: Page })),
+);
+const BundleSizePage = lazy(() =>
+  import('./pages/BundleSize').then(({ Page }) => ({ default: Page })),
+);
+const LoaderFilesPage = lazy(() =>
+  import('./pages/Loaders/Analysis').then(({ Page }) => ({ default: Page })),
+);
+const PluginsAnalyzePage = lazy(() =>
+  import('./pages/Plugins').then(({ Page }) => ({ default: Page })),
+);
+const ModuleResolvePage = lazy(() =>
+  import('./pages/ModuleResolve').then(({ Page }) => ({ default: Page })),
+);
+const LoaderTimelinePage = lazy(() =>
+  import('./pages/Loaders/Overall').then(({ Page }) => ({ default: Page })),
+);
+const RuleIndexPage = lazy(() =>
+  import('./pages/Resources/RuleIndex').then(({ Page }) => ({ default: Page })),
+);
+const TreeShakingPage = lazy(() =>
+  import('./pages/TreeShaking').then(({ TreeShakingPage }) => ({
+    default: TreeShakingPage,
+  })),
+);
+const BundleDiffPage = lazy(() =>
+  import('./pages/Resources/BundleDiff').then(({ Page }) => ({
+    default: Page,
+  })),
+);
+const UploaderPage = lazy(() =>
+  import('./pages/Uploader').then(({ Page }) => ({ default: Page })),
+);
 
 export default function Router(): React.ReactElement {
   const routes = [
     {
-      path: BundleSize.route,
-      element: <BundleSize.Page />,
+      path: bundleSizeRoute,
+      element: <BundleSizePage />,
     },
     {
-      path: LoaderFiles.route,
-      element: <LoaderFiles.Page />,
+      path: loaderFilesRoute,
+      element: <LoaderFilesPage />,
     },
     {
-      path: PluginsAnalyze.route,
-      element: <PluginsAnalyze.Page />,
+      path: pluginsAnalyzeRoute,
+      element: <PluginsAnalyzePage />,
     },
     {
-      path: ModuleResolve.route,
-      element: <ModuleResolve.Page />,
+      path: moduleResolveRoute,
+      element: <ModuleResolvePage />,
     },
     {
-      path: LoaderTimeline.route,
-      element: <LoaderTimeline.Page />,
+      path: loaderTimelineRoute,
+      element: <LoaderTimelinePage />,
     },
     {
-      path: RuleIndex.route,
-      element: <RuleIndex.Page />,
+      path: ruleIndexRoute,
+      element: <RuleIndexPage />,
     },
     {
-      path: TreeShaking.route,
-      element: <TreeShaking.TreeShakingPage />,
+      path: treeShakingRoute,
+      element: <TreeShakingPage />,
     },
-  ].filter((e) => Boolean(e)) as { path: string; element: React.JSX.Element }[];
+  ];
 
   return (
-    <Routes>
-      <Route path="/" element={<Overall.Page />} />
-      <Route path={Overall.route} element={<Overall.Page />} />
-      {routes.map((e) => (
-        <Route key={e.path} path={e.path} element={e.element} />
-      ))}
-      <Route path={BundleDiff.route} element={<BundleDiff.Page />} />
-      <Route path={Uploader.route} element={<Uploader.Page />} />
-    </Routes>
+    <Suspense fallback={<Skeleton active />}>
+      <Routes>
+        <Route path="/" element={<OverallPage />} />
+        <Route path={overallRoute} element={<OverallPage />} />
+        {routes.map((e) => (
+          <Route key={e.path} path={e.path} element={e.element} />
+        ))}
+        <Route path={bundleDiffRoute} element={<BundleDiffPage />} />
+        <Route path={uploaderRoute} element={<UploaderPage />} />
+      </Routes>
+    </Suspense>
   );
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export {
   rules,
 } from './rules';
 export { RsdoctorSDK, resolveClientDiffHtmlPath } from './sdk';
+export { inlineClientAssets } from './sdk/utils';
 export type {
   RsdoctorMultiplePluginOptions,
   RsdoctorRspackPluginOptions,

--- a/packages/core/src/sdk/sdk/index.ts
+++ b/packages/core/src/sdk/sdk/index.ts
@@ -15,6 +15,7 @@ import { Algorithm } from '@rsdoctor/shared/common-browser';
 import { Lodash } from '@rsdoctor/shared/common-browser';
 import { findRoot } from '../utils';
 import { decycle } from '@rsdoctor/shared/common-browser';
+import { inlineClientAssets } from '../utils/inlineClientAssets';
 
 export * from '../utils/openBrowser';
 export * from '../utils/base';
@@ -598,86 +599,7 @@ export class RsdoctorSDK<
   }
 
   public inlineScriptsAndStyles(htmlFilePath: string) {
-    // Helper function to inline JavaScript files
-    function inlineScripts(basePath: string, scripts: string[]): string {
-      return scripts
-        .map((src) => {
-          const scriptPath = resolveFilePath(basePath, src);
-          try {
-            const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
-            return `<script>${scriptContent}</script>`;
-          } catch (error) {
-            console.error(`Could not read script at ${scriptPath}:`, error);
-            return '';
-          }
-        })
-        .join('');
-    }
-
-    function resolveFilePath(basePath: string, filePath: string): string {
-      if (filePath.startsWith('/')) {
-        return path.resolve(basePath, filePath.slice(1));
-      }
-
-      return path.resolve(basePath, filePath);
-    }
-
-    // Helper function to inline CSS files
-    function inlineCss(basePath: string, cssFiles: string[]): string {
-      return cssFiles
-        .map((href) => {
-          const cssPath = resolveFilePath(basePath, href);
-          try {
-            const cssContent = fs.readFileSync(cssPath, 'utf-8');
-            return `<style>${cssContent}</style>`;
-          } catch (error) {
-            console.error(`Could not read CSS at ${cssPath}:`, error);
-            return '';
-          }
-        })
-        .join('');
-    }
-
-    // Path to your HTML file
-    let htmlContent = fs.readFileSync(htmlFilePath, 'utf-8');
-
-    // Base path to the resources
-    const basePath = path.dirname(htmlFilePath);
-
-    // Extract scripts and links from the HTML
-    const scriptSrcs = Array.from(
-      htmlContent.matchAll(
-        /<script\s+(?:defer="defer"|defer)\s+src=["'](.+?)["']><\/script>/g,
-      ),
-      (m) => m[1],
-    );
-    const cssHrefs = Array.from(
-      htmlContent.matchAll(/<link\s+href=["'](.+?)["']\s+rel="stylesheet">/g),
-      (m) => m[1],
-    );
-
-    // Remove all <script> tags
-    htmlContent = htmlContent.replace(
-      /<script\s+.*?src=["'].*?["']><\/script>/g,
-      '',
-    );
-
-    // Remove all <link rel="stylesheet"> tags
-    htmlContent = htmlContent.replace(
-      /<link\s+.*?rel=["']stylesheet["'].*?>/g,
-      '',
-    );
-
-    // Inline scripts and CSS
-    const inlinedScripts = inlineScripts(basePath, scriptSrcs);
-    const inlinedCss = inlineCss(basePath, cssHrefs);
-
-    const index = htmlContent.indexOf('</body>');
-    htmlContent =
-      htmlContent.slice(0, index) +
-      inlinedCss +
-      inlinedScripts +
-      htmlContent.slice(index);
+    let htmlContent = inlineClientAssets(htmlFilePath, 'index');
     htmlContent = this.addRsdoctorDataToHTML(this.getStoreData(), htmlContent);
 
     // Output the processed HTML content

--- a/packages/core/src/sdk/utils/index.ts
+++ b/packages/core/src/sdk/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './constant';
 export * from './base';
 export * from './upload';
+export * from './inlineClientAssets';

--- a/packages/core/src/sdk/utils/inlineClientAssets.ts
+++ b/packages/core/src/sdk/utils/inlineClientAssets.ts
@@ -1,0 +1,148 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CLIENT_MANIFEST_NAME = 'rsdoctor-client-manifest.json';
+
+interface ClientManifestEntry {
+  async?: {
+    css?: string[];
+    js?: string[];
+  };
+}
+
+interface ClientManifest {
+  entries?: Record<string, ClientManifestEntry>;
+}
+
+interface HtmlAsset {
+  path: string;
+  tag: string;
+}
+
+const getAttribute = (tag: string, name: string): string | undefined => {
+  const match = tag.match(new RegExp(`\\s${name}=["']([^"']+)["']`, 'i'));
+  return match?.[1];
+};
+
+const normalizeAssetPath = (assetPath: string): string =>
+  assetPath.replace(/[?#].*$/, '').replace(/^\.?\//, '');
+
+const resolveAssetPath = (basePath: string, assetPath: string): string => {
+  const resolvedPath = path.resolve(basePath, normalizeAssetPath(assetPath));
+  const relativePath = path.relative(basePath, resolvedPath);
+
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error(
+      `Client asset is outside its distribution directory: ${assetPath}`,
+    );
+  }
+
+  return resolvedPath;
+};
+
+const readAsset = (basePath: string, assetPath: string): string =>
+  fs.readFileSync(resolveAssetPath(basePath, assetPath), 'utf8');
+
+const escapeClosingTag = (content: string, tagName: string): string =>
+  content.replace(new RegExp(`</${tagName}`, 'gi'), `<\\/${tagName}`);
+
+const renderScript = (basePath: string, assetPath: string): string =>
+  `<script>${escapeClosingTag(readAsset(basePath, assetPath), 'script')}</script>`;
+
+const renderStyle = (
+  basePath: string,
+  assetPath: string,
+  dataHref = false,
+): string => {
+  const attribute = dataHref ? ` data-href="${assetPath}"` : '';
+  return `<style${attribute}>${escapeClosingTag(readAsset(basePath, assetPath), 'style')}</style>`;
+};
+
+const readAsyncAssets = (
+  basePath: string,
+  entryName: string,
+): Required<NonNullable<ClientManifestEntry['async']>> => {
+  const manifestPath = path.join(basePath, CLIENT_MANIFEST_NAME);
+  if (!fs.existsSync(manifestPath)) {
+    return { css: [], js: [] };
+  }
+
+  const manifest = JSON.parse(
+    fs.readFileSync(manifestPath, 'utf8'),
+  ) as ClientManifest;
+  const entry = manifest.entries?.[entryName];
+  if (!entry) {
+    throw new Error(
+      `Client manifest does not contain the "${entryName}" entry.`,
+    );
+  }
+
+  return {
+    css: entry.async?.css ?? [],
+    js: entry.async?.js ?? [],
+  };
+};
+
+export const inlineClientAssets = (
+  htmlFilePath: string,
+  entryName = path.basename(htmlFilePath, path.extname(htmlFilePath)),
+): string => {
+  const basePath = path.dirname(htmlFilePath);
+  const scripts: HtmlAsset[] = [];
+  const styles: HtmlAsset[] = [];
+  let htmlContent = fs.readFileSync(htmlFilePath, 'utf8');
+
+  htmlContent = htmlContent.replace(
+    /<script\b[^>]*\bsrc=["'][^"']+["'][^>]*><\/script>/gi,
+    (tag) => {
+      const src = getAttribute(tag, 'src');
+      if (src) scripts.push({ path: src, tag });
+      return src ? '' : tag;
+    },
+  );
+  htmlContent = htmlContent.replace(/<link\b[^>]*>/gi, (tag) => {
+    const href = getAttribute(tag, 'href');
+    const rel = getAttribute(tag, 'rel');
+    if (href && rel?.toLowerCase() === 'stylesheet') {
+      styles.push({ path: href, tag });
+      return '';
+    }
+    return tag;
+  });
+
+  const asyncAssets = readAsyncAssets(basePath, entryName);
+  const initialScriptPaths = new Set(
+    scripts.map(({ path: assetPath }) => normalizeAssetPath(assetPath)),
+  );
+  const initialStylePaths = new Set(
+    styles.map(({ path: assetPath }) => normalizeAssetPath(assetPath)),
+  );
+  const uniqueAsyncScripts = Array.from(new Set(asyncAssets.js)).filter(
+    (assetPath) => !initialScriptPaths.has(normalizeAssetPath(assetPath)),
+  );
+  const uniqueAsyncStyles = Array.from(new Set(asyncAssets.css)).filter(
+    (assetPath) => !initialStylePaths.has(normalizeAssetPath(assetPath)),
+  );
+
+  const inlinedStyles = [
+    ...styles.map(({ path: assetPath }) => renderStyle(basePath, assetPath)),
+    ...uniqueAsyncStyles.map((assetPath) =>
+      renderStyle(basePath, assetPath, true),
+    ),
+  ].join('');
+  // Rspack async chunks register themselves through the chunk loading global.
+  // Place them before the runtime so standalone reports can resolve lazy routes.
+  const inlinedScripts = [
+    ...uniqueAsyncScripts.map((assetPath) => renderScript(basePath, assetPath)),
+    ...scripts.map(({ path: assetPath }) => renderScript(basePath, assetPath)),
+  ].join('');
+  const bodyEnd = htmlContent.lastIndexOf('</body>');
+
+  if (bodyEnd === -1) {
+    throw new Error(
+      `Client HTML does not contain a closing body tag: ${htmlFilePath}`,
+    );
+  }
+
+  return `${htmlContent.slice(0, bodyEnd)}${inlinedStyles}${inlinedScripts}${htmlContent.slice(bodyEnd)}`;
+};

--- a/packages/core/tests/sdk/sdk/core/atomic-write.test.ts
+++ b/packages/core/tests/sdk/sdk/core/atomic-write.test.ts
@@ -42,6 +42,7 @@ describe('core package output', () => {
         'RsdoctorRspackPlugin',
         'RsdoctorSDK',
         'defineRule',
+        'inlineClientAssets',
         'logger',
         'resolveClientDiffHtmlPath',
         'rules',

--- a/packages/core/tests/sdk/utils/inlineClientAssets.test.ts
+++ b/packages/core/tests/sdk/utils/inlineClientAssets.test.ts
@@ -1,0 +1,135 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from '@rstest/core';
+import { inlineClientAssets } from '@/sdk/utils';
+
+describe('inlineClientAssets', () => {
+  const directories: string[] = [];
+
+  const createFixture = () => {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'rsdoctor-client-'),
+    );
+    directories.push(directory);
+    fs.mkdirSync(path.join(directory, 'resource/js'), { recursive: true });
+    fs.mkdirSync(path.join(directory, 'resource/css'), { recursive: true });
+    return directory;
+  };
+
+  afterEach(() => {
+    for (const directory of directories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines initial assets when a manifest is not available', () => {
+    const directory = createFixture();
+    const htmlPath = path.join(directory, 'index.html');
+    fs.writeFileSync(
+      htmlPath,
+      '<html><head><link href="./resource/css/index.css" rel="stylesheet"></head><body><script defer src="./resource/js/index.js"></script></body></html>',
+    );
+    fs.writeFileSync(path.join(directory, 'resource/css/index.css'), '.app{}');
+    fs.writeFileSync(path.join(directory, 'resource/js/index.js'), 'start();');
+
+    const result = inlineClientAssets(htmlPath);
+
+    expect(result).toContain('<style>.app{}</style>');
+    expect(result).toContain('<script>start();</script>');
+    expect(result).not.toContain('src=');
+    expect(result).not.toContain('rel="stylesheet"');
+  });
+
+  it('pre-registers only the selected entry async assets', () => {
+    const directory = createFixture();
+    const htmlPath = path.join(directory, 'index.html');
+    fs.writeFileSync(
+      htmlPath,
+      '<html><body><script defer="defer" src="./resource/js/runtime.js"></script></body></html>',
+    );
+    fs.writeFileSync(
+      path.join(directory, 'rsdoctor-client-manifest.json'),
+      JSON.stringify({
+        entries: {
+          index: {
+            async: {
+              js: [
+                'resource/js/route.js',
+                'resource/js/route.js',
+                'resource/js/runtime.js',
+              ],
+              css: ['resource/css/route.css'],
+            },
+          },
+          diff: { async: { js: ['resource/js/diff-route.js'] } },
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(directory, 'resource/js/runtime.js'),
+      'runtime();',
+    );
+    fs.writeFileSync(path.join(directory, 'resource/js/route.js'), 'route();');
+    fs.writeFileSync(
+      path.join(directory, 'resource/js/diff-route.js'),
+      'diffRoute();',
+    );
+    fs.writeFileSync(
+      path.join(directory, 'resource/css/route.css'),
+      '.route{}',
+    );
+
+    const result = inlineClientAssets(htmlPath);
+
+    expect(result).toContain(
+      '<style data-href="resource/css/route.css">.route{}</style>',
+    );
+    expect(result.indexOf('route();')).toBeLessThan(
+      result.indexOf('runtime();'),
+    );
+    expect(result.match(/route\(\);/g)).toHaveLength(1);
+    expect(result).not.toContain('diffRoute();');
+  });
+
+  it('supports an explicit entry for renamed HTML files', () => {
+    const directory = createFixture();
+    const htmlPath = path.join(directory, 'custom-report.html');
+    fs.writeFileSync(htmlPath, '<html><body></body></html>');
+    fs.writeFileSync(
+      path.join(directory, 'rsdoctor-client-manifest.json'),
+      JSON.stringify({
+        entries: {
+          index: { async: { js: ['resource/js/route.js'] } },
+        },
+      }),
+    );
+    fs.writeFileSync(path.join(directory, 'resource/js/route.js'), 'route();');
+
+    expect(inlineClientAssets(htmlPath, 'index')).toContain(
+      '<script>route();</script>',
+    );
+  });
+
+  it('escapes closing tags in inlined assets', () => {
+    const directory = createFixture();
+    const htmlPath = path.join(directory, 'index.html');
+    fs.writeFileSync(
+      htmlPath,
+      '<html><head><link rel="stylesheet" href="resource/css/index.css"></head><body><script src="resource/js/index.js"></script></body></html>',
+    );
+    fs.writeFileSync(
+      path.join(directory, 'resource/js/index.js'),
+      'const value = "</script>";',
+    );
+    fs.writeFileSync(
+      path.join(directory, 'resource/css/index.css'),
+      '.x::after{content:"</style>"}',
+    );
+
+    const result = inlineClientAssets(htmlPath);
+
+    expect(result).toContain('<\\/script>');
+    expect(result).toContain('<\\/style>');
+  });
+});


### PR DESCRIPTION
## Summary

This PR reduces the initial Rsdoctor client bundle by lazy-loading report routes and timeline charts. It adds a client asset manifest and a shared `inlineClientAssets` core export so brief and bundle-diff standalone reports pre-register async JavaScript and CSS and continue to work offline over `file://`.

## Related Links

None