### PR TITLE
chore: improve repository build and test configuration

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -37,7 +37,7 @@ jobs:
               - "!**/*.mdx"
               - "!**/_meta.json"
               - "!**/dictionary.txt"
-              - "!document/**"
+              - "!packages/document/**"
 
   ecosystem_ci_dispatch:
     name: Dispatch ecosystem CI

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,9 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      - 'document/**'
-      - '*.md'
-      - '*.mdx'
+      - 'packages/document/**'
+      - '**/*.md'
+      - '**/*.mdx'
 
   merge_group:
 

--- a/.github/workflows/test-ubuntu-node22.yml
+++ b/.github/workflows/test-ubuntu-node22.yml
@@ -9,9 +9,9 @@ on:
   push:
     branches: [main, release_*, release-*]
     paths-ignore:
-      - 'document/**'
-      - '*.md'
-      - '*.mdx'
+      - 'packages/document/**'
+      - '**/*.md'
+      - '**/*.mdx'
 
   merge_group:
 

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -9,9 +9,9 @@ on:
   push:
     branches: [main, release_*, release-*]
     paths-ignore:
-      - 'document/**'
-      - '*.md'
-      - '*.mdx'
+      - 'packages/document/**'
+      - '**/*.md'
+      - '**/*.mdx'
 
   merge_group:
 

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -9,9 +9,9 @@ on:
   push:
     branches: [main, release_*, release-*]
     paths-ignore:
-      - "document/**"
-      - "*.md"
-      - "*.mdx"
+      - 'packages/document/**'
+      - '**/*.md'
+      - '**/*.mdx'
 
   merge_group:
 

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -7,6 +7,7 @@
     "declarationMap": false,
     "composite": true,
     "outDir": "dist",
+    "tsBuildInfoFile": ".cache/tsconfig.tsbuildinfo",
     "skipLibCheck": true,
     "paths": {
       "src": ["./src"],

--- a/packages/core/rstest.config.ts
+++ b/packages/core/rstest.config.ts
@@ -1,0 +1,9 @@
+import path from 'node:path';
+import { defineConfig } from '@rstest/core';
+import rootConfig from '../../rstest.config';
+
+export default defineConfig({
+  extends: rootConfig,
+  root: path.resolve(__dirname, '../..'),
+  include: ['packages/core/**/*.test.ts'],
+});

--- a/scripts/skipCI.js
+++ b/scripts/skipCI.js
@@ -1,12 +1,28 @@
 const { execSync } = require('child_process');
 
-const SKIP_FOLDERS = [
+const SKIP_PATHS = [
   'cspell.json',
   '.github',
   '.vscode',
-  'document',
+  'packages/document',
   'scripts/skipCI.js',
 ];
+const SKIP_EXTENSIONS = ['.md', '.mdx'];
+
+function shouldSkipFile(file) {
+  return (
+    SKIP_PATHS.some(
+      (skipPath) => file.startsWith(`${skipPath}/`) || file === skipPath,
+    ) || SKIP_EXTENSIONS.some((extension) => file.endsWith(extension))
+  );
+}
+
+function shouldSkipCI(changedFiles) {
+  return (
+    changedFiles.length > 0 &&
+    changedFiles.every((file) => shouldSkipFile(file))
+  );
+}
 
 async function main() {
   execSync('git fetch origin main');
@@ -19,22 +35,14 @@ async function main() {
     .map((file) => file?.trim())
     .filter(Boolean);
 
-  const shouldNotSkipCI =
-    !changedFiles.length ||
-    changedFiles.some(
-      (file) =>
-        !SKIP_FOLDERS.some(
-          (folder) =>
-            file.startsWith(`${folder}/`) ||
-            file === folder ||
-            file.endsWith('.md'),
-        ),
-    );
-
-  console.log(shouldNotSkipCI ? 'false' : 'true');
+  console.log(shouldSkipCI(changedFiles) ? 'true' : 'false');
 }
 
-main().catch((err) => {
-  console.error('Failed to detect CI skip', err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('Failed to detect CI skip', err);
+    process.exit(1);
+  });
+}
+
+module.exports = { shouldSkipCI, shouldSkipFile };

--- a/scripts/skipCI.test.js
+++ b/scripts/skipCI.test.js
@@ -1,0 +1,30 @@
+const assert = require('node:assert/strict');
+const { describe, it } = require('node:test');
+const { shouldSkipCI, shouldSkipFile } = require('./skipCI');
+
+describe('skipCI', () => {
+  it('recognizes documentation files and paths', () => {
+    assert.equal(shouldSkipFile('README.md'), true);
+    assert.equal(shouldSkipFile('packages/core/README.mdx'), true);
+    assert.equal(shouldSkipFile('packages/document/docs/en/index.tsx'), true);
+    assert.equal(shouldSkipFile('packages/documentation/index.tsx'), false);
+  });
+
+  it('skips CI only when every changed file is skippable', () => {
+    assert.equal(
+      shouldSkipCI([
+        'packages/document/docs/en/index.mdx',
+        'packages/core/README.md',
+      ]),
+      true,
+    );
+    assert.equal(
+      shouldSkipCI([
+        'packages/document/docs/en/index.mdx',
+        'packages/core/src/index.ts',
+      ]),
+      false,
+    );
+    assert.equal(shouldSkipCI([]), false);
+  });
+});


### PR DESCRIPTION
## Summary

Repository automation still uses the obsolete `document/**` path, package-local Core tests miss the root legacy-decorator settings, and the Client emits TypeScript build metadata into `dist`. This PR fixes the documentation path filters and MDX handling, adds a package-local Rstest config, and keeps `tsconfig.tsbuildinfo` in the Client cache directory.

## Related Links

None