### PR TITLE
fix(core): update deprecated option warnings

### DIFF
--- a/e2e/cases/doctor-rspack/brief.test.ts
+++ b/e2e/cases/doctor-rspack/brief.test.ts
@@ -51,7 +51,9 @@ async function rspackCompile(compile: typeof compileByRspack) {
     plugins: [
       // @ts-ignore
       createRsdoctorPlugin({
-        mode: 'brief',
+        output: {
+          mode: 'brief',
+        },
       }),
     ],
   });

--- a/e2e/cases/doctor-rspack/linter-rule-render.test.ts
+++ b/e2e/cases/doctor-rspack/linter-rule-render.test.ts
@@ -40,7 +40,9 @@ async function rspackCompile(compile: typeof compileByRspack) {
     plugins: [
       // @ts-ignore
       createRsdoctorPlugin({
-        mode: 'brief',
+        output: {
+          mode: 'brief',
+        },
         linter: {
           rules: {
             'ecma-version-check': [

--- a/examples/rspack-minimal/rspack.config.mjs
+++ b/examples/rspack-minimal/rspack.config.mjs
@@ -92,7 +92,9 @@ const rspackConfig = {
     new RsdoctorRspackPlugin({
       disableClientServer: process.env.ENABLE_CLIENT_SERVER === 'false',
       features: ['bundle', 'plugins', 'loader'],
-      mode: 'brief',
+      output: {
+        mode: 'brief',
+      },
       linter: {
         rules: {
           'ecma-version-check': [

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -173,7 +173,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
   if (mode) {
     logger.info(
       chalk.yellow(
-        `The 'mode' configuration will be deprecated in a future version. Please use 'output.mode' instead.`,
+        `The 'mode' configuration is deprecated in Rsdoctor 2.x. Please use 'output.mode' instead.`,
       ),
     );
   }
@@ -182,7 +182,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
   if (_features.lite || finalMode === SDK.IMode[SDK.IMode.lite]) {
     logger.info(
       chalk.yellow(
-        `Lite features will be deprecated in a future version. Please use 'output: { reportCodeType: { noAssetsAndModuleSource: true }}' instead.`,
+        `Lite features are deprecated in Rsdoctor 2.x. Please use 'output: { reportCodeType: { noAssetsAndModuleSource: true }}' instead.`,
       ),
     );
   }
@@ -231,7 +231,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
   if (output.compressData !== undefined) {
     logger.info(
       chalk.yellow(
-        `The 'compressData' configuration will be deprecated in a future version.`,
+        `The 'compressData' configuration is deprecated in Rsdoctor 2.x.`,
       ),
     );
   }

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -97,6 +97,7 @@ function isValidMode(mode: any): mode is keyof typeof SDK.IMode {
 export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
   config: Plugin.RsdoctorRspackPluginOptions<Rules> = {},
 ): Plugin.RsdoctorPluginOptionsNormalized<Rules> {
+  const deprecatedMode = (config as { mode?: unknown }).mode;
   const userOutput = config.output;
   const defaultOutput = getDefaultOutput();
   const outputConfig: Config.IOutput<'brief' | 'normal'> = isJsonOutputEnv(
@@ -127,7 +128,6 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
     port,
     server: userServer = {},
     printLog = { serverUrls: true },
-    mode = undefined,
     brief = undefined,
     multiCompiler = true,
   } = normalizedConfig;
@@ -166,11 +166,8 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
       ? output.mode === ('lite' as SDK.IMode.normal)
         ? SDK.IMode[SDK.IMode.normal]
         : output.mode
-      : undefined) ||
-    mode ||
-    SDK.IMode[SDK.IMode.normal];
-
-  if (mode) {
+      : undefined) || SDK.IMode[SDK.IMode.normal];
+  if (deprecatedMode) {
     logger.info(
       chalk.yellow(
         `The 'mode' configuration is deprecated in Rsdoctor 2.x. Please use 'output.mode' instead.`,
@@ -179,7 +176,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
   }
   const _features = normalizeFeatures(features, finalMode);
   const _linter = normalizeLinter(linter);
-  if (_features.lite || finalMode === SDK.IMode[SDK.IMode.lite]) {
+  if (_features.lite) {
     logger.info(
       chalk.yellow(
         `Lite features are deprecated in Rsdoctor 2.x. Please use 'output: { reportCodeType: { noAssetsAndModuleSource: true }}' instead.`,

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -170,7 +170,7 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
   if (deprecatedMode) {
     logger.info(
       chalk.yellow(
-        `The 'mode' configuration is deprecated in Rsdoctor 2.x. Please use 'output.mode' instead.`,
+        `The top-level 'mode' configuration was removed in Rsdoctor 2.x and is ignored. Please use 'output.mode' instead.`,
       ),
     );
   }

--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -167,10 +167,12 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
         ? SDK.IMode[SDK.IMode.normal]
         : output.mode
       : undefined) || SDK.IMode[SDK.IMode.normal];
-  if (deprecatedMode) {
+  if (deprecatedMode !== undefined) {
+    const replacement =
+      deprecatedMode === 'lite' ? 'output.reportCodeType' : 'output.mode';
     logger.info(
       chalk.yellow(
-        `The top-level 'mode' configuration was removed in Rsdoctor 2.x and is ignored. Please use 'output.mode' instead.`,
+        `The top-level 'mode' configuration was removed in Rsdoctor 2.x and is ignored. Please use '${replacement}' instead.`,
       ),
     );
   }

--- a/packages/core/tests/build/utils/config.test.ts
+++ b/packages/core/tests/build/utils/config.test.ts
@@ -213,7 +213,7 @@ describe('normalizeUserConfig', () => {
       expect(
         consoleOutput.some((output) =>
           output.includes(
-            "The 'mode' configuration is deprecated in Rsdoctor 2.x. Please use 'output.mode' instead.",
+            "The top-level 'mode' configuration was removed in Rsdoctor 2.x and is ignored. Please use 'output.mode' instead.",
           ),
         ),
       ).toBe(true);
@@ -225,7 +225,7 @@ describe('normalizeUserConfig', () => {
       expect(
         consoleOutput.some((output) =>
           output.includes(
-            "The 'mode' configuration is deprecated in Rsdoctor 2.x. Please use 'output.mode' instead.",
+            "The top-level 'mode' configuration was removed in Rsdoctor 2.x and is ignored. Please use 'output.mode' instead.",
           ),
         ),
       ).toBe(false);

--- a/packages/core/tests/build/utils/config.test.ts
+++ b/packages/core/tests/build/utils/config.test.ts
@@ -107,16 +107,15 @@ describe('normalizeUserConfig', () => {
 
   it('should normalize output.reportCodeType according to mode', () => {
     const result = normalizeUserConfig({
-      output: { reportCodeType: { noCode: true } },
-      mode: 'brief',
+      output: { mode: 'brief', reportCodeType: { noCode: true } },
     });
     expect(result.output.reportCodeType).toBe(SDK.ToDataType.NoCode);
   });
 
-  it('should normalize output.reportCodeType and mode:lite', () => {
+  it('should normalize output.reportCodeType with lite features', () => {
     const result = normalizeUserConfig({
+      features: { lite: true },
       output: { reportCodeType: { noCode: true } },
-      mode: 'lite',
     });
     expect(result.output.reportCodeType).toBe(SDK.ToDataType.NoCode);
   });
@@ -207,11 +206,9 @@ describe('normalizeUserConfig', () => {
     },
   );
 
-  describe('mode configuration warnings', () => {
-    it('should show warning when using deprecated mode configuration', () => {
-      normalizeUserConfig({
-        mode: 'lite',
-      });
+  describe('deprecated configuration warnings', () => {
+    it('should show a warning for the removed top-level mode', () => {
+      normalizeUserConfig({ mode: 'brief' } as never);
 
       expect(
         consoleOutput.some((output) =>
@@ -220,6 +217,18 @@ describe('normalizeUserConfig', () => {
           ),
         ),
       ).toBe(true);
+    });
+
+    it('should not show the top-level mode warning for output.mode', () => {
+      normalizeUserConfig({ output: { mode: 'brief' } });
+
+      expect(
+        consoleOutput.some((output) =>
+          output.includes(
+            "The 'mode' configuration is deprecated in Rsdoctor 2.x. Please use 'output.mode' instead.",
+          ),
+        ),
+      ).toBe(false);
     });
 
     it('should show warning when using deprecated compressData configuration', () => {
@@ -254,22 +263,6 @@ describe('normalizeUserConfig', () => {
       ).toBe(false);
     });
 
-    it('should not show warning when using output.mode instead of mode', () => {
-      normalizeUserConfig({
-        output: {
-          mode: 'brief',
-        },
-      });
-
-      expect(
-        consoleOutput.some((output) =>
-          output.includes(
-            "The 'mode' configuration is deprecated in Rsdoctor 2.x. Please use 'output.mode' instead.",
-          ),
-        ),
-      ).toBe(false);
-    });
-
     it('should handle invalid mode values gracefully', () => {
       const result = normalizeUserConfig({
         output: {
@@ -296,32 +289,9 @@ describe('normalizeUserConfig', () => {
         ),
       ).toBe(true);
     });
-
-    it('should show both warnings when both mode and lite features are used', () => {
-      normalizeUserConfig({
-        mode: 'lite',
-        features: {
-          lite: true,
-        },
-      });
-
-      const modeWarning = consoleOutput.some((output) =>
-        output.includes(
-          "The 'mode' configuration is deprecated in Rsdoctor 2.x. Please use 'output.mode' instead.",
-        ),
-      );
-      const liteWarning = consoleOutput.some((output) =>
-        output.includes(
-          "Lite features are deprecated in Rsdoctor 2.x. Please use 'output: { reportCodeType: { noAssetsAndModuleSource: true }}' instead.",
-        ),
-      );
-
-      expect(modeWarning).toBe(true);
-      expect(liteWarning).toBe(true);
-    });
   });
 
-  describe('mode priority', () => {
+  describe('output mode', () => {
     it('should use brief json output when RSDOCTOR_OUTPUT is json', () => {
       process.env.RSDOCTOR_OUTPUT = 'json';
 
@@ -344,37 +314,13 @@ describe('normalizeUserConfig', () => {
       });
     });
 
-    it('should prioritize output.mode over mode', () => {
-      const result = normalizeUserConfig({
-        mode: 'normal',
-        output: {
-          mode: 'brief',
-        },
-      });
+    it('should ignore the removed top-level mode', () => {
+      const result = normalizeUserConfig({ mode: 'brief' } as never);
 
-      expect(result.output.mode).toBe('brief');
+      expect(result.output.mode).toBe('normal');
     });
 
-    it('should use mode when output.mode is not provided', () => {
-      const result = normalizeUserConfig({
-        mode: 'brief',
-      });
-
-      expect(result.output.mode).toBe('brief');
-    });
-
-    it('should handle output.mode with invalid value and fall back to mode', () => {
-      const result = normalizeUserConfig({
-        mode: 'brief',
-        output: {
-          mode: 'invalid' as any,
-        },
-      });
-
-      expect(result.output.mode).toBe('brief');
-    });
-
-    it('should use normal as default when neither mode nor output.mode is provided', () => {
+    it('should use normal as default when output.mode is not provided', () => {
       const result = normalizeUserConfig({});
 
       expect(result.output.mode).toBe('normal');
@@ -474,8 +420,8 @@ describe('normalizeUserConfig', () => {
   describe('output.reportCodeType', () => {
     it('should return NoCode when mode is brief regardless of reportCodeType', () => {
       const result = normalizeUserConfig({
-        mode: 'brief',
         output: {
+          mode: 'brief',
           reportCodeType: {
             noModuleSource: true,
             noAssetsAndModuleSource: false,
@@ -488,23 +434,7 @@ describe('normalizeUserConfig', () => {
 
     it('should return NoSourceAndAssets when mode is lite and no special flags', () => {
       const result = normalizeUserConfig({
-        mode: 'lite',
-        output: {
-          reportCodeType: {
-            noModuleSource: false,
-            noAssetsAndModuleSource: false,
-            noCode: false,
-          },
-        },
-      });
-      expect(result.output.reportCodeType).toBe(
-        SDK.ToDataType.NoSourceAndAssets,
-      );
-    });
-
-    it('should return NoSource when mode is lite and no special flags', () => {
-      const result = normalizeUserConfig({
-        mode: 'lite',
+        features: { lite: true },
         output: {
           reportCodeType: {
             noModuleSource: false,
@@ -520,7 +450,7 @@ describe('normalizeUserConfig', () => {
 
     it('should return NoSourceAndAssets when mode is lite and noAssetsAndModuleSource is true', () => {
       const result = normalizeUserConfig({
-        mode: 'lite',
+        features: { lite: true },
         output: {
           reportCodeType: {
             noModuleSource: false,
@@ -536,8 +466,8 @@ describe('normalizeUserConfig', () => {
 
     it('should respect noCode flag in normal mode', () => {
       const result = normalizeUserConfig({
-        mode: 'normal',
         output: {
+          mode: 'normal',
           reportCodeType: {
             noModuleSource: false,
             noAssetsAndModuleSource: false,
@@ -550,8 +480,8 @@ describe('normalizeUserConfig', () => {
 
     it('should respect noAssetsAndModuleSource flag in normal mode', () => {
       const result = normalizeUserConfig({
-        mode: 'normal',
         output: {
+          mode: 'normal',
           reportCodeType: {
             noModuleSource: false,
             noAssetsAndModuleSource: true,
@@ -566,8 +496,8 @@ describe('normalizeUserConfig', () => {
 
     it('should respect noModuleSource flag in normal mode', () => {
       const result = normalizeUserConfig({
-        mode: 'normal',
         output: {
+          mode: 'normal',
           reportCodeType: {
             noModuleSource: true,
             noAssetsAndModuleSource: false,
@@ -580,8 +510,8 @@ describe('normalizeUserConfig', () => {
 
     it('should return Normal when no flags are set in normal mode', () => {
       const result = normalizeUserConfig({
-        mode: 'normal',
         output: {
+          mode: 'normal',
           reportCodeType: {
             noModuleSource: false,
             noAssetsAndModuleSource: false,
@@ -594,8 +524,8 @@ describe('normalizeUserConfig', () => {
 
     it('should handle NewReportCodeType string values - noCode', () => {
       const result = normalizeUserConfig({
-        mode: 'normal',
         output: {
+          mode: 'normal',
           reportCodeType: 'noCode',
         },
       });
@@ -604,8 +534,8 @@ describe('normalizeUserConfig', () => {
 
     it('should handle NewReportCodeType string values - noAssetsAndModuleSource', () => {
       const result = normalizeUserConfig({
-        mode: 'normal',
         output: {
+          mode: 'normal',
           reportCodeType: 'noAssetsAndModuleSource',
         },
       });
@@ -616,8 +546,8 @@ describe('normalizeUserConfig', () => {
 
     it('should handle NewReportCodeType string values - noModuleSource', () => {
       const result = normalizeUserConfig({
-        mode: 'normal',
         output: {
+          mode: 'normal',
           reportCodeType: 'noModuleSource',
         },
       });
@@ -626,8 +556,8 @@ describe('normalizeUserConfig', () => {
 
     it('should handle undefined reportCodeType and use default', () => {
       const result = normalizeUserConfig({
-        mode: 'normal',
         output: {
+          mode: 'normal',
           reportCodeType: undefined,
         },
       });
@@ -636,8 +566,8 @@ describe('normalizeUserConfig', () => {
 
     it('should handle empty object reportCodeType and use default', () => {
       const result = normalizeUserConfig({
-        mode: 'normal',
         output: {
+          mode: 'normal',
           reportCodeType: {},
         },
       });
@@ -646,8 +576,8 @@ describe('normalizeUserConfig', () => {
 
     it('should prioritize noCode over other flags in normal mode', () => {
       const result = normalizeUserConfig({
-        mode: 'normal',
         output: {
+          mode: 'normal',
           reportCodeType: {
             noCode: true,
             noModuleSource: true,
@@ -660,8 +590,8 @@ describe('normalizeUserConfig', () => {
 
     it('should prioritize noAssetsAndModuleSource over noModuleSource in normal mode', () => {
       const result = normalizeUserConfig({
-        mode: 'normal',
         output: {
+          mode: 'normal',
           reportCodeType: {
             noCode: false,
             noModuleSource: true,

--- a/packages/core/tests/build/utils/config.test.ts
+++ b/packages/core/tests/build/utils/config.test.ts
@@ -207,16 +207,50 @@ describe('normalizeUserConfig', () => {
   );
 
   describe('deprecated configuration warnings', () => {
+    const removedModeWarning = (replacement: string) =>
+      `The top-level 'mode' configuration was removed in Rsdoctor 2.x and is ignored. Please use '${replacement}' instead.`;
+
     it('should show a warning for the removed top-level mode', () => {
       normalizeUserConfig({ mode: 'brief' } as never);
 
       expect(
         consoleOutput.some((output) =>
-          output.includes(
-            "The top-level 'mode' configuration was removed in Rsdoctor 2.x and is ignored. Please use 'output.mode' instead.",
-          ),
+          output.includes(removedModeWarning('output.mode')),
         ),
       ).toBe(true);
+    });
+
+    it("should recommend output.reportCodeType for mode: 'lite'", () => {
+      normalizeUserConfig({ mode: 'lite' } as never);
+
+      expect(
+        consoleOutput.some((output) =>
+          output.includes(removedModeWarning('output.reportCodeType')),
+        ),
+      ).toBe(true);
+    });
+
+    it.each(['', null, false, 0])(
+      'should show the top-level mode warning for %p',
+      (mode) => {
+        normalizeUserConfig({ mode } as never);
+
+        expect(
+          consoleOutput.some((output) =>
+            output.includes(removedModeWarning('output.mode')),
+          ),
+        ).toBe(true);
+      },
+    );
+
+    it('should not show the top-level mode warning for undefined', () => {
+      normalizeUserConfig({ mode: undefined } as never);
+
+      expect(
+        consoleOutput.some((output) =>
+          output.includes("The top-level 'mode' configuration was removed"),
+        ),
+      ).toBe(false);
     });
 
     it('should not show the top-level mode warning for output.mode', () => {
@@ -224,9 +258,7 @@ describe('normalizeUserConfig', () => {
 
       expect(
         consoleOutput.some((output) =>
-          output.includes(
-            "The top-level 'mode' configuration was removed in Rsdoctor 2.x and is ignored. Please use 'output.mode' instead.",
-          ),
+          output.includes(removedModeWarning('output.mode')),
         ),
       ).toBe(false);
     });

--- a/packages/core/tests/build/utils/config.test.ts
+++ b/packages/core/tests/build/utils/config.test.ts
@@ -216,7 +216,7 @@ describe('normalizeUserConfig', () => {
       expect(
         consoleOutput.some((output) =>
           output.includes(
-            "The 'mode' configuration will be deprecated in a future version. Please use 'output.mode' instead.",
+            "The 'mode' configuration is deprecated in Rsdoctor 2.x. Please use 'output.mode' instead.",
           ),
         ),
       ).toBe(true);
@@ -232,7 +232,7 @@ describe('normalizeUserConfig', () => {
       expect(
         consoleOutput.some((output) =>
           output.includes(
-            "The 'compressData' configuration will be deprecated in a future version.",
+            "The 'compressData' configuration is deprecated in Rsdoctor 2.x.",
           ),
         ),
       ).toBe(true);
@@ -248,7 +248,7 @@ describe('normalizeUserConfig', () => {
       expect(
         consoleOutput.some((output) =>
           output.includes(
-            "The 'compressData' configuration will be deprecated in a future version.",
+            "The 'compressData' configuration is deprecated in Rsdoctor 2.x.",
           ),
         ),
       ).toBe(false);
@@ -264,7 +264,7 @@ describe('normalizeUserConfig', () => {
       expect(
         consoleOutput.some((output) =>
           output.includes(
-            "The 'mode' configuration will be deprecated in a future version. Please use 'output.mode' instead.",
+            "The 'mode' configuration is deprecated in Rsdoctor 2.x. Please use 'output.mode' instead.",
           ),
         ),
       ).toBe(false);
@@ -291,7 +291,7 @@ describe('normalizeUserConfig', () => {
       expect(
         consoleOutput.some((output) =>
           output.includes(
-            "Lite features will be deprecated in a future version. Please use 'output: { reportCodeType: { noAssetsAndModuleSource: true }}' instead.",
+            "Lite features are deprecated in Rsdoctor 2.x. Please use 'output: { reportCodeType: { noAssetsAndModuleSource: true }}' instead.",
           ),
         ),
       ).toBe(true);
@@ -307,12 +307,12 @@ describe('normalizeUserConfig', () => {
 
       const modeWarning = consoleOutput.some((output) =>
         output.includes(
-          "The 'mode' configuration will be deprecated in a future version. Please use 'output.mode' instead.",
+          "The 'mode' configuration is deprecated in Rsdoctor 2.x. Please use 'output.mode' instead.",
         ),
       );
       const liteWarning = consoleOutput.some((output) =>
         output.includes(
-          "Lite features will be deprecated in a future version. Please use 'output: { reportCodeType: { noAssetsAndModuleSource: true }}' instead.",
+          "Lite features are deprecated in Rsdoctor 2.x. Please use 'output: { reportCodeType: { noAssetsAndModuleSource: true }}' instead.",
         ),
       );
 

--- a/packages/document/docs/en/config/options/mode.mdx
+++ b/packages/document/docs/en/config/options/mode.mdx
@@ -1,19 +1,19 @@
-import { Badge } from '@theme';
-
 # mode
 
 :::warning
 
-- Deprecated in V2, please use [output.mode](/config/options/output#mode) instead. Refer to [mode configuration migration](/config/options/options-v2#mode).
+The top-level `mode` option was removed in Rsdoctor 2.x. Use [output.mode](/config/options/output#mode) instead. See the [mode configuration migration guide](/config/options/options-v2#mode).
 
 :::
 
+The removed option accepted the following values:
+
 - **Type:** `"normal" | "brief" | "lite"`
-  - lite mode will be deprecated in V2, refer to [lite mode deprecation notice](/config/options/options-v2#lite)
+  - For migrating lite mode, see the [lite mode migration guide](/config/options/options-v2#lite).
 - **Optional:** `true`
 - **Default:** `normal`
 
-Select the Rsdoctor build report mode to use, which includes the following options:
+These values selected the following report behaviors:
 
 import ModeIntro from '@en/shared/mode-intro.md';
 

--- a/packages/document/docs/en/config/options/options-v2.mdx
+++ b/packages/document/docs/en/config/options/options-v2.mdx
@@ -1,39 +1,38 @@
-# Configuration Migration Guide
+# Configuration migration guide
 
-**Rsdoctor introduced new configuration options in version 1.2.4**. These new configuration options are easier to configure, more extensible, and compatible with the upcoming v2.0 release.
+**Rsdoctor introduced replacement configuration options in version 1.2.4.** These options are easier to configure, more extensible, and compatible with Rsdoctor 2.x.
 
-Configuration options from version 1.2.3 and earlier will still be supported, **but will be completely deprecated in Rsdoctor v2**, so we recommend migrating to the new configuration options in `1.2.4`.
+The replaced options from version 1.2.3 and earlier were removed in Rsdoctor 2.x. Migrate to the replacement options introduced in version 1.2.4.
 
-| Original Configuration              | New Configuration                                                                                                              |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| mode                                | Changed to configure `output.mode`.                                                                                            |
-| brief                               | Changed to configure `mode: 'brief'`, and configure `output.options` `type` as `html`.                                         |
-| output.compressData                 | Changed to configure `mode: 'brief'`, and configure `output.options.type` as `json`.                                           |
-| `mode: 'lite'` or `feature: 'lite'` | Changed to configure `mode: 'normal'`, and configure `output.options.reportCodeType` as `noCode` or `noAssetsAndModuleSource`. |
-| None                                | New `output.options.jsonOptions.section` configuration                                                                         |
+| Original configuration            | Replacement configuration                                                                             |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| mode                              | Configure `output.mode`.                                                                              |
+| brief                             | Set `output.mode` to `'brief'` and `output.options.type` to `['html']`.                               |
+| output.compressData               | Set `output.mode` to `'brief'` and `output.options.type` to `['json']`.                               |
+| `mode: 'lite'` or `features.lite` | Set `output.mode` to `'normal'` and `output.reportCodeType` to `noCode` or `noAssetsAndModuleSource`. |
+| None                              | Configure the new `output.options.jsonOptions.section` option.                                        |
 
-## Configuration Changes Details
+## Configuration changes
 
 ### mode
 
-The `mode` in the original configuration is migrated to the nested `output.mode` for better integration with other output-related configurations.
+The original top-level `mode` option moved to `output.mode` to keep output-related settings together.
 
 ### brief
 
-The current brief report mode outputs an HTML file as the report page. The new brief mode still supports JSON format, and for unified management of the same configuration, the brief configuration is moved to output.options.
-The original `brief` configuration is changed to configure `output.mode: 'brief'`, and configure `output.options` `type` as `html`.
+The original `brief` option moved to `output.options.htmlOptions`. Set `output.mode` to `'brief'` and `output.options.type` to `['html']` to generate an HTML report.
 
 ### output.compressData
 
-The original `output.compressData` configuration is changed to configure `mode: 'brief'`, and configure `output.options.type` as `json`.
+Replace `output.compressData` with `output.mode: 'brief'` and `output.options.type: ['json']`.
 
 ### lite
 
-The internal logic of lite mode is equivalent to `output.options.reportCodeType` being `noCode` or `noAssetsAndModuleSource`, mainly to solve the problem of large projects being too slow when opening reports or OOM during build.
+Lite mode is equivalent to setting `output.reportCodeType` to `noCode` or `noAssetsAndModuleSource`. It reduces the data retained during builds and can help large projects avoid slow report loading or out-of-memory errors.
 
-Considering that users cannot clearly distinguish the actual meaning of lite mode, having too many modes is not conducive to management and configuration, and the `output.options.reportCodeType` configuration is clearer, so `mode: 'lite'` will be deprecated in the future V2 version.
+The top-level `mode: 'lite'` option was removed in Rsdoctor 2.x, and `features.lite` is deprecated. Use `output.reportCodeType` to state which code data the report should retain.
 
-The original `mode: 'lite'` and `feature: 'lite'` configurations are changed to configure `mode: 'normal'`, and configure `output.options.reportCodeType` as `noCode` or `noAssetsAndModuleSource`.
+Replace the original `mode: 'lite'` or `features.lite` configuration with `output.mode: 'normal'` and set `output.reportCodeType` to `noCode` or `noAssetsAndModuleSource`.
 
 ### output.options.jsonOptions.section
 

--- a/packages/document/docs/en/config/options/options-v2.mdx
+++ b/packages/document/docs/en/config/options/options-v2.mdx
@@ -2,7 +2,7 @@
 
 **Rsdoctor introduced replacement configuration options in version 1.2.4.** These options are easier to configure, more extensible, and compatible with Rsdoctor 2.x.
 
-The replaced options from version 1.2.3 and earlier were removed in Rsdoctor 2.x. Migrate to the replacement options introduced in version 1.2.4.
+The top-level `mode` option was removed in Rsdoctor 2.x. Other replaced options, including `brief`, `features.lite`, and `output.compressData`, remain available for backward compatibility but are deprecated. Migrate these configurations to the replacements introduced in version 1.2.4.
 
 | Original configuration            | Replacement configuration                                                                             |
 | --------------------------------- | ----------------------------------------------------------------------------------------------------- |
@@ -16,15 +16,15 @@ The replaced options from version 1.2.3 and earlier were removed in Rsdoctor 2.x
 
 ### mode
 
-The original top-level `mode` option moved to `output.mode` to keep output-related settings together.
+The top-level `mode` option was removed in Rsdoctor 2.x. Use `output.mode` to keep output-related settings together.
 
 ### brief
 
-The original `brief` option moved to `output.options.htmlOptions`. Set `output.mode` to `'brief'` and `output.options.type` to `['html']` to generate an HTML report.
+The `brief` option remains available for backward compatibility but is deprecated. Set `output.mode` to `'brief'` and `output.options.type` to `['html']` to generate an HTML report.
 
 ### output.compressData
 
-Replace `output.compressData` with `output.mode: 'brief'` and `output.options.type: ['json']`.
+The `output.compressData` option remains available for backward compatibility but is deprecated. Replace it with `output.mode: 'brief'` and `output.options.type: ['json']`.
 
 ### lite
 

--- a/packages/document/docs/en/config/options/options.mdx
+++ b/packages/document/docs/en/config/options/options.mdx
@@ -43,7 +43,6 @@ This `Options` object is the configuration for [RsdoctorRspackPlugin](#rsdoctorr
 - [server](./server.mdx) - **Report Server Configuration**: Configure the Rsdoctor report server, including `server.port` and `server.cors`.
 - [supports](./supports.mdx) - **Feature Support Configuration**: Enable compatibility support for specific build tools, such as BannerPlugin, etc.
 - [brief](./brief.mdx) - **Brief Mode Configuration**: Control the generation of brief mode reports, including HTML filename and whether to generate JSON data files.
-- [mode](./mode.mdx) - **Build Report Data Output Mode**: Select the output mode for reports, supporting normal (normal mode) and brief (brief mode).
 - [multiCompiler](./multiCompiler.mdx) - **Multi-compiler Configuration**: Automatically detect and isolate reports for Rspack MultiCompiler and Rsbuild environments.
 
 ### RsdoctorRspackPluginOptions
@@ -60,14 +59,6 @@ interface RsdoctorRspackPluginOptions<
   /** Rsdoctor feature toggles */
   features?:
     RsdoctorRspackPluginFeatures | Array<keyof RsdoctorRspackPluginFeatures>;
-
-  /**
-   * @deprecated Use `output.mode` instead. If using `lite` mode, please use `output.reportCodeType: 'noCode' or 'noAssetsAndModuleSource'` instead
-   * Rsdoctor mode options:
-   * - normal: Normal mode
-   * - brief: Brief mode, only displays duration analysis and build artifact analysis results, does not display any code parts
-   */
-  mode?: 'brief' | 'normal' | 'lite';
 
   disableClientServer?: boolean;
 

--- a/packages/document/docs/en/guide/start/cicd.mdx
+++ b/packages/document/docs/en/guide/start/cicd.mdx
@@ -12,7 +12,7 @@ In Brief mode, data reports are integrated into a single HTML page, making it ea
 
 <Badge text="Version: 0.4.0" type="warning" />
 
-You can enable Brief mode by configuring the [mode.brief](/config/options/mode) option in the Rsdoctor plugin. After the build, Brief mode will generate a report in the build output directory: `[outputDir]/.rsdoctor/report-rsdoctor.html`. You can view the build analysis summary by opening the HTML file in a browser.
+You can enable Brief mode by setting [output.mode](/config/options/output#mode) to `'brief'` in the Rsdoctor plugin. After the build, Brief mode generates a report at `[outputDir]/.rsdoctor/report-rsdoctor.html`. Open the HTML file in a browser to view the build analysis summary.
 
 - In Brief mode, no code data is displayed to prevent the page from crashing due to large data sizes.
 - The report output directory and file name can be configured. Refer to: [Options](/config/options/brief).
@@ -27,7 +27,9 @@ module.exports = {
     process.env.RSDOCTOR &&
       new RsdoctorRspackPlugin({
         // other options
-        mode: 'brief',
+        output: {
+          mode: 'brief',
+        },
       }),
   ].filter(Boolean),
 };

--- a/packages/document/docs/en/shared/mode-intro.md
+++ b/packages/document/docs/en/shared/mode-intro.md
@@ -1,6 +1,6 @@
 - **normal mode:** Generates a `.rsdoctor` folder in the build output directory, which contains various data files and displays code in the report page. The output directory can be configured via [reportDir](/config/options/output#reportdir).
 
-- **brief mode:** Generates an HTML report file in the `.rsdoctor` folder within the build output directory. All build analysis data will be consolidated and injected into this HTML file, which can be viewed by opening it in a browser. Brief mode also has additional configuration options, detailed at: [brief](/config/options/brief).
+- **brief mode:** Generates an HTML report file in the `.rsdoctor` folder within the build output directory. All build analysis data is consolidated and injected into this HTML file, which can be opened directly in a browser. See the [brief output configuration](/config/options/output#mode-brief) for details.
 
 - **lite mode:** Based on the normal mode, this mode does not display source code and product code, only showing the information of the bundled code.
-  - lite mode will be deprecated in V2, refer to [lite mode deprecation notice](/config/options/options-v2#lite).
+  - The top-level `mode: 'lite'` option was removed in Rsdoctor 2.x, and `features.lite` is deprecated. Use [output.reportCodeType](/config/options/output#reportcodetype) instead.

--- a/packages/document/docs/zh/config/options/mode.mdx
+++ b/packages/document/docs/zh/config/options/mode.mdx
@@ -1,19 +1,19 @@
-import { Badge } from '@theme';
-
 # mode
 
 :::warning
 
-- V2 中即将废弃，请使用 [output.mode](/config/options/output#mode) 代替。参考 [mode 配置迁移](/config/options/options-v2#mode)。
+顶层 `mode` 配置已在 Rsdoctor 2.x 中移除，请使用 [output.mode](/config/options/output#mode) 代替。参考 [mode 配置迁移说明](/config/options/options-v2#mode)。
 
 :::
 
+已移除的配置曾支持以下值：
+
 - **类型：** `"normal" | "brief" | "lite"`
-  - lite 模式即将在 V2 废弃，参考[lite 模式废弃说明](/config/options/options-v2#lite)
+  - lite 模式的迁移方式请参考 [lite 模式迁移说明](/config/options/options-v2#lite)。
 - **可选：** `true`
 - **默认值：** `normal`
 
-选择使用的 Rsdoctor 构建报告模式，有以下几种：
+这些值对应以下报告行为：
 
 import ModeIntro from '@zh/shared/mode-intro.md';
 

--- a/packages/document/docs/zh/config/options/options-v2.mdx
+++ b/packages/document/docs/zh/config/options/options-v2.mdx
@@ -1,39 +1,38 @@
 # 配置迁移说明
 
-**Rsdoctor 在 1.2.4 版本中引入了新的配置项，新的配置项更易于配置，更好扩展，与以后发布的 v2.0 版本兼容**。
+**Rsdoctor 在 1.2.4 版本中引入了替代配置项。** 新配置更易于使用和扩展，并与 Rsdoctor 2.x 兼容。
 
-1.2.3 及之前版本的配置项仍会保留，**但在 Rsdoctor v2 时会完全废弃掉**，推荐迁移到 `1.2.4` 的新版配置。
+1.2.3 及之前版本中被替代的配置项已在 Rsdoctor 2.x 中移除，请迁移到 1.2.4 引入的替代配置。
 
-| 原配置                              | 新配置                                                                                                           |
-| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| mode                                | 改为配置 `output.mode`。                                                                                         |
-| brief                               | 改为配置 `mode: 'brief'`，同时，配置 `output.options` 的 `type` 为 `html`。                                      |
-| output.compressData                 | 改为配置 `mode: 'brief'`，同时，配置 `output.options.type` 为 `json`。                                           |
-| `mode: 'lite'` 或 `feature: 'lite'` | 改为配置 `mode: 'normal'`，同时，配置 `output.options.reportCodeType` 为 `noCode` 或 `noAssetsAndModuleSource`。 |
-| 无                                  | 新增 `output.options.jsonOptions.section` 配置                                                                   |
+| 原配置                            | 替代配置                                                                                                    |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| mode                              | 配置 `output.mode`。                                                                                        |
+| brief                             | 将 `output.mode` 设为 `'brief'`，并将 `output.options.type` 设为 `['html']`。                               |
+| output.compressData               | 将 `output.mode` 设为 `'brief'`，并将 `output.options.type` 设为 `['json']`。                               |
+| `mode: 'lite'` 或 `features.lite` | 将 `output.mode` 设为 `'normal'`，并将 `output.reportCodeType` 设为 `noCode` 或 `noAssetsAndModuleSource`。 |
+| 无                                | 配置新增的 `output.options.jsonOptions.section`。                                                           |
 
 ## 配置改动详情
 
 ### mode
 
-原有配置中的 `mode` 迁移为嵌套的 `output.mode`，便于与其他输出相关的配置整合。
+原有的顶层 `mode` 配置已迁移为 `output.mode`，便于统一管理输出相关配置。
 
 ### brief
 
-目前的 brief 简报模式输出一个 html 文件为报告页，新增的 brief 模式还是支持 JSON 格式，同时也为了相同配置统一管理，所以 brief 配置前移到了 output.options 中。
-原有的 `brief` 配置改为配置 `output.mode: 'brief'`，同时配置 `output.options` 的 `type` 为 `html`。
+原有的 `brief` 配置已迁移到 `output.options.htmlOptions`。将 `output.mode` 设为 `'brief'`，并将 `output.options.type` 设为 `['html']`，即可生成 HTML 报告。
 
 ### output.compressData
 
-原有的 `output.compressData` 配置改为配置 `mode: 'brief'`，同时配置 `output.options.type` 为 `json`。
+使用 `output.mode: 'brief'` 和 `output.options.type: ['json']` 代替 `output.compressData`。
 
 ### lite
 
-lite 模式的内部逻辑等同于 `output.options.reportCodeType` 为 `noCode` 或 `noAssetsAndModuleSource`，主要是为了解决大项目在打开报告时过慢或者构建时 OOM 的问题。
+lite 模式等同于将 `output.reportCodeType` 设为 `noCode` 或 `noAssetsAndModuleSource`。它会减少构建时保留的数据，有助于缓解大型项目报告加载缓慢或构建 OOM 的问题。
 
-考虑到用户并不能清楚分辨 lite 模式的实际含义，mode 太多也不利于管理和配置，同时，`output.options.reportCodeType` 配置更加清晰，所以未来 V2 版本中会废弃掉 `mode: 'lite'`。
+顶层 `mode: 'lite'` 已在 Rsdoctor 2.x 中移除，`features.lite` 也已废弃。请使用 `output.reportCodeType` 明确报告需要保留的代码数据。
 
-原有的 `mode: 'lite'` 和 `feature: 'lite'` 配置改为配置 `mode: 'normal'`，同时配置 `output.options.reportCodeType` 为 `noCode` 或 `noAssetsAndModuleSource`。
+将原有的 `mode: 'lite'` 或 `features.lite` 替换为 `output.mode: 'normal'`，并将 `output.reportCodeType` 设为 `noCode` 或 `noAssetsAndModuleSource`。
 
 ### 新增 output.options.jsonOptions.section
 

--- a/packages/document/docs/zh/config/options/options-v2.mdx
+++ b/packages/document/docs/zh/config/options/options-v2.mdx
@@ -2,7 +2,7 @@
 
 **Rsdoctor 在 1.2.4 版本中引入了替代配置项。** 新配置更易于使用和扩展，并与 Rsdoctor 2.x 兼容。
 
-1.2.3 及之前版本中被替代的配置项已在 Rsdoctor 2.x 中移除，请迁移到 1.2.4 引入的替代配置。
+顶层 `mode` 配置已在 Rsdoctor 2.x 中移除。其他被替代的配置（包括 `brief`、`features.lite` 和 `output.compressData`）仍为向后兼容而保留，但已废弃。请迁移到 1.2.4 引入的替代配置。
 
 | 原配置                            | 替代配置                                                                                                    |
 | --------------------------------- | ----------------------------------------------------------------------------------------------------------- |
@@ -16,15 +16,15 @@
 
 ### mode
 
-原有的顶层 `mode` 配置已迁移为 `output.mode`，便于统一管理输出相关配置。
+顶层 `mode` 配置已在 Rsdoctor 2.x 中移除。请使用 `output.mode` 统一管理输出相关配置。
 
 ### brief
 
-原有的 `brief` 配置已迁移到 `output.options.htmlOptions`。将 `output.mode` 设为 `'brief'`，并将 `output.options.type` 设为 `['html']`，即可生成 HTML 报告。
+`brief` 配置仍为向后兼容而保留，但已废弃。将 `output.mode` 设为 `'brief'`，并将 `output.options.type` 设为 `['html']`，即可生成 HTML 报告。
 
 ### output.compressData
 
-使用 `output.mode: 'brief'` 和 `output.options.type: ['json']` 代替 `output.compressData`。
+`output.compressData` 配置仍为向后兼容而保留，但已废弃。请使用 `output.mode: 'brief'` 和 `output.options.type: ['json']` 代替它。
 
 ### lite
 

--- a/packages/document/docs/zh/config/options/options.mdx
+++ b/packages/document/docs/zh/config/options/options.mdx
@@ -43,7 +43,6 @@ new RsdoctorRspackPlugin({/** RsdoctorRspackPluginOptions */});
 - [server](./server.mdx) - **报告服务配置**：配置 Rsdoctor 报告服务，包括 `server.port` 和 `server.cors`
 - [supports](./supports.mdx) - **特性支持配置**：启用特定构建工具的兼容性支持，如 BannerPlugin 等
 - [brief](./brief.mdx) - **Brief 模式的配置**：控制简要模式报告的生成，包括 HTML 文件名和是否生成 JSON 数据文件
-- [mode](./mode.mdx) - **构建报告数据输出模式**：选择报告的输出模式，支持 normal（普通模式）和 brief（简要模式）
 - [multiCompiler](./multiCompiler.mdx) - **多编译器配置**：自动识别并隔离 Rspack MultiCompiler 和 Rsbuild environments 的分析报告
 
 ### RsdoctorRspackPluginOptions
@@ -59,14 +58,6 @@ interface RsdoctorRspackPluginOptions<
   /** Rsdoctor 功能开关 */
   features?:
     RsdoctorRspackPluginFeatures | Array<keyof RsdoctorRspackPluginFeatures>;
-
-  /**
-   * @deprecated 使用 `output.mode` 代替，如果使用 `lite` 模式，请使用 `output.reportCodeType: 'noCode' or 'noAssetsAndModuleSource'` 代替
-   * Rsdoctor 模式选项：
-   * - normal: 普通模式
-   * - brief: 简要模式，仅显示持续时间分析和构建产物分析结果，不显示任何代码部分
-   */
-  mode?: 'brief' | 'normal' | 'lite';
 
   disableClientServer?: boolean;
 

--- a/packages/document/docs/zh/guide/start/cicd.mdx
+++ b/packages/document/docs/zh/guide/start/cicd.mdx
@@ -12,7 +12,7 @@ Brief 模式中，会将数据报告整合到一个 HTML 页面中，方便用�
 
 <Badge text="Version: 0.4.0" type="warning" />
 
-通过配置 Rsdoctor 插件的 [mode.brief](/config/options/mode) 选项，即可开启 Brief 模式。Brief 模式会在构建后生成一份报告到构建产物目录中： `[outputDir]/.rsdoctor/report-rsdoctor.html`，通过浏览器打开 HTML 文件，
+将 Rsdoctor 插件的 [output.mode](/config/options/output#mode) 设置为 `'brief'`，即可开启 Brief 模式。Brief 模式会在构建后生成一份报告到构建产物目录中：`[outputDir]/.rsdoctor/report-rsdoctor.html`。通过浏览器打开 HTML 文件，
 即可看到构建分析简报。
 
 - Brief 模式下是不展示任何的代码数据的，为了防止数据过大导致页面崩溃。
@@ -29,7 +29,9 @@ module.exports = {
     process.env.RSDOCTOR &&
       new RsdoctorRspackPlugin({
         // 其他插件选项
-        mode: 'brief',
+        output: {
+          mode: 'brief',
+        },
       }),
   ].filter(Boolean),
 };

--- a/packages/document/docs/zh/shared/mode-intro.md
+++ b/packages/document/docs/zh/shared/mode-intro.md
@@ -1,6 +1,6 @@
 - **normal 模式：** 在构建产物目录中生成一个 `.rsdoctor` 文件夹，其中包含各种数据文件，并在报告页面中展示代码。输出目录可以通过 [reportDir](/config/options/output#reportdir) 进行配置。
 
-- **brief 模式：** 在构建产物目录的 `.rsdoctor` 文件夹中生成一个 HTML 报告文件，所有构建分析数据会整合注入到这个 HTML 文件中，可以通过浏览器打开该 HTML 文件查看报告。brief 模式还有更多配置项，详细信息请参阅：[brief](/config/options/brief).
+- **brief 模式：** 在构建产物目录的 `.rsdoctor` 文件夹中生成一个 HTML 报告文件，所有构建分析数据会整合注入到该文件中，可以直接通过浏览器打开。详细配置请参考 [brief 输出配置](/config/options/output#mode-brief)。
 
 - **lite 模式：** 基于普通模式，不展示源码和产物代码，仅显示打包后的代码信息。
-  - lite 模式即将在 V2 废弃，参考 [lite 模式废弃说明](/config/options/options-v2#lite)。
+  - 顶层 `mode: 'lite'` 已在 Rsdoctor 2.x 中移除，`features.lite` 也已废弃。请使用 [output.reportCodeType](/config/options/output#reportcodetype) 代替。

--- a/packages/shared/src/types/plugin/plugin.ts
+++ b/packages/shared/src/types/plugin/plugin.ts
@@ -45,7 +45,6 @@ export interface RsdoctorPluginOptionsNormalized<
     | 'supports'
     | 'port'
     | 'brief'
-    | 'mode'
     | 'server'
     | 'multiCompiler'
   >
@@ -152,15 +151,6 @@ export interface RsdoctorRspackPluginOptions<
    */
   features?:
     RsdoctorRspackPluginFeatures | Array<keyof RsdoctorRspackPluginFeatures>;
-
-  /**
-   * @deprecated  Use `output.mode` instead, if you're using `lite` mode, please use `output.reportCodeType: 'noCode' or 'noAssetsAndModuleSource'` instead.
-   * Rsdoctor mode option:
-   * - normal: Refers to the normal mode.
-   * - brief: Refers to the brief mode, which only displays the results of the duration analysis and build artifact analysis
-   *    and does not display any part of the code.
-   */
-  mode?: 'brief' | 'normal' | 'lite';
 
   /**
    * Configuration for the bundler loader interceptor. TODO: delete this option.

--- a/packages/shared/tests/published-types.test.ts
+++ b/packages/shared/tests/published-types.test.ts
@@ -120,7 +120,20 @@ describe('@rsdoctor/shared published declarations', () => {
       installSharedDependencies(consumerNodeModules);
       fs.writeFileSync(
         path.join(consumerRoot, 'index.ts'),
-        "import type { SDK } from '@rsdoctor/shared/types';\n\nconst moduleData = {} as SDK.ModuleData;\nvoid moduleData;\n",
+        [
+          "import type { Plugin, SDK } from '@rsdoctor/shared/types';",
+          '',
+          'const moduleData = {} as SDK.ModuleData;',
+          "const options: Plugin.RsdoctorRspackPluginOptions<[]> = { output: { mode: 'brief' } };",
+          'const removedMode: Plugin.RsdoctorRspackPluginOptions<[]> = {',
+          '  // @ts-expect-error The top-level mode option was removed in Rsdoctor 2.x.',
+          "  mode: 'brief',",
+          '};',
+          'void moduleData;',
+          'void options;',
+          'void removedMode;',
+          '',
+        ].join('\n'),
       );
       fs.writeFileSync(
         path.join(consumerRoot, 'package.json'),


### PR DESCRIPTION
## Summary

Rsdoctor 2.x still reports several deprecated configuration fields as future deprecations. This PR changes the `mode`, lite, and `compressData` warnings to describe their current 2.x status.

## Related Links

None