### PR TITLE
docs: align output configuration with Rsdoctor 2.x

### DIFF
--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -194,13 +194,6 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
   }
   const _features = normalizeFeatures(features, finalMode);
   const _linter = normalizeLinter(linter);
-  if (_features.lite) {
-    logger.info(
-      chalk.yellow(
-        `Lite features are deprecated in Rsdoctor 2.x. Please use 'output: { reportCodeType: { noAssetsAndModuleSource: true }}' instead.`,
-      ),
-    );
-  }
   // Process mode-specific configurations
   const { finalBrief, finalNormalOptions } = processModeConfigurations(
     finalMode,

--- a/packages/core/tests/build/utils/config.test.ts
+++ b/packages/core/tests/build/utils/config.test.ts
@@ -306,20 +306,17 @@ describe('normalizeUserConfig', () => {
       expect(result.output.mode).toBe('normal');
     });
 
-    it('should show warning when lite features are enabled', () => {
+    it('should not show a deprecation warning when lite features are enabled', () => {
       normalizeUserConfig({
         features: {
           lite: true,
         },
       });
+      normalizeUserConfig({
+        features: ['lite'],
+      });
 
-      expect(
-        consoleOutput.some((output) =>
-          output.includes(
-            "Lite features are deprecated in Rsdoctor 2.x. Please use 'output: { reportCodeType: { noAssetsAndModuleSource: true }}' instead.",
-          ),
-        ),
-      ).toBe(true);
+      expect(consoleOutput).toEqual([]);
     });
   });
 

--- a/packages/document/docs/en/config/options/brief.mdx
+++ b/packages/document/docs/en/config/options/brief.mdx
@@ -3,7 +3,7 @@
 import { Badge } from '@theme';
 
 :::warning
-Deprecated in V2, please use [output.mode: 'brief'](/config/options/output#mode) instead. Refer to [brief configuration migration](/config/options/options-v2#brief).
+The legacy `brief` option is deprecated in Rsdoctor 2.x and retained for backward compatibility. Use [output.mode: 'brief'](/config/options/output#mode) instead. See [brief configuration migration](/config/options/options-v2#brief).
 :::
 
 - **Type:** [BriefType](#brieftype)
@@ -12,7 +12,7 @@ Deprecated in V2, please use [output.mode: 'brief'](/config/options/output#mode)
 
 Detailed configuration options for Brief mode are as follows:
 
-- **reportHtmlName:** Configures the filename of the HTML report in Brief mode. The default value is `report-rsdoctor.html`.
+- **reportHtmlName:** Configures the filename of the HTML report in Brief mode. The default value is `rsdoctor-report.html`.
 
 ## briefType
 

--- a/packages/document/docs/en/config/options/features.mdx
+++ b/packages/document/docs/en/config/options/features.mdx
@@ -12,7 +12,7 @@ The `features` attribute is used for analysis feature toggles, and the specific 
 - **plugins**: Plugin calls and time consumption analysis, enabled by default.
 - **bundle**: Build artifact analysis, enabled by default.
 - **resolver**: Resolver analysis, disabled by default.
-- **lite**: **(lite mode will be deprecated in V2, refer to [lite mode deprecation notice](/config/options/options-v2#lite))** lite mode. The difference between lite mode and normal mode is that source code information is no longer displayed, only packaged code information is displayed, so the code analyzed on the page will also be packaged. Default is normal mode.
+- **lite**: Enables lite mode. Both `features: { lite: true }` and `features: ['lite']` are supported. Unlike normal mode, lite mode omits source code information and only displays bundled code. Lite mode is disabled by default.
 
 Therefore, **the default configuration enables Bundle analysis capabilities, Loader and Plugin build-time analysis**. Resolver analysis is not enabled by default. To enable it, explicitly configure `resolver` in `features`.
 

--- a/packages/document/docs/en/config/options/mode.mdx
+++ b/packages/document/docs/en/config/options/mode.mdx
@@ -9,7 +9,7 @@ The top-level `mode` option was removed in Rsdoctor 2.x. Use [output.mode](/conf
 The removed option accepted the following values:
 
 - **Type:** `"normal" | "brief" | "lite"`
-  - `lite` is deprecated in Rsdoctor 2.x. Use [output.reportCodeType](/config/options/output#reportcodetype) instead.
+  - `lite` was removed and is ignored in Rsdoctor 2.x. Use [output.reportCodeType](/config/options/output#reportcodetype) instead.
 - **Optional:** `true`
 - **Default:** `normal`
 

--- a/packages/document/docs/en/config/options/mode.mdx
+++ b/packages/document/docs/en/config/options/mode.mdx
@@ -9,7 +9,7 @@ The top-level `mode` option was removed in Rsdoctor 2.x. Use [output.mode](/conf
 The removed option accepted the following values:
 
 - **Type:** `"normal" | "brief" | "lite"`
-  - For migrating lite mode, see the [lite mode migration guide](/config/options/options-v2#lite).
+  - `lite` is deprecated in Rsdoctor 2.x. Use [output.reportCodeType](/config/options/output#reportcodetype) instead.
 - **Optional:** `true`
 - **Default:** `normal`
 

--- a/packages/document/docs/en/config/options/options-v2.mdx
+++ b/packages/document/docs/en/config/options/options-v2.mdx
@@ -1,18 +1,18 @@
-# Configuration migration guide
+# Legacy configuration migration
 
-**Rsdoctor introduced replacement configuration options in version 1.2.4.** These options are easier to configure, more extensible, and compatible with Rsdoctor 2.x.
+**Rsdoctor 1.2.4 introduced the output configuration used by Rsdoctor 2.x.** It is easier to configure and extend than the legacy options.
 
-The top-level `mode` option was removed in Rsdoctor 2.x. Other replaced options, including `brief`, `features.lite`, and `output.compressData`, remain available for backward compatibility but are deprecated. Migrate these configurations to the replacements introduced in version 1.2.4.
+Configuration options from version 1.2.3 and earlier are deprecated in Rsdoctor 2.x and retained for backward compatibility. Migrate them to the replacements below.
 
-| Original configuration            | Replacement configuration                                                                             |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| mode                              | Configure `output.mode`.                                                                              |
-| brief                             | Set `output.mode` to `'brief'` and `output.options.type` to `['html']`.                               |
-| output.compressData               | Set `output.mode` to `'brief'` and `output.options.type` to `['json']`.                               |
-| `mode: 'lite'` or `features.lite` | Set `output.mode` to `'normal'` and `output.reportCodeType` to `noCode` or `noAssetsAndModuleSource`. |
-| None                              | Configure the new `output.options.jsonOptions.section` option.                                        |
+| Original Configuration                 | New Configuration                                                                                           |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| mode                                   | Configure `output.mode` instead.                                                                            |
+| brief                                  | Configure `output.mode: 'brief'` and set `output.options.type` to `['html']`.                               |
+| output.compressData                    | Configure `output.mode: 'brief'` and set `output.options.type` to `['json']`.                               |
+| `mode: 'lite'` or `features: ['lite']` | Configure `output.mode: 'normal'` and set `output.reportCodeType` to `noCode` or `noAssetsAndModuleSource`. |
+| None                                   | New `output.options.jsonOptions.sections` configuration                                                     |
 
-## Configuration changes
+## Configuration changes details
 
 ### mode
 
@@ -20,20 +20,21 @@ The top-level `mode` option was removed in Rsdoctor 2.x. Use `output.mode` to ke
 
 ### brief
 
-The `brief` option remains available for backward compatibility but is deprecated. Set `output.mode` to `'brief'` and `output.options.type` to `['html']` to generate an HTML report.
+The current brief report mode outputs an HTML file as the report page. The new brief mode still supports JSON format, and for unified management of the same configuration, the brief configuration is moved to output.options.
+Replace the original `brief` configuration with `output.mode: 'brief'` and set `output.options.type` to `['html']`.
 
 ### output.compressData
 
-The `output.compressData` option remains available for backward compatibility but is deprecated. Replace it with `output.mode: 'brief'` and `output.options.type: ['json']`.
+Replace the original `output.compressData` configuration with `output.mode: 'brief'` and set `output.options.type` to `['json']`.
 
 ### lite
 
-Lite mode is equivalent to setting `output.reportCodeType` to `noCode` or `noAssetsAndModuleSource`. It reduces the data retained during builds and can help large projects avoid slow report loading or out-of-memory errors.
+The internal logic of lite mode is equivalent to `output.reportCodeType` being `noCode` or `noAssetsAndModuleSource`, mainly to solve the problem of large projects being too slow when opening reports or OOM during build.
 
-The top-level `mode: 'lite'` option was removed in Rsdoctor 2.x, and `features.lite` is deprecated. Use `output.reportCodeType` to state which code data the report should retain.
+`mode: 'lite'` is deprecated in Rsdoctor 2.x and retained for backward compatibility. The `output.reportCodeType` configuration expresses the intended report content more clearly.
 
-Replace the original `mode: 'lite'` or `features.lite` configuration with `output.mode: 'normal'` and set `output.reportCodeType` to `noCode` or `noAssetsAndModuleSource`.
+Replace `mode: 'lite'` or `features: ['lite']` with `output.mode: 'normal'`, and set `output.reportCodeType` to `noCode` or `noAssetsAndModuleSource`.
 
-### output.options.jsonOptions.section
+### output.options.jsonOptions.sections
 
-Support for the new `output.options.jsonOptions.section` configuration for more granular JSON output option customization. For specific sections configuration items, refer to [output.options.jsonOptions.section](/config/options/output#options).
+Use `output.options.jsonOptions.sections` to control which sections are included in JSON output. See [output.options.jsonOptions.sections](/config/options/output#options) for the available fields.

--- a/packages/document/docs/en/config/options/options-v2.mdx
+++ b/packages/document/docs/en/config/options/options-v2.mdx
@@ -13,7 +13,7 @@ The top-level `mode` option was removed and is ignored in Rsdoctor 2.x. The lega
 | `features: { lite: true }` or `features: ['lite']` | Still supported. The equivalent `output` configuration uses `output.mode: 'normal'` and `output.reportCodeType` as above. |
 | None                                               | New `output.options.jsonOptions.sections` configuration                                                                   |
 
-## Configuration changes details
+## Configuration change details
 
 ### mode
 

--- a/packages/document/docs/en/config/options/options-v2.mdx
+++ b/packages/document/docs/en/config/options/options-v2.mdx
@@ -2,15 +2,16 @@
 
 **Rsdoctor 1.2.4 introduced the output configuration used by Rsdoctor 2.x.** It is easier to configure and extend than the legacy options.
 
-Configuration options from version 1.2.3 and earlier are deprecated in Rsdoctor 2.x and retained for backward compatibility. Migrate them to the replacements below.
+The top-level `mode` option was removed and is ignored in Rsdoctor 2.x. The legacy `brief` and `output.compressData` options are deprecated and retained for backward compatibility. Use the table below to migrate these options. Both forms of the `features` lite configuration remain supported and are included only to show the equivalent `output` configuration.
 
-| Original Configuration                 | New Configuration                                                                                           |
-| -------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| mode                                   | Configure `output.mode` instead.                                                                            |
-| brief                                  | Configure `output.mode: 'brief'` and set `output.options.type` to `['html']`.                               |
-| output.compressData                    | Configure `output.mode: 'brief'` and set `output.options.type` to `['json']`.                               |
-| `mode: 'lite'` or `features: ['lite']` | Configure `output.mode: 'normal'` and set `output.reportCodeType` to `noCode` or `noAssetsAndModuleSource`. |
-| None                                   | New `output.options.jsonOptions.sections` configuration                                                     |
+| Original Configuration                             | New Configuration                                                                                                         |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| mode                                               | Configure `output.mode` instead.                                                                                          |
+| brief                                              | Configure `output.mode: 'brief'` and set `output.options.type` to `['html']`.                                             |
+| output.compressData                                | Configure `output.mode: 'brief'` and set `output.options.type` to `['json']`.                                             |
+| `mode: 'lite'`                                     | Configure `output.mode: 'normal'` and set `output.reportCodeType` to `noCode` or `noAssetsAndModuleSource`.               |
+| `features: { lite: true }` or `features: ['lite']` | Still supported. The equivalent `output` configuration uses `output.mode: 'normal'` and `output.reportCodeType` as above. |
+| None                                               | New `output.options.jsonOptions.sections` configuration                                                                   |
 
 ## Configuration changes details
 
@@ -31,9 +32,9 @@ Replace the original `output.compressData` configuration with `output.mode: 'bri
 
 The internal logic of lite mode is equivalent to `output.reportCodeType` being `noCode` or `noAssetsAndModuleSource`, mainly to solve the problem of large projects being too slow when opening reports or OOM during build.
 
-`mode: 'lite'` is deprecated in Rsdoctor 2.x and retained for backward compatibility. The `output.reportCodeType` configuration expresses the intended report content more clearly.
+`mode: 'lite'` was removed and is ignored in Rsdoctor 2.x. Replace it with `output.mode: 'normal'`, and set `output.reportCodeType` to `noCode` or `noAssetsAndModuleSource`.
 
-Replace `mode: 'lite'` or `features: ['lite']` with `output.mode: 'normal'`, and set `output.reportCodeType` to `noCode` or `noAssetsAndModuleSource`.
+Both `features: { lite: true }` and `features: ['lite']` remain supported and do not need to be migrated. The equivalent `output.reportCodeType` configuration expresses the intended report content more clearly.
 
 ### output.options.jsonOptions.sections
 

--- a/packages/document/docs/en/config/options/options.mdx
+++ b/packages/document/docs/en/config/options/options.mdx
@@ -1,34 +1,14 @@
-import { Badge, Tab, Tabs } from '@theme';
-
 # Overview
 
 ## RsdoctorRspackPlugin
 
 The `RsdoctorRspackPlugin` class is exported from `@rsdoctor/core`. Its configuration type is [RsdoctorRspackPluginOptions](#rsdoctorrspackpluginoptions).
 
-<Tabs>
-
-<Tab label="esm">
-
 ```ts
 import { RsdoctorRspackPlugin } from '@rsdoctor/core';
 
 new RsdoctorRspackPlugin({/** RsdoctorRspackPluginOptions */});
 ```
-
-</Tab>
-
-<Tab label="cjs">
-
-```js
-const { RsdoctorRspackPlugin } = require('@rsdoctor/core');
-
-new RsdoctorRspackPlugin({/** RsdoctorRspackPluginOptions */});
-```
-
-</Tab>
-
-</Tabs>
 
 ## Options
 

--- a/packages/document/docs/en/config/options/output.mdx
+++ b/packages/document/docs/en/config/options/output.mdx
@@ -11,7 +11,7 @@ import { Badge } from '@theme';
 Rsdoctor report mode, default is `normal`.
 
 - **normal:** Generates a `.rsdoctor` folder in the build output directory, containing various data files and displaying code in the report page. The output directory can be configured via [reportDir](#reportdir).
-- **brief:** Generates an HTML report file in the `.rsdoctor` folder of the build output directory. All build analysis data is integrated and injected into this HTML file, which can be opened in a browser to view the report. Brief mode has more configuration options, see [mode: 'brief'](#mode-brief) for details.
+- **brief:** Generates `rsdoctor-report.html` in the report output directory. This directory defaults to the build output directory and can be configured via [reportDir](#reportdir). All build analysis data is injected into this standalone HTML file, which can be opened directly in a browser. See [mode: 'brief'](#mode-brief) for more options.
 
 :::tip
 `output.mode` does not support `lite`. Use [output.reportCodeType](#reportcodetype) to control whether source and asset code is included. The `features` lite configurations remain supported.
@@ -36,7 +36,7 @@ Brief mode is used to generate lightweight analysis reports, supporting both HTM
   - If configured with `['json']`, it will generate a JSON file named `rsdoctor-data.json`.
   - If configured with `['html']`, it will generate an HTML file. The filename can be configured via `htmlOptions.reportHtmlName`.
 - **`htmlOptions`**: HTML output related configuration
-  - **`reportHtmlName`**: HTML report filename, defaults to `report-rsdoctor.html`
+  - **`reportHtmlName`**: HTML report filename, defaults to `rsdoctor-report.html`
 - **`jsonOptions`**: JSON output related configuration
   - **`fileName`**: JSON stats filename, defaults to `rsdoctor-data.json`
   - **`sections`**: Module configuration for JSON output
@@ -137,7 +137,7 @@ interface BriefModeOptions {
 }
 
 interface BriefConfig {
-  /** HTML report filename, defaults to report-rsdoctor.html */
+  /** HTML report filename, defaults to rsdoctor-report.html */
   reportHtmlName?: string;
 }
 

--- a/packages/document/docs/en/config/options/output.mdx
+++ b/packages/document/docs/en/config/options/output.mdx
@@ -14,7 +14,7 @@ Rsdoctor report mode, default is `normal`.
 - **brief:** Generates an HTML report file in the `.rsdoctor` folder of the build output directory. All build analysis data is integrated and injected into this HTML file, which can be opened in a browser to view the report. Brief mode has more configuration options, see [mode: 'brief'](#mode-brief) for details.
 
 :::tip
-Mode does not have a lite configuration option. The lite mode will be deprecated. Refer to [lite mode deprecation notice](./options-v2.mdx#lite).
+`output.mode` does not support `lite`. Use [output.reportCodeType](#reportcodetype) to control whether source and asset code is included. The `features` lite configurations remain supported.
 :::
 
 ## options

--- a/packages/document/docs/en/guide/start/cicd.mdx
+++ b/packages/document/docs/en/guide/start/cicd.mdx
@@ -12,11 +12,11 @@ In Brief mode, data reports are integrated into a single HTML page, making it ea
 
 <Badge text="Version: 0.4.0" type="warning" />
 
-You can enable Brief mode by setting [output.mode](/config/options/output#mode) to `'brief'` in the Rsdoctor plugin. After the build, Brief mode generates a report at `[outputDir]/.rsdoctor/report-rsdoctor.html`. Open the HTML file in a browser to view the build analysis summary.
+You can enable Brief mode by setting [output.mode](/config/options/output#mode) to `'brief'` in the Rsdoctor plugin. After the build, Brief mode generates a report at `[outputDir]/rsdoctor-report.html`. If [output.reportDir](/config/options/output#reportdir) is configured, the report is generated at `[reportDir]/rsdoctor-report.html` instead. Open the HTML file in a browser to view the build analysis summary.
 
 - In Brief mode, no code data is displayed to prevent the page from crashing due to large data sizes.
-- The report output directory and file name can be configured. Refer to: [Options](/config/options/brief).
-- For more configurations, refer to: [Options](/config/options/brief).
+- Configure the output directory with [output.reportDir](/config/options/output#reportdir) and the filename with [output.options.htmlOptions.reportHtmlName](/config/options/output#mode-brief).
+- For more configurations, see [mode: 'brief'](/config/options/output#mode-brief).
 
 ```ts title="rspack.config.js"
 const { RsdoctorRspackPlugin } = require('@rsdoctor/core');

--- a/packages/document/docs/en/shared/mode-intro.md
+++ b/packages/document/docs/en/shared/mode-intro.md
@@ -1,6 +1,6 @@
 - **normal mode:** Generates a `.rsdoctor` folder in the build output directory, which contains various data files and displays code in the report page. The output directory can be configured via [reportDir](/config/options/output#reportdir).
 
-- **brief mode:** Generates `rsdoctor-report.html` in the build output directory. All build analysis data is consolidated and injected into this standalone HTML file, which can be opened directly in a browser. See [mode: 'brief'](/config/options/output#mode-brief) for the available options.
+- **brief mode:** Generates `rsdoctor-report.html` in the report output directory. This directory defaults to the build output directory and can be configured via [reportDir](/config/options/output#reportdir). All build analysis data is injected into this standalone HTML file, which can be opened directly in a browser. See [mode: 'brief'](/config/options/output#mode-brief) for the available options.
 
 - **lite mode:** Based on the normal mode, this mode does not display source code and product code, only showing the information of the bundled code.
   - The top-level `mode: 'lite'` option was removed and is ignored in Rsdoctor 2.x. The `features` lite configurations remain supported. Use [output.reportCodeType](/config/options/output#reportcodetype) for new configurations.

--- a/packages/document/docs/en/shared/mode-intro.md
+++ b/packages/document/docs/en/shared/mode-intro.md
@@ -1,6 +1,6 @@
 - **normal mode:** Generates a `.rsdoctor` folder in the build output directory, which contains various data files and displays code in the report page. The output directory can be configured via [reportDir](/config/options/output#reportdir).
 
-- **brief mode:** Generates `rsdoctor-report.html` in the build output directory. All build analysis data is consolidated and injected into this standalone HTML file, which can be opened directly in a browser. Brief mode also has additional configuration options, detailed at: [brief](/config/options/brief).
+- **brief mode:** Generates `rsdoctor-report.html` in the build output directory. All build analysis data is consolidated and injected into this standalone HTML file, which can be opened directly in a browser. See [mode: 'brief'](/config/options/output#mode-brief) for the available options.
 
 - **lite mode:** Based on the normal mode, this mode does not display source code and product code, only showing the information of the bundled code.
-  - Lite mode is deprecated in Rsdoctor 2.x and retained for backward compatibility. Use [output.reportCodeType](/config/options/output#reportcodetype) instead.
+  - The top-level `mode: 'lite'` option was removed and is ignored in Rsdoctor 2.x. The `features` lite configurations remain supported. Use [output.reportCodeType](/config/options/output#reportcodetype) for new configurations.

--- a/packages/document/docs/en/shared/mode-intro.md
+++ b/packages/document/docs/en/shared/mode-intro.md
@@ -1,6 +1,6 @@
 - **normal mode:** Generates a `.rsdoctor` folder in the build output directory, which contains various data files and displays code in the report page. The output directory can be configured via [reportDir](/config/options/output#reportdir).
 
-- **brief mode:** Generates an HTML report file in the `.rsdoctor` folder within the build output directory. All build analysis data is consolidated and injected into this HTML file, which can be opened directly in a browser. See the [brief output configuration](/config/options/output#mode-brief) for details.
+- **brief mode:** Generates `rsdoctor-report.html` in the build output directory. All build analysis data is consolidated and injected into this standalone HTML file, which can be opened directly in a browser. Brief mode also has additional configuration options, detailed at: [brief](/config/options/brief).
 
 - **lite mode:** Based on the normal mode, this mode does not display source code and product code, only showing the information of the bundled code.
-  - The top-level `mode: 'lite'` option was removed in Rsdoctor 2.x, and `features.lite` is deprecated. Use [output.reportCodeType](/config/options/output#reportcodetype) instead.
+  - Lite mode is deprecated in Rsdoctor 2.x and retained for backward compatibility. Use [output.reportCodeType](/config/options/output#reportcodetype) instead.

--- a/packages/document/docs/zh/config/options/brief.mdx
+++ b/packages/document/docs/zh/config/options/brief.mdx
@@ -3,7 +3,7 @@
 import { Badge } from '@theme';
 
 :::warning
-V2 中即将废弃，请使用 [output.mode: 'brief'](/config/options/output#mode) 代替。参考 [brief 配置迁移](/config/options/options-v2#brief)。
+旧版 `brief` 配置已在 Rsdoctor 2.x 中废弃，仅为向后兼容而保留。请改用 [output.mode: 'brief'](/config/options/output#mode)。参阅 [brief 配置迁移](/config/options/options-v2#brief)。
 :::
 
 - **类型：** [BriefType](#brieftype)
@@ -12,7 +12,7 @@ V2 中即将废弃，请使用 [output.mode: 'brief'](/config/options/output#mod
 
 Brief 模式的详细配置选项如下：
 
-- **reportHtmlName:** 配置 Brief 模式下 HTML 报告的文件名称，默认值为 `report-rsdoctor.html`。
+- **reportHtmlName:** 配置 Brief 模式下 HTML 报告的文件名称，默认值为 `rsdoctor-report.html`。
 
 ## briefType
 

--- a/packages/document/docs/zh/config/options/features.mdx
+++ b/packages/document/docs/zh/config/options/features.mdx
@@ -12,7 +12,7 @@ features 属性是用于分析功能开关的，具体的功能项如下：
 - **plugins**：Plugins 调用以及耗时分析，默认开启。
 - **bundle**：构建产物分析，默认开启。
 - **resolver**：Resolver 分析，默认关闭。
-- **lite**: **(lite 模式即将在 V2 废弃，参考[lite 模式废弃说明](/config/options/options-v2#lite))** lite 模式。lite 模式和普通模式的区别就是不再展示源码信息，只展示打包后的代码信息，这样分析页面上的代码也将是打包后的。默认普通模式。
+- **lite**：启用 lite 模式。`features: { lite: true }` 和 `features: ['lite']` 均受支持。与普通模式相比，lite 模式不展示源码信息，仅展示打包后的代码。lite 模式默认关闭。
 
 所以，**默认配置是开启了 Bundle 分析能力、 Loader 和 Plugin 构建时分析**，没有开启 Resolver 分析能力。如需启用 Resolver 分析，可以在 `features` 中显式配置 `resolver`。
 

--- a/packages/document/docs/zh/config/options/mode.mdx
+++ b/packages/document/docs/zh/config/options/mode.mdx
@@ -2,7 +2,7 @@
 
 :::warning
 
-- 旧版 `mode` 配置已在 Rsdoctor 2.x 中废弃，仅为向后兼容而保留。请改用 [output.mode](/config/options/output#mode)。参阅 [mode 配置迁移](/config/options/options-v2#mode)。
+旧版顶层 `mode` 配置已在 Rsdoctor 2.x 中移除且会被忽略，请改用 [output.mode](/config/options/output#mode)。参阅 [mode 配置迁移](/config/options/options-v2#mode)。
 
 :::
 

--- a/packages/document/docs/zh/config/options/mode.mdx
+++ b/packages/document/docs/zh/config/options/mode.mdx
@@ -2,14 +2,14 @@
 
 :::warning
 
-顶层 `mode` 配置已在 Rsdoctor 2.x 中移除，请使用 [output.mode](/config/options/output#mode) 代替。参考 [mode 配置迁移说明](/config/options/options-v2#mode)。
+- 旧版 `mode` 配置已在 Rsdoctor 2.x 中废弃，仅为向后兼容而保留。请改用 [output.mode](/config/options/output#mode)。参阅 [mode 配置迁移](/config/options/options-v2#mode)。
 
 :::
 
 已移除的配置曾支持以下值：
 
 - **类型：** `"normal" | "brief" | "lite"`
-  - lite 模式的迁移方式请参考 [lite 模式迁移说明](/config/options/options-v2#lite)。
+  - `lite` 已在 Rsdoctor 2.x 中废弃，请改用 [output.reportCodeType](/config/options/output#reportcodetype)。
 - **可选：** `true`
 - **默认值：** `normal`
 

--- a/packages/document/docs/zh/config/options/mode.mdx
+++ b/packages/document/docs/zh/config/options/mode.mdx
@@ -9,7 +9,7 @@
 已移除的配置曾支持以下值：
 
 - **类型：** `"normal" | "brief" | "lite"`
-  - `lite` 已在 Rsdoctor 2.x 中废弃，请改用 [output.reportCodeType](/config/options/output#reportcodetype)。
+  - `lite` 已在 Rsdoctor 2.x 中移除且会被忽略，请改用 [output.reportCodeType](/config/options/output#reportcodetype)。
 - **可选：** `true`
 - **默认值：** `normal`
 

--- a/packages/document/docs/zh/config/options/options-v2.mdx
+++ b/packages/document/docs/zh/config/options/options-v2.mdx
@@ -1,16 +1,16 @@
-# 配置迁移说明
+# 旧版配置迁移
 
-**Rsdoctor 在 1.2.4 版本中引入了替代配置项。** 新配置更易于使用和扩展，并与 Rsdoctor 2.x 兼容。
+**Rsdoctor 1.2.4 引入了 Rsdoctor 2.x 使用的 output 配置。** 与旧版配置相比，新配置更易于使用和扩展。
 
-顶层 `mode` 配置已在 Rsdoctor 2.x 中移除。其他被替代的配置（包括 `brief`、`features.lite` 和 `output.compressData`）仍为向后兼容而保留，但已废弃。请迁移到 1.2.4 引入的替代配置。
+1.2.3 及之前版本的配置项已在 Rsdoctor 2.x 中废弃，仅为向后兼容而保留。请迁移到下表中的替代配置。
 
-| 原配置                            | 替代配置                                                                                                    |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| mode                              | 配置 `output.mode`。                                                                                        |
-| brief                             | 将 `output.mode` 设为 `'brief'`，并将 `output.options.type` 设为 `['html']`。                               |
-| output.compressData               | 将 `output.mode` 设为 `'brief'`，并将 `output.options.type` 设为 `['json']`。                               |
-| `mode: 'lite'` 或 `features.lite` | 将 `output.mode` 设为 `'normal'`，并将 `output.reportCodeType` 设为 `noCode` 或 `noAssetsAndModuleSource`。 |
-| 无                                | 配置新增的 `output.options.jsonOptions.section`。                                                           |
+| 原配置                                 | 新配置                                                                                                        |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| mode                                   | 改为配置 `output.mode`。                                                                                      |
+| brief                                  | 改为配置 `output.mode: 'brief'`，并将 `output.options.type` 设置为 `['html']`。                               |
+| output.compressData                    | 改为配置 `output.mode: 'brief'`，并将 `output.options.type` 设置为 `['json']`。                               |
+| `mode: 'lite'` 或 `features: ['lite']` | 改为配置 `output.mode: 'normal'`，并将 `output.reportCodeType` 设置为 `noCode` 或 `noAssetsAndModuleSource`。 |
+| 无                                     | 新增 `output.options.jsonOptions.sections` 配置                                                               |
 
 ## 配置改动详情
 
@@ -20,20 +20,21 @@
 
 ### brief
 
-`brief` 配置仍为向后兼容而保留，但已废弃。将 `output.mode` 设为 `'brief'`，并将 `output.options.type` 设为 `['html']`，即可生成 HTML 报告。
+目前的 brief 简报模式输出一个 html 文件为报告页，新增的 brief 模式还是支持 JSON 格式，同时也为了相同配置统一管理，所以 brief 配置前移到了 output.options 中。
+将原有的 `brief` 配置替换为 `output.mode: 'brief'`，并将 `output.options.type` 设置为 `['html']`。
 
 ### output.compressData
 
-`output.compressData` 配置仍为向后兼容而保留，但已废弃。请使用 `output.mode: 'brief'` 和 `output.options.type: ['json']` 代替它。
+将原有的 `output.compressData` 配置替换为 `output.mode: 'brief'`，并将 `output.options.type` 设置为 `['json']`。
 
 ### lite
 
-lite 模式等同于将 `output.reportCodeType` 设为 `noCode` 或 `noAssetsAndModuleSource`。它会减少构建时保留的数据，有助于缓解大型项目报告加载缓慢或构建 OOM 的问题。
+lite 模式的内部逻辑等同于 `output.reportCodeType` 为 `noCode` 或 `noAssetsAndModuleSource`，主要是为了解决大项目在打开报告时过慢或者构建时 OOM 的问题。
 
-顶层 `mode: 'lite'` 已在 Rsdoctor 2.x 中移除，`features.lite` 也已废弃。请使用 `output.reportCodeType` 明确报告需要保留的代码数据。
+`mode: 'lite'` 已在 Rsdoctor 2.x 中废弃，仅为向后兼容而保留。`output.reportCodeType` 能更清晰地表达需要包含的报告内容。
 
-将原有的 `mode: 'lite'` 或 `features.lite` 替换为 `output.mode: 'normal'`，并将 `output.reportCodeType` 设为 `noCode` 或 `noAssetsAndModuleSource`。
+将 `mode: 'lite'` 或 `features: ['lite']` 替换为 `output.mode: 'normal'`，并将 `output.reportCodeType` 设置为 `noCode` 或 `noAssetsAndModuleSource`。
 
-### 新增 output.options.jsonOptions.section
+### 新增 output.options.jsonOptions.sections
 
-支持新增的 `output.options.jsonOptions.section` 配置，用于更细粒度的 JSON 输出选项定制。具体 sections 配置项参考[output.options.jsonOptions.section](/config/options/output#options)。
+使用 `output.options.jsonOptions.sections` 控制 JSON 输出包含的数据分区。可配置字段请参阅 [output.options.jsonOptions.sections](/config/options/output#options)。

--- a/packages/document/docs/zh/config/options/options-v2.mdx
+++ b/packages/document/docs/zh/config/options/options-v2.mdx
@@ -2,15 +2,16 @@
 
 **Rsdoctor 1.2.4 引入了 Rsdoctor 2.x 使用的 output 配置。** 与旧版配置相比，新配置更易于使用和扩展。
 
-1.2.3 及之前版本的配置项已在 Rsdoctor 2.x 中废弃，仅为向后兼容而保留。请迁移到下表中的替代配置。
+顶层 `mode` 配置已在 Rsdoctor 2.x 中移除且会被忽略。旧版 `brief` 和 `output.compressData` 配置已废弃，仅为向后兼容而保留。请根据下表迁移这些配置。两种 `features` lite 配置仍受支持，下表仅列出其等价的 `output` 配置。
 
-| 原配置                                 | 新配置                                                                                                        |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| mode                                   | 改为配置 `output.mode`。                                                                                      |
-| brief                                  | 改为配置 `output.mode: 'brief'`，并将 `output.options.type` 设置为 `['html']`。                               |
-| output.compressData                    | 改为配置 `output.mode: 'brief'`，并将 `output.options.type` 设置为 `['json']`。                               |
-| `mode: 'lite'` 或 `features: ['lite']` | 改为配置 `output.mode: 'normal'`，并将 `output.reportCodeType` 设置为 `noCode` 或 `noAssetsAndModuleSource`。 |
-| 无                                     | 新增 `output.options.jsonOptions.sections` 配置                                                               |
+| 原配置                                             | 新配置                                                                                                        |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| mode                                               | 改为配置 `output.mode`。                                                                                      |
+| brief                                              | 改为配置 `output.mode: 'brief'`，并将 `output.options.type` 设置为 `['html']`。                               |
+| output.compressData                                | 改为配置 `output.mode: 'brief'`，并将 `output.options.type` 设置为 `['json']`。                               |
+| `mode: 'lite'`                                     | 改为配置 `output.mode: 'normal'`，并将 `output.reportCodeType` 设置为 `noCode` 或 `noAssetsAndModuleSource`。 |
+| `features: { lite: true }` 或 `features: ['lite']` | 仍受支持。等价的 `output` 配置为 `output.mode: 'normal'`，并按上一行设置 `output.reportCodeType`。            |
+| 无                                                 | 新增 `output.options.jsonOptions.sections` 配置                                                               |
 
 ## 配置改动详情
 
@@ -31,9 +32,9 @@
 
 lite 模式的内部逻辑等同于 `output.reportCodeType` 为 `noCode` 或 `noAssetsAndModuleSource`，主要是为了解决大项目在打开报告时过慢或者构建时 OOM 的问题。
 
-`mode: 'lite'` 已在 Rsdoctor 2.x 中废弃，仅为向后兼容而保留。`output.reportCodeType` 能更清晰地表达需要包含的报告内容。
+`mode: 'lite'` 已在 Rsdoctor 2.x 中移除且会被忽略。请将其替换为 `output.mode: 'normal'`，并将 `output.reportCodeType` 设置为 `noCode` 或 `noAssetsAndModuleSource`。
 
-将 `mode: 'lite'` 或 `features: ['lite']` 替换为 `output.mode: 'normal'`，并将 `output.reportCodeType` 设置为 `noCode` 或 `noAssetsAndModuleSource`。
+`features: { lite: true }` 和 `features: ['lite']` 均仍受支持，无需迁移。等价的 `output.reportCodeType` 配置能更清晰地表达需要包含的报告内容。
 
 ### 新增 output.options.jsonOptions.sections
 

--- a/packages/document/docs/zh/config/options/options.mdx
+++ b/packages/document/docs/zh/config/options/options.mdx
@@ -1,34 +1,14 @@
-import { Badge, Tab, Tabs } from '@theme';
-
 # 总览
 
 ## RsdoctorRspackPlugin 插件
 
 `RsdoctorRspackPlugin` 类由 `@rsdoctor/core` 导出，其配置类型为 [RsdoctorRspackPluginOptions](#rsdoctorrspackpluginoptions)。
 
-<Tabs>
-
-<Tab label="esm">
-
 ```ts
 import { RsdoctorRspackPlugin } from '@rsdoctor/core';
 
 new RsdoctorRspackPlugin({/** RsdoctorRspackPluginOptions */});
 ```
-
-</Tab>
-
-<Tab label="cjs">
-
-```js
-const { RsdoctorRspackPlugin } = require('@rsdoctor/core');
-
-new RsdoctorRspackPlugin({/** RsdoctorRspackPluginOptions */});
-```
-
-</Tab>
-
-</Tabs>
 
 ## 配置项
 

--- a/packages/document/docs/zh/config/options/output.mdx
+++ b/packages/document/docs/zh/config/options/output.mdx
@@ -14,7 +14,7 @@ Rsdoctor 报告模式，默认是 `normal`。
 - **brief:** 在构建产物目录的 `.rsdoctor` 文件夹中生成一个 HTML 报告文件，所有构建分析数据会整合注入到这个 HTML 文件中，可以通过浏览器打开该 HTML 文件查看报告。brief 模式还有更多配置项，详细信息请参阅：[mode: 'brief'](#mode-brief)。
 
 :::tip
-mode 是没有 lite 配置项的，lite 模式即将废弃，参考 [lite 模式废弃说明](./options-v2.mdx#lite)。
+`output.mode` 不支持 `lite`。请使用 [output.reportCodeType](#reportcodetype) 控制是否包含源码和产物代码。`features` lite 配置仍受支持。
 :::
 
 ## options

--- a/packages/document/docs/zh/config/options/output.mdx
+++ b/packages/document/docs/zh/config/options/output.mdx
@@ -11,7 +11,7 @@ import { Badge } from '@theme';
 Rsdoctor 报告模式，默认是 `normal`。
 
 - **normal:** 在构建产物目录中生成一个 `.rsdoctor` 文件夹，其中包含各种数据文件，并在报告页面中展示代码。输出目录可以通过 [reportDir](#reportdir) 进行配置。
-- **brief:** 在构建产物目录的 `.rsdoctor` 文件夹中生成一个 HTML 报告文件，所有构建分析数据会整合注入到这个 HTML 文件中，可以通过浏览器打开该 HTML 文件查看报告。brief 模式还有更多配置项，详细信息请参阅：[mode: 'brief'](#mode-brief)。
+- **brief:** 在报告输出目录中生成 `rsdoctor-report.html`。该目录默认为构建产物目录，也可通过 [reportDir](#reportdir) 配置。所有构建分析数据都会注入这个独立 HTML 文件，可以直接在浏览器中打开。更多配置请参阅 [mode: 'brief'](#mode-brief)。
 
 :::tip
 `output.mode` 不支持 `lite`。请使用 [output.reportCodeType](#reportcodetype) 控制是否包含源码和产物代码。`features` lite 配置仍受支持。
@@ -36,7 +36,7 @@ Brief 模式用于生成轻量级的分析报告，支持 HTML 和 JSON 两种�
   - 如果配置了 `['json']`，则会生成一个 json 文件。文件名为 `rsdoctor-data.json`。
   - 如果配置了 `['html']`，则会生成一个 html 文件。文件名可通过 `htmlOptions.reportHtmlName` 配置。
 - **`htmlOptions`**：HTML 输出相关配置
-  - **`reportHtmlName`**：HTML 报告文件名，默认为 `report-rsdoctor.html`
+  - **`reportHtmlName`**：HTML 报告文件名，默认为 `rsdoctor-report.html`
 - **`jsonOptions`**：JSON 输出相关配置
   - **`sections`**：JSON 输出包含的模块配置
     - **`moduleGraph`**：是否包含模块图数据，默认为 `true`
@@ -136,7 +136,7 @@ interface BriefModeOptions {
 }
 
 interface BriefConfig {
-  /** HTML 报告文件名，默认为 report-rsdoctor.html */
+  /** HTML 报告文件名，默认为 rsdoctor-report.html */
   reportHtmlName?: string;
 }
 

--- a/packages/document/docs/zh/guide/start/cicd.mdx
+++ b/packages/document/docs/zh/guide/start/cicd.mdx
@@ -12,12 +12,11 @@ Brief 模式中，会将数据报告整合到一个 HTML 页面中，方便用�
 
 <Badge text="Version: 0.4.0" type="warning" />
 
-将 Rsdoctor 插件的 [output.mode](/config/options/output#mode) 设置为 `'brief'`，即可开启 Brief 模式。Brief 模式会在构建后生成一份报告到构建产物目录中：`[outputDir]/.rsdoctor/report-rsdoctor.html`。通过浏览器打开 HTML 文件，
-即可看到构建分析简报。
+将 Rsdoctor 插件的 [output.mode](/config/options/output#mode) 设置为 `'brief'`，即可开启 Brief 模式。构建后，Brief 模式会在 `[outputDir]/rsdoctor-report.html` 生成报告。如果配置了 [output.reportDir](/config/options/output#reportdir)，报告将改为生成在 `[reportDir]/rsdoctor-report.html`。通过浏览器打开 HTML 文件即可查看构建分析简报。
 
 - Brief 模式下是不展示任何的代码数据的，为了防止数据过大导致页面崩溃。
-- 报告输出的目录和文件名可配置，可参考：[Options](/config/options/brief)。
-- 更多配置可参考：[Options](/config/options/brief)。
+- 使用 [output.reportDir](/config/options/output#reportdir) 配置输出目录，使用 [output.options.htmlOptions.reportHtmlName](/config/options/output#mode-brief) 配置文件名。
+- 更多配置请参阅 [mode: 'brief'](/config/options/output#mode-brief)。
 
 ```ts title="rspack.config.js"
 const { RsdoctorRspackPlugin } = require('@rsdoctor/core');

--- a/packages/document/docs/zh/shared/mode-intro.md
+++ b/packages/document/docs/zh/shared/mode-intro.md
@@ -1,6 +1,6 @@
 - **normal 模式：** 在构建产物目录中生成一个 `.rsdoctor` 文件夹，其中包含各种数据文件，并在报告页面中展示代码。输出目录可以通过 [reportDir](/config/options/output#reportdir) 进行配置。
 
-- **brief 模式：** 在构建产物目录中生成 `rsdoctor-report.html`。所有构建分析数据都会整合并注入这个独立 HTML 文件，可以直接在浏览器中打开。Brief 模式还有更多配置项，详细信息请参阅：[brief](/config/options/brief)。
+- **brief 模式：** 在构建产物目录中生成 `rsdoctor-report.html`。所有构建分析数据都会整合并注入这个独立 HTML 文件，可以直接在浏览器中打开。可用配置项请参阅 [mode: 'brief'](/config/options/output#mode-brief)。
 
 - **lite 模式：** 基于普通模式，不展示源码和产物代码，仅显示打包后的代码信息。
-  - Lite 模式已在 Rsdoctor 2.x 中废弃，仅为向后兼容而保留。请改用 [output.reportCodeType](/config/options/output#reportcodetype)。
+  - 顶层 `mode: 'lite'` 配置已在 Rsdoctor 2.x 中移除且会被忽略。`features` lite 配置仍受支持。新配置请使用 [output.reportCodeType](/config/options/output#reportcodetype)。

--- a/packages/document/docs/zh/shared/mode-intro.md
+++ b/packages/document/docs/zh/shared/mode-intro.md
@@ -1,6 +1,6 @@
 - **normal 模式：** 在构建产物目录中生成一个 `.rsdoctor` 文件夹，其中包含各种数据文件，并在报告页面中展示代码。输出目录可以通过 [reportDir](/config/options/output#reportdir) 进行配置。
 
-- **brief 模式：** 在构建产物目录的 `.rsdoctor` 文件夹中生成一个 HTML 报告文件，所有构建分析数据会整合注入到该文件中，可以直接通过浏览器打开。详细配置请参考 [brief 输出配置](/config/options/output#mode-brief)。
+- **brief 模式：** 在构建产物目录中生成 `rsdoctor-report.html`。所有构建分析数据都会整合并注入这个独立 HTML 文件，可以直接在浏览器中打开。Brief 模式还有更多配置项，详细信息请参阅：[brief](/config/options/brief)。
 
 - **lite 模式：** 基于普通模式，不展示源码和产物代码，仅显示打包后的代码信息。
-  - 顶层 `mode: 'lite'` 已在 Rsdoctor 2.x 中移除，`features.lite` 也已废弃。请使用 [output.reportCodeType](/config/options/output#reportcodetype) 代替。
+  - Lite 模式已在 Rsdoctor 2.x 中废弃，仅为向后兼容而保留。请改用 [output.reportCodeType](/config/options/output#reportcodetype)。

--- a/packages/document/docs/zh/shared/mode-intro.md
+++ b/packages/document/docs/zh/shared/mode-intro.md
@@ -1,6 +1,6 @@
 - **normal 模式：** 在构建产物目录中生成一个 `.rsdoctor` 文件夹，其中包含各种数据文件，并在报告页面中展示代码。输出目录可以通过 [reportDir](/config/options/output#reportdir) 进行配置。
 
-- **brief 模式：** 在构建产物目录中生成 `rsdoctor-report.html`。所有构建分析数据都会整合并注入这个独立 HTML 文件，可以直接在浏览器中打开。可用配置项请参阅 [mode: 'brief'](/config/options/output#mode-brief)。
+- **brief 模式：** 在报告输出目录中生成 `rsdoctor-report.html`。该目录默认为构建产物目录，也可通过 [reportDir](/config/options/output#reportdir) 配置。所有构建分析数据都会注入这个独立 HTML 文件，可以直接在浏览器中打开。可用配置项请参阅 [mode: 'brief'](/config/options/output#mode-brief)。
 
 - **lite 模式：** 基于普通模式，不展示源码和产物代码，仅显示打包后的代码信息。
   - 顶层 `mode: 'lite'` 配置已在 Rsdoctor 2.x 中移除且会被忽略。`features` lite 配置仍受支持。新配置请使用 [output.reportCodeType](/config/options/output#reportcodetype)。


### PR DESCRIPTION
## Summary

Update the bilingual output-option and migration references to describe current Rsdoctor 2.x behavior. Correct brief report defaults and configuration paths such as `output.reportCodeType` and `jsonOptions.sections`, while marking legacy fields as currently deprecated.

## Related Links

None