### PR TITLE
fix(core): skip sourcemap assets without source

### DIFF
--- a/packages/core/src/inner-plugins/plugins/sourcemapTool.ts
+++ b/packages/core/src/inner-plugins/plugins/sourcemapTool.ts
@@ -280,7 +280,7 @@ export async function handleAfterEmitAssets(
             });
           }
 
-          if (sourceMapAsset) {
+          if (sourceMapAsset?.source) {
             map = JSON.parse(sourceMapAsset.source.source().toString());
             const outputPath = compilation.options.output?.path;
             if (outputPath && typeof outputPath === 'string') {

--- a/packages/core/tests/plugins/sourcemapTool.test.ts
+++ b/packages/core/tests/plugins/sourcemapTool.test.ts
@@ -321,6 +321,43 @@ describe('sourcemapTool', () => {
       expect(sourceMap).toBe('console.log("test");');
     });
 
+    it('should skip source map assets without a source', async () => {
+      const plugin = createMockPluginInstance();
+      const compilation = {
+        compiler: { rspack: {} },
+        options: {
+          output: {
+            filename: '[name].[contenthash].js',
+          },
+        },
+        getAssets: () => [
+          {
+            name: 'worker.abc123.js',
+            source: {
+              source: () => 'console.log("worker");\n',
+              name: 'worker.abc123.js',
+              sourceAndMap: () => ({
+                source: 'console.log("worker");\n',
+                map: null,
+              }),
+            },
+            info: {
+              related: {
+                sourceMap: 'worker.abc123.js.map',
+              },
+            },
+          },
+          {
+            name: 'worker.abc123.js.map',
+            info: {},
+          },
+        ],
+      } as any;
+
+      await handleAfterEmitAssets(compilation, plugin);
+      expect(plugin.sourceMapSets.size).toBe(0);
+    });
+
     it('should find source map by base name without hash when exact match fails', async () => {
       const plugin = createMockPluginInstance();
       const compilation = {


### PR DESCRIPTION
## Summary

  - Prevent `handleAfterEmitAssets` from crashing when a related sourcemap asset has no `source`.
  - Add a regression test covering this case.

  ## Problem

Rspack's `compilation.getAssets()` may contain an asset descriptor with `name` and `info`, but without `source`.

This can happen when `worker-rspack-loader` uses `inline: 'no-fallback'` and removes the generated worker sourcemap from `compilation.assets`. Rsdoctor still finds the remaining descriptor through `asset.info.related.sourceMap` and attempts to call:

 ```ts
 sourceMapAsset.source.source()
```

  This causes the build to fail with:

```
TypeError: Cannot read properties of undefined (reading 'source')
```

  The issue was reproduced with:

  - @rsdoctor/core@1.6.1
  - @rspack/core@2.1.2
  - worker-rspack-loader@3.1.2

  ## Solution

Check that the matched sourcemap asset has a source before trying to parse it. Assets without source content are skipped because there is no sourcemap data available to process.

  ## Tests

  - Added a regression test with a related sourcemap descriptor that has no source.
  - Verified that the test fails with the original implementation.
  - Verified:

```
  pnpm --filter @rsdoctor/core exec rstest run tests/plugins/sourcemapTool.test.ts
  pnpm --filter @rsdoctor/core run build
```