### PR TITLE
fix(loader): distinguish pitch and normal loader results

### DIFF
--- a/packages/client/src/components/Loader/executions.tsx
+++ b/packages/client/src/components/Loader/executions.tsx
@@ -339,6 +339,7 @@ export const LoaderExecutions = ({
                       file: resource.path,
                       loader: loader.loader,
                       loaderIndex: loader.loaderIndex,
+                      isPitch: loader.isPitch,
                     }}
                     showSkeleton={false}
                   >

--- a/packages/core/src/sdk/server/apis/loader.ts
+++ b/packages/core/src/sdk/server/apis/loader.ts
@@ -96,12 +96,12 @@ export class LoaderAPI extends BaseAPI {
     SDK.ServerAPI.InferResponseType<SDK.ServerAPI.API.GetLoaderFileInputAndOutput>
   > {
     const { req } = this.ctx;
-    const { file, loader, loaderIndex } =
+    const { file, loader, loaderIndex, isPitch } =
       req.body as SDK.ServerAPI.InferRequestBodyType<SDK.ServerAPI.API.GetLoaderFileInputAndOutput>;
 
     return this.dataLoader.loadAPI(
       SDK.ServerAPI.API.GetLoaderFileInputAndOutput,
-      { file, loader, loaderIndex },
+      { file, loader, loaderIndex, isPitch },
     );
   }
 }

--- a/packages/shared/src/common/data/index.ts
+++ b/packages/shared/src/common/data/index.ts
@@ -146,8 +146,8 @@ export class APIDataLoader {
             params.file,
             params.loader,
             params.loaderIndex,
-            params.isPitch,
             res || [],
+            params.isPitch,
           ) as R;
         });
 

--- a/packages/shared/src/common/data/index.ts
+++ b/packages/shared/src/common/data/index.ts
@@ -146,6 +146,7 @@ export class APIDataLoader {
             params.file,
             params.loader,
             params.loaderIndex,
+            params.isPitch,
             res || [],
           ) as R;
         });

--- a/packages/shared/src/common/loader.ts
+++ b/packages/shared/src/common/loader.ts
@@ -337,6 +337,7 @@ export function getLoaderFileInputAndOutput(
   file: string,
   loader: string,
   loaderIndex: number,
+  isPitch: boolean,
   loaders: SDK.LoaderData,
 ): SDK.ServerAPI.InferResponseType<SDK.ServerAPI.API.GetLoaderFileInputAndOutput> {
   for (let i = 0; i < loaders.length; i++) {
@@ -347,7 +348,8 @@ export function getLoaderFileInputAndOutput(
         const l = item.loaders[j];
         if (
           getLoadrName(l.loader) === loader &&
-          l.loaderIndex === loaderIndex
+          l.loaderIndex === loaderIndex &&
+          l.isPitch === isPitch
         ) {
           return {
             input: l.input || '',

--- a/packages/shared/src/common/loader.ts
+++ b/packages/shared/src/common/loader.ts
@@ -337,8 +337,8 @@ export function getLoaderFileInputAndOutput(
   file: string,
   loader: string,
   loaderIndex: number,
-  isPitch: boolean,
   loaders: SDK.LoaderData,
+  isPitch?: boolean,
 ): SDK.ServerAPI.InferResponseType<SDK.ServerAPI.API.GetLoaderFileInputAndOutput> {
   for (let i = 0; i < loaders.length; i++) {
     const item = loaders[i];
@@ -349,7 +349,7 @@ export function getLoaderFileInputAndOutput(
         if (
           getLoadrName(l.loader) === loader &&
           l.loaderIndex === loaderIndex &&
-          l.isPitch === isPitch
+          (isPitch === undefined || l.isPitch === isPitch)
         ) {
           return {
             input: l.input || '',

--- a/packages/shared/src/types/sdk/server/apis/loader.ts
+++ b/packages/shared/src/types/sdk/server/apis/loader.ts
@@ -60,5 +60,6 @@ export interface LoaderAPIRequestBody {
     file: string;
     loader: string;
     loaderIndex: number;
+    isPitch: boolean;
   };
 }

--- a/packages/shared/src/types/sdk/server/apis/loader.ts
+++ b/packages/shared/src/types/sdk/server/apis/loader.ts
@@ -60,6 +60,6 @@ export interface LoaderAPIRequestBody {
     file: string;
     loader: string;
     loaderIndex: number;
-    isPitch: boolean;
+    isPitch?: boolean;
   };
 }

--- a/packages/shared/tests/common/loader.test.ts
+++ b/packages/shared/tests/common/loader.test.ts
@@ -84,8 +84,8 @@ describe('test src/common/loader.ts', () => {
       '/test/file.js',
       'babel-loader',
       0,
-      false,
       mockLoaderData,
+      false,
     );
 
     expect(result).toBeDefined();
@@ -98,8 +98,8 @@ describe('test src/common/loader.ts', () => {
       '/test/file.js',
       'ts-loader',
       1,
-      false,
       mockLoaderData,
+      false,
     );
 
     expect(result).toBeDefined();
@@ -112,8 +112,8 @@ describe('test src/common/loader.ts', () => {
       '/test/file.js',
       'non-existent-loader',
       0,
-      false,
       mockLoaderData,
+      false,
     );
 
     expect(result.input).toBe('');
@@ -125,8 +125,8 @@ describe('test src/common/loader.ts', () => {
       '/non-existent/file.js',
       'babel-loader',
       0,
-      false,
       mockLoaderData,
+      false,
     );
 
     expect(result.input).toBe('');
@@ -138,21 +138,33 @@ describe('test src/common/loader.ts', () => {
       '/test/file.js',
       'babel-loader',
       0,
-      true,
       mockLoaderData,
+      true,
     );
     const normalResult = Loader.getLoaderFileInputAndOutput(
       '/test/file.js',
       'babel-loader',
       0,
-      false,
       mockLoaderData,
+      false,
     );
 
     expect(pitchResult.input).toBe('');
     expect(pitchResult.output).toBe('pitch result');
     expect(normalResult.input).toBe('const foo = 1;');
     expect(normalResult.output).toBe('var foo = 1;');
+  });
+
+  it('getLoaderFileInputAndOutput should preserve legacy lookup behavior when isPitch is omitted', () => {
+    const result = Loader.getLoaderFileInputAndOutput(
+      '/test/file.js',
+      'babel-loader',
+      0,
+      mockLoaderData,
+    );
+
+    expect(result.input).toBe('');
+    expect(result.output).toBe('pitch result');
   });
 
   it('getLoaderFileDetails should throw error for non-existent file', () => {

--- a/packages/shared/tests/common/loader.test.ts
+++ b/packages/shared/tests/common/loader.test.ts
@@ -16,6 +16,21 @@ describe('test src/common/loader.ts', () => {
           loader: 'babel-loader',
           loaderIndex: 0,
           path: '/node_modules/babel-loader/lib/index.js',
+          input: null,
+          result: 'pitch result',
+          startAt: 900,
+          endAt: 950,
+          options: {},
+          isPitch: true,
+          sync: false,
+          errors: [],
+          pid: 1,
+          ppid: 0,
+        },
+        {
+          loader: 'babel-loader',
+          loaderIndex: 0,
+          path: '/node_modules/babel-loader/lib/index.js',
           input: 'const foo = 1;',
           result: 'var foo = 1;',
           startAt: 1000,
@@ -51,7 +66,7 @@ describe('test src/common/loader.ts', () => {
 
     expect(result).toBeDefined();
     expect(result.resource.path).toBe('/test/file.js');
-    expect(result.loaders).toHaveLength(2);
+    expect(result.loaders).toHaveLength(3);
 
     // Verify that input and result are NOT included
     result.loaders.forEach((loader) => {
@@ -69,6 +84,7 @@ describe('test src/common/loader.ts', () => {
       '/test/file.js',
       'babel-loader',
       0,
+      false,
       mockLoaderData,
     );
 
@@ -82,6 +98,7 @@ describe('test src/common/loader.ts', () => {
       '/test/file.js',
       'ts-loader',
       1,
+      false,
       mockLoaderData,
     );
 
@@ -95,6 +112,7 @@ describe('test src/common/loader.ts', () => {
       '/test/file.js',
       'non-existent-loader',
       0,
+      false,
       mockLoaderData,
     );
 
@@ -107,11 +125,34 @@ describe('test src/common/loader.ts', () => {
       '/non-existent/file.js',
       'babel-loader',
       0,
+      false,
       mockLoaderData,
     );
 
     expect(result.input).toBe('');
     expect(result.output).toBe('');
+  });
+
+  it('getLoaderFileInputAndOutput should distinguish pitch and normal loader executions', () => {
+    const pitchResult = Loader.getLoaderFileInputAndOutput(
+      '/test/file.js',
+      'babel-loader',
+      0,
+      true,
+      mockLoaderData,
+    );
+    const normalResult = Loader.getLoaderFileInputAndOutput(
+      '/test/file.js',
+      'babel-loader',
+      0,
+      false,
+      mockLoaderData,
+    );
+
+    expect(pitchResult.input).toBe('');
+    expect(pitchResult.output).toBe('pitch result');
+    expect(normalResult.input).toBe('const foo = 1;');
+    expect(normalResult.output).toBe('var foo = 1;');
   });
 
   it('getLoaderFileDetails should throw error for non-existent file', () => {


### PR DESCRIPTION
## Summary

- include `isPitch` in the loader input/output API request
- forward `isPitch` through the client, core API, and shared data loader
- match loader executions by `file`, `loader`, `loaderIndex`, and `isPitch`
- add a regression test for pitch and normal executions sharing the same
  loader name and index

This prevents Loader Details from returning an empty pitch result when the
user selects the corresponding normal loader execution.

## Verification

- `packages/shared/tests/common/loader.test.ts`: 7 tests passed
- full workspace build passed
- Prettier and `git diff --check` passed
- verified against a real Next.js report:
  - pitch: input 0, output 0
  - normal SWC: input 3479, output 7053

## Related Links

Closes #1927
 
before the fix:
<img width="2508" height="1346" alt="image" src="https://github.com/user-attachments/assets/c1de75b4-129e-41b9-9d95-bc4213c5ccd6" />

after the fix:
<img width="2561" height="1351" alt="Clipboard_Screenshot_1786950837" src="https://github.com/user-attachments/assets/8e412039-ecaf-4a7a-b273-519174cab2f7" />
