### PR TITLE
chore(deps): update nanoid to 3.3.18

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,7 @@ overrides:
   es-object-atoms: 1.1.2
   get-intrinsic: 1.3.0
   minimatch: ^10.2.6
+  nanoid: 3.3.18
   node-forge: 1.4.0
   qs: 6.15.3
   rc-dialog: 9.1.0
@@ -5015,8 +5016,8 @@ packages:
     engines: {node: ^22 || >= 24}
     hasBin: true
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -11843,7 +11844,7 @@ snapshots:
 
   nano-staged@1.0.2: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.18: {}
 
   needle@3.3.1:
     dependencies:
@@ -12185,7 +12186,7 @@ snapshots:
 
   postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,6 +77,7 @@ overrides:
   es-object-atoms: 1.1.2
   get-intrinsic: 1.3.0
   minimatch: ^10.2.6
+  nanoid: 3.3.18
   node-forge: 1.4.0
   qs: 6.15.3
   rc-dialog: 9.1.0


### PR DESCRIPTION
## Summary

This PR updates the transitive `nanoid` dependency to 3.3.18 to resolve two high-severity infinite-loop denial-of-service advisories while retaining compatibility with PostCSS's 3.x dependency range.

## Related Links

- https://github.com/ai/nanoid/releases/tag/3.3.18
- https://github.com/advisories/GHSA-28wg-ghj8-5hjv
- https://github.com/advisories/GHSA-2v37-7h3g-55p8