### PR TITLE
refactor(core): remove compressData option

### DIFF
--- a/packages/core/src/inner-plugins/utils/config.ts
+++ b/packages/core/src/inner-plugins/utils/config.ts
@@ -19,7 +19,6 @@ function getDefaultOutput() {
     },
     options: undefined,
     reportDir: '',
-    compressData: undefined,
   };
 }
 function getDefaultSupports() {
@@ -121,7 +120,6 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
   )
     ? {
         reportDir: userOutput?.reportDir,
-        compressData: userOutput?.compressData,
         mode: 'brief' as const,
         options: {
           type: ['json'] as Array<'json'>,
@@ -234,15 +232,6 @@ export function normalizeUserConfig<Rules extends Linter.ExtendRuleData[]>(
         typeof multiCompiler === 'object' ? multiCompiler.group : undefined,
     },
   };
-
-  // Add deprecation warning for compressData
-  if (output.compressData !== undefined) {
-    logger.info(
-      chalk.yellow(
-        `The 'compressData' configuration is deprecated in Rsdoctor 2.x.`,
-      ),
-    );
-  }
 
   return res;
 }

--- a/packages/core/tests/build/utils/config.test.ts
+++ b/packages/core/tests/build/utils/config.test.ts
@@ -51,8 +51,6 @@ describe('normalizeUserConfig', () => {
       treeShaking: false,
     });
     expect(result.output.reportCodeType).toBeDefined();
-    // @ts-ignore
-    expect(result.output.compressData).toBe(undefined);
     expect(result.output.mode).toBe('normal');
     expect(result.multiCompiler).toEqual({
       enabled: true,
@@ -70,17 +68,6 @@ describe('normalizeUserConfig', () => {
     expect(
       normalizeUserConfig({ multiCompiler: { group: 'ssr' } }).multiCompiler,
     ).toEqual({ enabled: true, group: 'ssr' });
-  });
-
-  it('should handle compressData configuration correctly', () => {
-    const result = normalizeUserConfig({
-      output: {
-        compressData: true,
-      },
-    });
-
-    // compressData is deprecated and not included in final output
-    expect(result.output).not.toHaveProperty('compressData');
   });
 
   it('should respect custom features array', () => {
@@ -259,38 +246,6 @@ describe('normalizeUserConfig', () => {
       expect(
         consoleOutput.some((output) =>
           output.includes(removedModeWarning('output.mode')),
-        ),
-      ).toBe(false);
-    });
-
-    it('should show warning when using deprecated compressData configuration', () => {
-      normalizeUserConfig({
-        output: {
-          compressData: false,
-        },
-      });
-
-      expect(
-        consoleOutput.some((output) =>
-          output.includes(
-            "The 'compressData' configuration is deprecated in Rsdoctor 2.x.",
-          ),
-        ),
-      ).toBe(true);
-    });
-
-    it('should not show compressData warning when compressData is undefined', () => {
-      normalizeUserConfig({
-        output: {
-          compressData: undefined,
-        },
-      });
-
-      expect(
-        consoleOutput.some((output) =>
-          output.includes(
-            "The 'compressData' configuration is deprecated in Rsdoctor 2.x.",
-          ),
         ),
       ).toBe(false);
     });

--- a/packages/document/docs/en/config/options/options-v2.mdx
+++ b/packages/document/docs/en/config/options/options-v2.mdx
@@ -2,7 +2,7 @@
 
 **Rsdoctor 1.2.4 introduced the output configuration used by Rsdoctor 2.x.** It is easier to configure and extend than the legacy options.
 
-The top-level `mode` option was removed and is ignored in Rsdoctor 2.x. The legacy `brief` and `output.compressData` options are deprecated and retained for backward compatibility. Use the table below to migrate these options. Both forms of the `features` lite configuration remain supported and are included only to show the equivalent `output` configuration.
+The top-level `mode` and legacy `output.compressData` options were removed and are ignored in Rsdoctor 2.x. The legacy `brief` option is deprecated and retained for backward compatibility. Use the table below to migrate these options. Both forms of the `features` lite configuration remain supported and are included only to show the equivalent `output` configuration.
 
 | Original Configuration                             | New Configuration                                                                                                         |
 | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
@@ -26,7 +26,7 @@ Replace the original `brief` configuration with `output.mode: 'brief'` and set `
 
 ### output.compressData
 
-Replace the original `output.compressData` configuration with `output.mode: 'brief'` and set `output.options.type` to `['json']`.
+`output.compressData` was removed and is ignored in Rsdoctor 2.x. Replace it with `output.mode: 'brief'` and set `output.options.type` to `['json']`.
 
 ### lite
 

--- a/packages/document/docs/en/config/options/output.mdx
+++ b/packages/document/docs/en/config/options/output.mdx
@@ -209,11 +209,5 @@ The output directory for Rsdoctor reports. By default, it is the build output di
 ## compressData
 
 :::warning
-Deprecated in V2, please use `output.mode: 'brief'` and `output.options.type: 'json'` instead. Refer to [compressData configuration migration](/config/options/options-v2#outputcompressdata).
+Removed in Rsdoctor 2.x and ignored. Use `output.mode: 'brief'` and set `output.options.type` to `['json']` instead. Refer to [compressData configuration migration](/config/options/options-v2#outputcompressdata).
 :::
-
-- **Type:** `boolean`
-- **Optional:** `true`
-- **Default:** `true`
-
-compressData is used to configure whether to compress the analysis data under `[outputDir]/.rsdoctor`.

--- a/packages/document/docs/en/guide/start/migration-v2.mdx
+++ b/packages/document/docs/en/guide/start/migration-v2.mdx
@@ -68,7 +68,7 @@ Agent CLI reads the data file directly, so MCP-specific options such as server p
 
 ## Configuration migration
 
-Package migration does not automatically update deprecated configuration fields. Follow the [configuration migration guide](/config/options/options-v2) for `mode`, `brief`, `output.compressData`, and related output options.
+Package migration does not automatically update removed or deprecated configuration fields. Follow the [configuration migration guide](/config/options/options-v2) for `mode`, `brief`, `output.compressData`, and related output options.
 
 ## Verify the upgrade
 

--- a/packages/document/docs/zh/config/options/options-v2.mdx
+++ b/packages/document/docs/zh/config/options/options-v2.mdx
@@ -2,7 +2,7 @@
 
 **Rsdoctor 1.2.4 引入了 Rsdoctor 2.x 使用的 output 配置。** 与旧版配置相比，新配置更易于使用和扩展。
 
-顶层 `mode` 配置已在 Rsdoctor 2.x 中移除且会被忽略。旧版 `brief` 和 `output.compressData` 配置已废弃，仅为向后兼容而保留。请根据下表迁移这些配置。两种 `features` lite 配置仍受支持，下表仅列出其等价的 `output` 配置。
+顶层 `mode` 和旧版 `output.compressData` 配置已在 Rsdoctor 2.x 中移除且会被忽略。旧版 `brief` 配置已废弃，仅为向后兼容而保留。请根据下表迁移这些配置。两种 `features` lite 配置仍受支持，下表仅列出其等价的 `output` 配置。
 
 | 原配置                                             | 新配置                                                                                                        |
 | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
@@ -26,7 +26,7 @@
 
 ### output.compressData
 
-将原有的 `output.compressData` 配置替换为 `output.mode: 'brief'`，并将 `output.options.type` 设置为 `['json']`。
+`output.compressData` 已在 Rsdoctor 2.x 中移除且会被忽略。请将其替换为 `output.mode: 'brief'`，并将 `output.options.type` 设置为 `['json']`。
 
 ### lite
 

--- a/packages/document/docs/zh/config/options/output.mdx
+++ b/packages/document/docs/zh/config/options/output.mdx
@@ -141,6 +141,8 @@ interface BriefConfig {
 }
 
 interface JsonOptions {
+  /** JSON stats 文件名，默认为 rsdoctor-data.json */
+  fileName?: string;
   /** JSON 输出包含的模块配置 */
   sections?: JsonSectionOptions;
 }
@@ -206,11 +208,5 @@ Rsdoctor 报告输出目录，默认是构建产物输出目录。
 ## compressData
 
 :::warning
-V2 中即将废弃，请使用 `output.mode: 'brief'` 和 `output.options.type: 'json'` 代替。参考 [compressData 配置迁移](/config/options/options-v2#outputcompressdata)。
+已在 Rsdoctor 2.x 中移除且会被忽略。请使用 `output.mode: 'brief'`，并将 `output.options.type` 设置为 `['json']`。参考 [compressData 配置迁移](/config/options/options-v2#outputcompressdata)。
 :::
-
-- **类型：** `boolean`
-- **可选：** `true`
-- **默认值：** `true`
-
-compressData 用于配置是否将 `[outputDir]/.rsdoctor` 下的分析数据进行压缩处理。

--- a/packages/document/docs/zh/guide/start/migration-v2.mdx
+++ b/packages/document/docs/zh/guide/start/migration-v2.mdx
@@ -68,7 +68,7 @@ Agent CLI 直接读取数据文件，因此不再需要 MCP Server 端口、comp
 
 ## 配置迁移
 
-包迁移不会自动更新已废弃的配置项。`mode`、`brief`、`output.compressData` 以及相关输出选项的迁移方法，请参考[配置迁移说明](/config/options/options-v2)。
+包迁移不会自动更新已移除或废弃的配置项。`mode`、`brief`、`output.compressData` 以及相关输出选项的迁移方法，请参考[配置迁移说明](/config/options/options-v2)。
 
 ## 验证升级结果
 

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -55,13 +55,6 @@ interface OutputBaseConfig {
    * Control the Rsdoctor reporter codes records.
    */
   reportCodeType?: IReportCodeType | undefined | NewReportCodeType;
-  /**
-   * @deprecated
-   * Configure whether to compress data.
-   * @default false
-   *
-   */
-  compressData?: boolean;
 }
 
 // Brief Mode Type

--- a/packages/shared/src/types/plugin/plugin.ts
+++ b/packages/shared/src/types/plugin/plugin.ts
@@ -110,14 +110,6 @@ interface OutputBaseConfig {
    * Control the Rsdoctor reporter codes records.
    */
   reportCodeType?: IReportCodeType | undefined | NewReportCodeType;
-
-  /**
-   * @deprecated
-   * Configure whether to compress data.
-   * @default false
-   *
-   */
-  compressData?: boolean;
 }
 
 export type IReportCodeType = {


### PR DESCRIPTION
## Summary

Rsdoctor 2.x no longer supports the legacy `output.compressData` option, but it remained in public types and normalization code. This PR removes the obsolete API and documents migration to `output.mode: 'brief'` with `output.options.type: ['json']`. It also restores the missing `JsonOptions.fileName` entry in the Chinese documentation.

## Related Links

None