### PR TITLE
refactor: migrate to Rsbuild splitChunks config

### DIFF
--- a/examples/rsbuild-minimal/rsbuild.config.ts
+++ b/examples/rsbuild-minimal/rsbuild.config.ts
@@ -52,23 +52,16 @@ export default defineConfig({
     minify: false,
     filenameHash: false,
   },
-  performance: {
-    chunkSplit: {
-      strategy: 'split-by-experience',
-      override: {
-        cacheGroups: {
-          shared: {
-            test: /[\\/]src[\\/]utils[\\/]shared\.ts$/,
-            name: 'shared',
-            chunks: 'async',
-            priority: 20,
-            reuseExistingChunk: true,
-          },
-        },
+  splitChunks: {
+    preset: 'default',
+    cacheGroups: {
+      shared: {
+        test: /[\\/]src[\\/]utils[\\/]shared\.ts$/,
+        name: 'shared',
+        chunks: 'async',
+        priority: 20,
+        reuseExistingChunk: true,
       },
-    },
-    bundleAnalyze: {
-      generateStatsFile: true,
     },
   },
 });

--- a/packages/client/rsbuild.config.ts
+++ b/packages/client/rsbuild.config.ts
@@ -99,51 +99,50 @@ export default defineConfig(({ env }) => {
 
     performance: {
       buildCache: true,
-      chunkSplit: {
-        strategy: 'custom',
-        splitChunks: {
-          cacheGroups: {
-            monaco: {
-              test: /node_modules\/monaco-editor\/*/,
-              name: 'monaco',
-              chunks: (chunk) => chunk.name === 'index',
-              maxSize: 1000000,
-              minSize: 500000,
-            },
-            react: {
-              test: /node_modules\/react-*/,
-              name: 'react',
-              chunks: 'all',
-            },
-            rc: {
-              test: /node_modules\/rc-*/,
-              name: 'rc',
-              chunks: (chunk) => chunk.name === 'index',
-              maxSize: 1000000,
-              minSize: 500000,
-            },
-            antDesign: {
-              chunks: (chunk) => chunk.name === 'index',
-              name: 'ant-design',
-              test: /node_modules\/antd\//,
-              maxSize: 1000000,
-              minSize: 500000,
-            },
-            antDesignIcons: {
-              name: 'ant-design-icons',
-              test: /node_modules\/@ant-design\/icons/,
-              chunks: (chunk) => chunk.name === 'index',
-              maxSize: 1000000,
-              minSize: 200000,
-            },
-            vender: {
-              chunks: 'all',
-              name: 'vender',
-              test: /node_modules\/(acorn|lodash|i18next|remark-*)/,
-              maxSize: 1000000,
-              minSize: 200000,
-            },
-          },
+    },
+
+    splitChunks: {
+      preset: 'none',
+      cacheGroups: {
+        monaco: {
+          test: /node_modules\/monaco-editor\/*/,
+          name: 'monaco',
+          chunks: (chunk) => chunk.name === 'index',
+          maxSize: 1000000,
+          minSize: 500000,
+        },
+        react: {
+          test: /node_modules\/react-*/,
+          name: 'react',
+          chunks: 'all',
+        },
+        rc: {
+          test: /node_modules\/rc-*/,
+          name: 'rc',
+          chunks: (chunk) => chunk.name === 'index',
+          maxSize: 1000000,
+          minSize: 500000,
+        },
+        antDesign: {
+          chunks: (chunk) => chunk.name === 'index',
+          name: 'ant-design',
+          test: /node_modules\/antd\//,
+          maxSize: 1000000,
+          minSize: 500000,
+        },
+        antDesignIcons: {
+          name: 'ant-design-icons',
+          test: /node_modules\/@ant-design\/icons/,
+          chunks: (chunk) => chunk.name === 'index',
+          maxSize: 1000000,
+          minSize: 200000,
+        },
+        vender: {
+          chunks: 'all',
+          name: 'vender',
+          test: /node_modules\/(acorn|lodash|i18next|remark-*)/,
+          maxSize: 1000000,
+          minSize: 200000,
         },
       },
     },

--- a/packages/document/docs/en/guide/rules/rules.mdx
+++ b/packages/document/docs/en/guide/rules/rules.mdx
@@ -239,21 +239,17 @@ When a module is included in both **initial chunks** and **async chunks**, the s
 
 - **Same module referenced in two ways**: The module is both synchronously `import`ed in the main bundle or entry, and dynamically `import()`ed somewhere else, so the bundler emits it in both initial and async chunks.
 - **A file is both an entry and an async chunk**: For example, a utility module is configured as an entry and also `import()`ed in app code, so it appears in the entry’s initial chunk and in a dynamically loaded async chunk.
-- **splitChunks overlapping with entry**: A path is split into an async chunk via `splitChunks` / `chunkSplit`, but that path is also an entry or a main-bundle dependency, leading to mixed chunk types.
+- **splitChunks overlapping with entry**: A path is split into an async chunk via `splitChunks`, but that path is also an entry or a main-bundle dependency, leading to mixed chunk types.
 
 #### Solutions and recommendations
 
-1. **Use a single import style**  
-   Prefer one way to reference a module: either all synchronous imports (in initial) or all dynamic `import()` (in async). Avoid having the same file both synchronously imported in the main bundle and dynamically imported elsewhere.
+1. **Use a single import style**: Prefer one way to reference a module: either all synchronous imports (in initial) or all dynamic `import()` (in async). Avoid having the same file both synchronously imported in the main bundle and dynamically imported elsewhere.
 
-2. **Review entry vs dynamic loading**  
-   If a file is both an entry and part of an async chunk, either remove one of those usages or treat the file as a shared dependency and extract it into a single shared chunk via build config, so both initial and async chunks reference it instead of duplicating it.
+2. **Review entry vs dynamic loading**: If a file is both an entry and part of an async chunk, either remove one of those usages or treat the file as a shared dependency and extract it into a single shared chunk via build config, so both initial and async chunks reference it instead of duplicating it.
 
-3. **Adjust splitChunks / chunkSplit**  
-   Check rules for that module path in `optimization.splitChunks` (Rspack) or `performance.chunkSplit` (Rsbuild), and avoid the same module being split into both initial and async chunks. Use `chunks: 'async'` or `chunks: 'initial'` where appropriate, or control which chunk type it goes into via `cacheGroups` and `test` / `chunks`.
+3. **Adjust splitChunks**: Check rules for that module path in `optimization.splitChunks` (Rspack) or `splitChunks` (Rsbuild), and avoid the same module being split into both initial and async chunks. Use `chunks: 'async'` or `chunks: 'initial'` where appropriate, or control which chunk type it goes into via `cacheGroups` and `test` / `chunks`.
 
-4. **Trace dependencies**  
-   From the reported module path and chunk list, search the codebase for references to that module, distinguish sync vs dynamic imports, then converge to a single chunk type or extract a common chunk as above.
+4. **Trace dependencies**: From the reported module path and chunk list, search the codebase for references to that module, distinguish sync vs dynamic imports, then converge to a single chunk type or extract a common chunk as above.
 
 #### Configuration
 

--- a/packages/document/docs/zh/guide/rules/rules.mdx
+++ b/packages/document/docs/zh/guide/rules/rules.mdx
@@ -235,21 +235,17 @@ interface Config {
 
 - **同一模块被两种方式引用**：既在主包或 entry 里被同步 `import`，又在某处被动态 `import()` 引用，构建工具会分别打进 initial 与 async chunk。
 - **某文件既作 entry 又作异步 chunk**：例如某工具模块既在配置里被设为 entry，又在业务代码里被 `import()`，会导致该模块同时出现在 entry 产物的 initial chunk 和动态加载的 async chunk 中。
-- **splitChunks 与 entry 重叠**：通过 `splitChunks` / `chunkSplit` 把某路径单独拆成 async chunk，但该路径同时又是 entry 或主包依赖，也会出现混合。
+- **splitChunks 与 entry 重叠**：通过 `splitChunks` 把某路径单独拆成 async chunk，但该路径同时又是 entry 或主包依赖，也会出现混合。
 
 #### 解决方案与建议
 
-1. **统一引用方式**  
-   尽量对同一模块只使用一种引用方式：要么全部同步 import（放进 initial），要么全部动态 `import()`（放进 async）。避免「主包同步引用 + 某处动态引用」同一文件。
+1. **统一引用方式**：尽量对同一模块只使用一种引用方式：要么全部同步 import（放进 initial），要么全部动态 `import()`（放进 async）。避免「主包同步引用 + 某处动态引用」同一文件。
 
-2. **审视 entry 与动态加载**  
-   若某文件既作为 entry 又被打进异步 **chunk**，考虑：去掉其中一种用法；或将该文件只作为公共依赖，通过构建配置抽成单一 shared chunk，由 initial 与 async 共同引用，而不是重复打包。
+2. **审视 entry 与动态加载**：若某文件既作为 entry 又被打进异步 **chunk**，考虑：去掉其中一种用法；或将该文件只作为公共依赖，通过构建配置抽成单一 shared chunk，由 initial 与 async 共同引用，而不是重复打包。
 
-3. **调整 splitChunks / chunkSplit**  
-   检查 `optimization.splitChunks`（Rspack）或 `performance.chunkSplit`（Rsbuild）中对该模块路径的规则，避免同一模块被同时拆到 initial 与 async 两类 chunk。可适当使用 `chunks: 'async'` 或 `chunks: 'initial'` 做区分，或通过 `cacheGroups` 的 `test` 与 `chunks` 控制其只进入一类 chunk。
+3. **调整 splitChunks**：检查 `optimization.splitChunks`（Rspack）或 `splitChunks`（Rsbuild）中对该模块路径的规则，避免同一模块被同时拆到 initial 与 async 两类 chunk。可适当使用 `chunks: 'async'` 或 `chunks: 'initial'` 做区分，或通过 `cacheGroups` 的 `test` 与 `chunks` 控制其只进入一类 chunk。
 
-4. **梳理依赖关系**  
-   根据报告中的模块路径与 chunk 列表，在源码中搜索该模块的引用位置，区分同步与动态引用，再按上述方式收敛为单一 chunk 类型或抽成公共 chunk。
+4. **梳理依赖关系**：根据报告中的模块路径与 chunk 列表，在源码中搜索该模块的引用位置，区分同步与动态引用，再按上述方式收敛为单一 chunk 类型或抽成公共 chunk。
 
 #### 配置
 

--- a/packages/shared/src/types/rule/code/E1006.ts
+++ b/packages/shared/src/types/rule/code/E1006.ts
@@ -21,13 +21,13 @@ In the **Module Mixed Chunks** tab of Bundle Alerts, each entry shows the module
 
 - **Same module referenced in two ways**: The module is both synchronously imported in the main bundle or entry and dynamically \`import()\`ed elsewhere, so the bundler emits it in both initial and async chunks.
 - **A file is both an entry and an async chunk**: e.g. a utility module is configured as an entry and also \`import()\`ed in app code, so it appears in the entry's initial chunk and in a dynamically loaded async chunk.
-- **splitChunks overlapping with entry**: A path is split into an async chunk via \`splitChunks\` / \`chunkSplit\`, but that path is also an entry or a main-bundle dependency, leading to mixed chunk types.
+- **splitChunks overlapping with entry**: A path is split into an async chunk via \`splitChunks\`, but that path is also an entry or a main-bundle dependency, leading to mixed chunk types.
 
 #### General Solution
 
 1. **Use a single import style**: Prefer one way to reference a module—either all synchronous imports (initial) or all dynamic \`import()\` (async). Avoid the same file being both synchronously imported in the main bundle and dynamically imported elsewhere.
 2. **Review entry vs dynamic loading**: If a file is both an entry and part of an async chunk, remove one of those usages or extract it into a single shared chunk via build config so both initial and async chunks reference it instead of duplicating it.
-3. **Adjust splitChunks**: Check rules for that module path in \`optimization.splitChunks\` (Rspack) or \`performance.chunkSplit\` (Rsbuild), and avoid the same module being split into both initial and async chunks. Use \`chunks: 'async'\` or \`chunks: 'initial'\` where appropriate, or control which chunk type it goes into via \`cacheGroups\` and \`test\` / \`chunks\`.
+3. **Adjust splitChunks**: Check rules for that module path in \`optimization.splitChunks\` (Rspack) or \`splitChunks\` (Rsbuild), and avoid the same module being split into both initial and async chunks. Use \`chunks: 'async'\` or \`chunks: 'initial'\` where appropriate, or control which chunk type it goes into via \`cacheGroups\` and \`test\` / \`chunks\`.
 4. **Trace dependencies**: From the reported module path and chunk list, search the codebase for references to that module, distinguish sync vs dynamic imports, then converge to a single chunk type or extract a common chunk.
 `,
 };


### PR DESCRIPTION
## Summary

Rsbuild v2 deprecates `performance.chunkSplit` in favor of the top-level `splitChunks` option. This PR migrates the client and minimal example configs without changing their chunking output, removes the obsolete `bundleAnalyze` example setting, and updates the E1006 guidance in the shared message and bilingual docs.

## Related Links

- https://rsbuild.rs/guide/upgrade/v1-to-v2#migrate-performancechunksplit