### PR TITLE
docs: remove broken README media link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Rsdoctor is committed to being a one-stop, intelligent build analyzer that makes
 
 For webpack projects, continue using Rsdoctor 1.x or migrate to Rspack. See the [migration guide](https://rsdoctor.rs/guide/start/migration-v2) for details.
 
-https://github.com/user-attachments/assets/b8bb4ebf-b823-47bc-91ab-2d74f0057ef7
-
 ## 🔥 Features
 
 - **Compilation Visualization**: Rsdoctor visualizes the compilation behavior and time consumption, making it easy to view build issues.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,8 +19,6 @@ Rsdoctor 致力于成为一站式、智能化的构建分析工具，通过可�
 
 webpack 项目应继续使用 Rsdoctor 1.x，或先迁移到 Rspack。详情请参阅 [迁移指南](https://rsdoctor.rs/zh/guide/start/migration-v2)。
 
-https://github.com/user-attachments/assets/b8bb4ebf-b823-47bc-91ab-2d74f0057ef7
-
 ## 🔥 特性
 
 - **编译可视化**：Rsdoctor 将编译行为及耗时进行可视化展示，方便开发者查看构建问题。


### PR DESCRIPTION
## Summary

- Remove the stale user-attachment URL from the English and Chinese READMEs.
- Keep both README variants aligned; the removed media URL currently returns HTTP 404.

## Related Links

None

## Validation

- `pnpm lint`
- `pnpm exec prettier --check README.md README.zh-CN.md`
- `git diff HEAD^ --check`