### PR TITLE
fix(e2e): stabilize doctor-rspack tests on Windows

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -67,47 +67,52 @@ jobs:
         if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
         run: pnpm run test
 
-  # # ======== e2e ========
-  # e2e-windows:
-  #   runs-on: windows-latest
-  #   strategy:
-  #     matrix:
-  #       node-version: [18.x]
+  # ======== e2e ========
+  e2e-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        node-version: [22.x]
 
-  #   # Steps represent a sequence of tasks that will be executed as part of the job
-  #   steps:
-  #     - name: Git config
-  #       shell: bash
-  #       run: |
-  #         git config --system core.longpaths true
+    steps:
+      - name: Git config
+        shell: bash
+        run: |
+          git config --system core.longpaths true
 
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 10
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 10
 
-  #     - name: Install Pnpm
-  #       run: corepack enable
+      - name: Install Pnpm
+        run: |
+          npm install -g corepack@latest --force
+          corepack enable
 
-  #     - name: Check skip CI
-  #       shell: bash
-  #       run: echo "RESULT=$(node ./scripts/skipCI.js)" >> "$GITHUB_OUTPUT"
-  #       id: skip-ci
+      - name: Check skip CI
+        shell: bash
+        run: echo "RESULT=$(node ./scripts/skipCI.js)" >> "$GITHUB_OUTPUT"
+        id: skip-ci
 
-  #     - name: Log skip CI result
-  #       run: echo "${{steps.skip-ci.outputs.RESULT}}"
+      - name: Log skip CI result
+        run: echo "${{steps.skip-ci.outputs.RESULT}}"
 
-  #     - name: Setup Node.js ${{ matrix.node-version }}
-  #       if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'pnpm'
+      - name: Setup Node.js ${{ matrix.node-version }}
+        if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
 
-  #     - name: Install Dependencies
-  #       if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
-  #       run: pnpm install && cd ./e2e && npx playwright install
+      - name: Install Dependencies
+        if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
+        run: pnpm install
 
-  #     - name: E2E Test
-  #       if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
-  #       run: pnpm run e2e
+      - name: Install Playwright Browsers
+        if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
+        run: pnpm --dir e2e exec playwright install chromium
+
+      - name: E2E Test
+        if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
+        run: pnpm run e2e

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -67,52 +67,47 @@ jobs:
         if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
         run: pnpm run test
 
-  # ======== e2e ========
-  e2e-windows:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        node-version: [22.x]
+  # # ======== e2e ========
+  # e2e-windows:
+  #   runs-on: windows-latest
+  #   strategy:
+  #     matrix:
+  #       node-version: [18.x]
 
-    steps:
-      - name: Git config
-        shell: bash
-        run: |
-          git config --system core.longpaths true
+  #   # Steps represent a sequence of tasks that will be executed as part of the job
+  #   steps:
+  #     - name: Git config
+  #       shell: bash
+  #       run: |
+  #         git config --system core.longpaths true
 
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 10
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 10
 
-      - name: Install Pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
+  #     - name: Install Pnpm
+  #       run: corepack enable
 
-      - name: Check skip CI
-        shell: bash
-        run: echo "RESULT=$(node ./scripts/skipCI.js)" >> "$GITHUB_OUTPUT"
-        id: skip-ci
+  #     - name: Check skip CI
+  #       shell: bash
+  #       run: echo "RESULT=$(node ./scripts/skipCI.js)" >> "$GITHUB_OUTPUT"
+  #       id: skip-ci
 
-      - name: Log skip CI result
-        run: echo "${{steps.skip-ci.outputs.RESULT}}"
+  #     - name: Log skip CI result
+  #       run: echo "${{steps.skip-ci.outputs.RESULT}}"
 
-      - name: Setup Node.js ${{ matrix.node-version }}
-        if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
+  #     - name: Setup Node.js ${{ matrix.node-version }}
+  #       if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: 'pnpm'
 
-      - name: Install Dependencies
-        if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
-        run: pnpm install
+  #     - name: Install Dependencies
+  #       if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
+  #       run: pnpm install && cd ./e2e && npx playwright install
 
-      - name: Install Playwright Browsers
-        if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
-        run: pnpm --dir e2e exec playwright install chromium
-
-      - name: E2E Test
-        if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
-        run: pnpm run e2e
+  #     - name: E2E Test
+  #       if: ${{steps.skip-ci.outputs.RESULT != 'true'}}
+  #       run: pnpm run e2e

--- a/e2e/cases/doctor-rspack/brief.test.ts
+++ b/e2e/cases/doctor-rspack/brief.test.ts
@@ -78,24 +78,15 @@ test('rspack brief mode', async ({ page }) => {
 
   const titleContent = 'Bundle Overall';
 
-  const bundleTitleExists = await page
-    .locator(`text=${titleContent}`)
-    .first()
-    .isVisible();
-
-  const compileTabExists = await page
-    .locator(`text='Compile Analysis'`)
-    .first()
-    .isVisible();
-
-  const bundleTabExists = await page
-    .locator(`text='Bundle Size'`)
-    .first()
-    .isVisible();
-
-  expect(bundleTitleExists).toBe(true);
-  expect(compileTabExists).toBe(true);
-  expect(bundleTabExists).toBe(true);
+  await expect(page.locator(`text=${titleContent}`).first()).toBeVisible({
+    timeout: 10000,
+  });
+  await expect(page.locator(`text='Compile Analysis'`).first()).toBeVisible({
+    timeout: 10000,
+  });
+  await expect(page.locator(`text='Bundle Size'`).first()).toBeVisible({
+    timeout: 10000,
+  });
 });
 
 function fileExists(filePath: string) {

--- a/e2e/cases/doctor-rspack/plugin.test.ts
+++ b/e2e/cases/doctor-rspack/plugin.test.ts
@@ -2,7 +2,6 @@ import { expect, test } from '@test-kit/rstest';
 import { compileByRspack } from '@scripts/test-helper';
 import { Compiler } from '@rspack/core';
 import * as core from '@actions/core';
-import os from 'os';
 import path from 'path';
 import { createRsdoctorPlugin } from './test-utils';
 
@@ -126,19 +125,11 @@ test('rspack data store', async () => {
     `graphData.modules[0].identifier: ${graphData.modules[0].identifier}`,
   );
 
-  if (os.EOL === '\n') {
-    expect(
-      graphData.modules[0].identifier.indexOf('/fixtures/'),
-    ).toBeGreaterThan(0);
-  } else {
-    expect(
-      graphData.modules[0].identifier.indexOf('\\fixtures\\'),
-    ).toBeGreaterThan(0);
-  }
+  expect(graphData.modules[0].identifier).toMatch(/[\\/]fixtures[\\/]/);
 
   graphData.modules.forEach((mod) => (mod.identifier = ''));
   expect(graphData.modules[0].size.sourceSize).toBeGreaterThan(0);
-  expect(graphData.modules[0].path).toMatch('/fixtures/');
+  expect(graphData.modules[0].path).toMatch(/[\\/]fixtures[\\/]/);
 
   // TODO: Change report Rspack config to afterPlugin hook, this should be reWrite
   // @ts-ignore

--- a/e2e/cases/doctor-rspack/uploader.test.ts
+++ b/e2e/cases/doctor-rspack/uploader.test.ts
@@ -119,7 +119,7 @@ test.describe.skipIf(!compileByRspack)('Uploader Integration Tests', () => {
 
     try {
       const navigationPromise = page.waitForURL(/.*#\/overall.*/, {
-        timeout: 2000,
+        timeout: 10000,
       });
 
       // Use Playwright's file upload method
@@ -178,39 +178,11 @@ test.describe.skipIf(!compileByRspack)('Uploader Integration Tests', () => {
       manifestData.clientRoutes &&
       manifestData.clientRoutes.includes('Overall')
     ) {
-      // Wait for the page to fully load and render
-      await page.waitForTimeout(2000);
-
-      // Try multiple possible selectors for the Bundle Overall menu
-      const possibleSelectors = [
-        "text='Bundle Overall'",
-        "[data-testid='bundle-overall']",
-        "text='Overall'",
-        ".ant-menu-item:has-text('Bundle Overall')",
-        ".ant-menu-item:has-text('Overall')",
-      ];
-
-      let found = false;
-      for (const selector of possibleSelectors) {
-        try {
-          const element = page.locator(selector).first();
-          await expect(element).toBeVisible({ timeout: 3000 });
-          found = true;
-          break;
-        } catch {
-          // Continue to next selector
-          console.log(`Selector "${selector}" not found, trying next...`);
-        }
-      }
-
-      if (!found) {
-        // If none of the selectors work, log the page content for debugging
-        const pageContent = await page.content();
-        console.log('Page content:', pageContent.substring(0, 1000));
-        throw new Error(
-          'Could not find Bundle Overall menu item with any selector',
-        );
-      }
+      await page.waitForFunction(
+        () => document.body.innerText.includes('Overall'),
+        undefined,
+        { timeout: 10000 },
+      );
     }
   });
 


### PR DESCRIPTION
## Summary

- make fixture path assertions work with both POSIX and Windows separators
- wait for the brief report UI to become visible before asserting navigation items
- make uploader navigation and menu rendering waits tolerant of slower Windows startup

Fixes #1943

## Validation

- `pnpm lint`
- `pnpm run e2e:base cases/doctor-rspack` (13/13 passed)