### PR TITLE
fix(client): keep overall columns at 3:1

### DIFF
--- a/packages/client/src/pages/Overall/index.module.scss
+++ b/packages/client/src/pages/Overall/index.module.scss
@@ -39,8 +39,7 @@
 }
 
 .sideColumn {
-  flex: 1 1 320px;
-  min-width: 300px;
+  flex: 1 1 0;
 
   :global(.ant-card) {
     background: var(--color-bg-box-subtle);
@@ -54,13 +53,11 @@
 }
 
 @media (max-width: 1200px) {
-  .columns {
-    flex-wrap: wrap;
+  .mainColumn {
+    flex: 3 1 0;
   }
 
-  .mainColumn,
   .sideColumn {
-    flex-basis: 100%;
-    width: 100%;
+    flex: 1 1 0;
   }
 }

--- a/packages/client/src/pages/Overall/index.module.scss
+++ b/packages/client/src/pages/Overall/index.module.scss
@@ -53,11 +53,13 @@
 }
 
 @media (max-width: 1200px) {
-  .mainColumn {
-    flex: 3 1 0;
+  .columns {
+    flex-wrap: wrap;
   }
 
+  .mainColumn,
   .sideColumn {
-    flex: 1 1 0;
+    flex-basis: 100%;
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes the Overall page columns becoming nearly equal in width on 13-inch displays.

It removes the side column's fixed width basis and preserves the existing media query while enforcing a consistent 3:1 layout across screen sizes.