### PR TITLE
docs: move LLMs UI to page outline

### DIFF
--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -157,6 +157,9 @@ export default defineConfig({
   },
   globalStyles: path.join(__dirname, 'theme', 'index.css'),
   themeConfig: {
+    llmsUI: {
+      placement: 'outline',
+    },
     footer: {
       message: 'Copyright © ByteDance',
     },


### PR DESCRIPTION
## Summary

This PR moves the LLMs UI actions into the documentation page outline so they stay accessible alongside page navigation. It sets `themeConfig.llmsUI.placement` to `outline`.

## Related Links

https://github.com/rstackjs/rstack-cli/pull/414