### PR TITLE
chore(deps): migrate to @rstackjs/doc-ui v1.14.9

### DIFF
--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -47,7 +47,7 @@
     "@rsdoctor/shared": "workspace:*"
   },
   "dependencies": {
-    "@rstack-dev/doc-ui": "1.14.8",
+    "@rstackjs/doc-ui": "1.14.9",
     "clsx": "catalog:",
     "react-markdown": "catalog:",
     "@rspress/core": "2.0.19"

--- a/packages/document/theme/components/Features.tsx
+++ b/packages/document/theme/components/Features.tsx
@@ -1,7 +1,7 @@
 import {
   containerStyle,
   innerContainerStyle,
-} from '@rstack-dev/doc-ui/section-style';
+} from '@rstackjs/doc-ui/section-style';
 import { useI18n } from '@rspress/core/runtime';
 import { HomeFeature } from '@rspress/core/theme-original';
 import './Features.module.scss';

--- a/packages/document/theme/components/Hero.tsx
+++ b/packages/document/theme/components/Hero.tsx
@@ -1,4 +1,4 @@
-import { Hero as BaseHero } from '@rstack-dev/doc-ui/hero';
+import { Hero as BaseHero } from '@rstackjs/doc-ui/hero';
 import { useI18n, useNavigate } from '@rspress/core/runtime';
 import { useI18nUrl } from './utils';
 import './Hero.module.scss';

--- a/packages/document/theme/components/ToolStack.tsx
+++ b/packages/document/theme/components/ToolStack.tsx
@@ -1,5 +1,5 @@
-import { containerStyle } from '@rstack-dev/doc-ui/section-style';
-import { ToolStack as BaseToolStack } from '@rstack-dev/doc-ui/tool-stack';
+import { containerStyle } from '@rstackjs/doc-ui/section-style';
+import { ToolStack as BaseToolStack } from '@rstackjs/doc-ui/tool-stack';
 import { useLang } from '@rspress/core/runtime';
 
 export function ToolStack() {

--- a/packages/document/theme/index.css
+++ b/packages/document/theme/index.css
@@ -1,15 +1,5 @@
 :root {
-  --rp-c-brand: #ff5e00;
-  --rp-c-brand-dark: #ff704d;
-  --rp-c-brand-darker: #ff704d;
-  --rp-c-brand-light: #ff7524;
-  --rp-c-brand-lighter: #ff7524;
   --rp-c-link: var(--rp-c-brand);
-  --rp-c-brand-tint: rgba(255, 94, 0, 0.07);
-}
-
-.dark {
-  --rp-c-link: var(--rp-c-brand-light);
 }
 
 button:focus,

--- a/packages/document/theme/index.tsx
+++ b/packages/document/theme/index.tsx
@@ -1,11 +1,12 @@
 import { Layout as BaseLayout } from '@rspress/core/theme-original';
-import { NavIcon } from '@rstack-dev/doc-ui/nav-icon';
+import { NavIcon } from '@rstackjs/doc-ui/nav-icon';
 import { HomeLayout } from './pages';
 import {
   Search as PluginAlgoliaSearch,
   ZH_LOCALES,
 } from '@rspress/plugin-algolia/runtime';
 import { useLang } from '@rspress/core/runtime';
+import '@rstackjs/doc-ui/theme.css';
 
 const Layout = () => <BaseLayout beforeNavTitle={<NavIcon />} />;
 

--- a/packages/document/theme/pages/index.tsx
+++ b/packages/document/theme/pages/index.tsx
@@ -1,4 +1,4 @@
-import { BackgroundImage } from '@rstack-dev/doc-ui/background-image';
+import { BackgroundImage } from '@rstackjs/doc-ui/background-image';
 import { CopyRight } from '../components/Copyright';
 import { Hero } from '../components/Hero';
 import { Features } from '../components/Features';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -751,9 +751,9 @@ importers:
       '@rspress/core':
         specifier: 2.0.19
         version: 2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.1)(micromark@4.0.1)
-      '@rstack-dev/doc-ui':
-        specifier: 1.14.8
-        version: 1.14.8(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.1)(micromark@4.0.1))
+      '@rstackjs/doc-ui':
+        specifier: 1.14.9
+        version: 1.14.9(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.1)(micromark@4.0.1))
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -2891,8 +2891,8 @@ packages:
   '@rspress/shared@2.0.19':
     resolution: {integrity: sha512-INrETllWuR49lksqCz+xeLSO6rKtHA+5Ix2YQWcP9nerCuTSyGYwH8eBC0HrIacJkGHxB8wkkbV99tyzGtY8Wg==}
 
-  '@rstack-dev/doc-ui@1.14.8':
-    resolution: {integrity: sha512-CAibkpvCnJEcxsypu3ZE9JjtQw+1+iJGv9X09Yg4//9FevHpfaHW+b2onFG+Z/xOlUXGg83rJTb7CO6YbToP0w==}
+  '@rstackjs/doc-ui@1.14.9':
+    resolution: {integrity: sha512-Te7Wx4K9JuvluP7HsH/Dpdju5QhClUe17/9YBzHlul+x2wg63jOkngv79DlMXyYDJgHQ+11vZfz18B+bnPhttw==}
     peerDependencies:
       '@rspress/core': '>=2.0.0'
     peerDependenciesMeta:
@@ -9231,7 +9231,7 @@ snapshots:
       - core-js
       - supports-color
 
-  '@rstack-dev/doc-ui@1.14.8(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.1)(micromark@4.0.1))':
+  '@rstackjs/doc-ui@1.14.9(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.1)(micromark@4.0.1))':
     optionalDependencies:
       '@rspress/core': 2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.1)(micromark@4.0.1)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,6 +65,7 @@ minimumReleaseAgeExclude:
   - '@rstest/*'
   - '@rsdoctor/*'
   - '@rslint/*'
+  - '@rstackjs/*'
   - 'rsbuild-plugin-dts'
   # Renovate security update: ws@8.21.0
   - ws@8.21.0


### PR DESCRIPTION
## Summary

`@rstackjs/doc-ui` replaces the old `@rstack-dev/doc-ui` package and now provides shared Rspress theme styles. This PR migrates the Rsdoctor website to v1.14.9, loads the shared `theme.css`, and keeps only Rsdoctor-specific theme overrides locally.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/8382
- https://github.com/rstackjs/rstack-doc-ui/releases/tag/v1.14.9