### PR TITLE
docs: update banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <picture>
-  <img alt="Rsdoctor Banner" width="100%" src="https://github.com/web-infra-dev/rsdoctor/assets/7237365/0f9d2e86-d919-451a-befa-fa84603a87cf" />
+  <img alt="Rsdoctor Banner" width="100%" src="https://assets.rspack.rs/rsdoctor/rsdoctor-banner.png" />
 </picture>
 
 # Rsdoctor

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,5 @@
 <picture>
-  <img alt="Rsdoctor Banner" width="100%" src="https://github.com/web-infra-dev/rsdoctor/assets/7237365/0f9d2e86-d919-451a-befa-fa84603a87cf" />
+  <img alt="Rsdoctor Banner" width="100%" src="https://assets.rspack.rs/rsdoctor/rsdoctor-banner.png" />
 </picture>
 
 # Rsdoctor

--- a/packages/document/docs/en/blog/release/release-note-0_1.mdx
+++ b/packages/document/docs/en/blog/release/release-note-0_1.mdx
@@ -9,7 +9,7 @@ _January 24, 2024_
 <picture>
   <img
     alt="Rsdoctor Banner"
-    src="https://github.com/web-infra-dev/rsdoctor/assets/7237365/0f9d2e86-d919-451a-befa-fa84603a87cf"
+    src="https://assets.rspack.rs/rsdoctor/rsdoctor-banner.png"
     style={{ margin: 'auto' }}
   />
 </picture>

--- a/packages/document/docs/zh/blog/release/release-note-0_1.mdx
+++ b/packages/document/docs/zh/blog/release/release-note-0_1.mdx
@@ -9,7 +9,7 @@ _January 24, 2024_
 <picture>
   <img
     alt="Rsdoctor Banner"
-    src="https://github.com/web-infra-dev/rsdoctor/assets/7237365/0f9d2e86-d919-451a-befa-fa84603a87cf"
+    src="https://assets.rspack.rs/rsdoctor/rsdoctor-banner.png"
     style={{ margin: 'auto' }}
   />
 </picture>

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -47,7 +47,7 @@
     "@rsdoctor/shared": "workspace:*"
   },
   "dependencies": {
-    "@rstackjs/doc-ui": "1.14.9",
+    "@rstackjs/doc-ui": "1.14.11",
     "clsx": "catalog:",
     "react-markdown": "catalog:",
     "@rspress/core": "2.0.19"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -752,8 +752,8 @@ importers:
         specifier: 2.0.19
         version: 2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.1)(micromark@4.0.1)
       '@rstackjs/doc-ui':
-        specifier: 1.14.9
-        version: 1.14.9(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.1)(micromark@4.0.1))
+        specifier: 1.14.11
+        version: 1.14.11(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.1)(micromark@4.0.1))
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -2891,8 +2891,8 @@ packages:
   '@rspress/shared@2.0.19':
     resolution: {integrity: sha512-INrETllWuR49lksqCz+xeLSO6rKtHA+5Ix2YQWcP9nerCuTSyGYwH8eBC0HrIacJkGHxB8wkkbV99tyzGtY8Wg==}
 
-  '@rstackjs/doc-ui@1.14.9':
-    resolution: {integrity: sha512-Te7Wx4K9JuvluP7HsH/Dpdju5QhClUe17/9YBzHlul+x2wg63jOkngv79DlMXyYDJgHQ+11vZfz18B+bnPhttw==}
+  '@rstackjs/doc-ui@1.14.11':
+    resolution: {integrity: sha512-VJ7trL69YzClO/zFPIgKu3l6b9pvKcUIurniWyirH5JcELqKcmlH7RAI6esfnJglHFqk7xONyqKa7bqsnBCruA==}
     peerDependencies:
       '@rspress/core': '>=2.0.0'
     peerDependenciesMeta:
@@ -9231,7 +9231,7 @@ snapshots:
       - core-js
       - supports-color
 
-  '@rstackjs/doc-ui@1.14.9(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.1)(micromark@4.0.1))':
+  '@rstackjs/doc-ui@1.14.11(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.1)(micromark@4.0.1))':
     optionalDependencies:
       '@rspress/core': 2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.1)(micromark@4.0.1)
 


### PR DESCRIPTION
## Summary

This PR updates `@rstackjs/doc-ui` to v1.14.11 to keep the documentation UI on the latest patch release.
It also moves shared Rsdoctor banner references from GitHub-hosted media to the stable Rspack asset host.

## Related Links

https://github.com/rstackjs/rstack-doc-ui/releases/tag/v1.14.11