### PR TITLE
chore: modernize Rsbuild minimal example

### DIFF
--- a/examples/rsbuild-minimal/package.json
+++ b/examples/rsbuild-minimal/package.json
@@ -2,20 +2,13 @@
   "name": "@examples/doctor-rsbuild-minimal",
   "version": "0.0.1",
   "private": true,
-  "description": "",
-  "files": [
-    "dist",
-    "src",
-    "package.json"
-  ],
+  "type": "module",
   "scripts": {
-    "start:analysis": "ENABLE_CLIENT_SERVER=true rsbuild dev",
+    "start:analysis": "ENABLE_CLIENT_SERVER=true rsbuild",
     "build:analysis": "ENABLE_CLIENT_SERVER=true rsbuild build",
     "build": "rsbuild build",
-    "start": "rsbuild dev"
+    "start": "rsbuild"
   },
-  "author": "",
-  "license": "MIT",
   "dependencies": {
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/examples/rsbuild-minimal/rsbuild.config.ts
+++ b/examples/rsbuild-minimal/rsbuild.config.ts
@@ -5,7 +5,6 @@ import { AssetsCountLimit } from './rules/assets-count-limit';
 
 export default defineConfig({
   source: {
-    include: ['src/**/*.ts', 'src/**/*.tsx'],
     entry: {
       index: './src/index.tsx',
       shared: './src/utils/shared.ts',
@@ -13,9 +12,9 @@ export default defineConfig({
   },
   plugins: [pluginReact()],
   tools: {
-    bundlerChain: (chain) => {
-      chain.plugin('Rsdoctor').use(RsdoctorRspackPlugin, [
-        {
+    rspack: {
+      plugins: [
+        new RsdoctorRspackPlugin({
           disableClientServer: !process.env.ENABLE_CLIENT_SERVER,
           features: ['resolver', 'bundle', 'plugins', 'loader'],
           // output: {
@@ -44,8 +43,8 @@ export default defineConfig({
             },
           },
           port: 9988,
-        },
-      ]);
+        }),
+      ],
     },
   },
   output: {


### PR DESCRIPTION
## Summary

This PR modernizes the minimal Rsbuild example to match the current Rsbuild CLI and Rspack configuration APIs.
It marks the package as ESM, removes redundant metadata and source inclusion, and registers Rsdoctor through `tools.rspack.plugins`.

## Related Links

None