### PR TITLE
chore: use Rstack check and sort package.json

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --ignore-scripts
 
-      - name: Lint
-        run: pnpm run lint
+      - name: Check
+        run: pnpm run check
 
       - name: Agent CLI Type Check
         run: pnpm --filter @rsdoctor/agent-cli run type-check

--- a/e2e/cases/doctor-rspack/fixtures/loaders/esm/package.json
+++ b/e2e/cases/doctor-rspack/fixtures/loaders/esm/package.json
@@ -1,6 +1,6 @@
 {
-  "private": true,
   "name": "@test/rsdoctor-rspack",
   "version": "0.1.0",
+  "private": true,
   "type": "module"
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,7 +1,7 @@
 {
-  "private": true,
   "name": "@rsdoctor/e2e",
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "test": "rstest run",
     "test:local": "npx playwright install chromium && rstest run"
@@ -10,13 +10,13 @@
     "@actions/core": "^1.11.1",
     "@lynx-js/react": "^0.125.0",
     "@lynx-js/rspeedy": "^0.16.5",
-    "@rstest/core": "catalog:",
-    "@rstest/playwright": "catalog:",
     "@rsbuild/plugin-less": "catalog:",
     "@rsdoctor/cli": "workspace:*",
     "@rsdoctor/core": "workspace:*",
     "@rsdoctor/shared": "workspace:*",
     "@rspack/core": "catalog:",
+    "@rstest/core": "catalog:",
+    "@rstest/playwright": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "loader-utils": "^2.0.4",

--- a/examples/rsbuild-minimal/package.json
+++ b/examples/rsbuild-minimal/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start:analysis": "ENABLE_CLIENT_SERVER=true rsbuild",
-    "build:analysis": "ENABLE_CLIENT_SERVER=true rsbuild build",
     "build": "rsbuild build",
-    "start": "rsbuild"
+    "build:analysis": "ENABLE_CLIENT_SERVER=true rsbuild build",
+    "start": "rsbuild",
+    "start:analysis": "ENABLE_CLIENT_SERVER=true rsbuild"
   },
   "dependencies": {
     "react": "catalog:",

--- a/examples/rspack-banner-minimal/package.json
+++ b/examples/rspack-banner-minimal/package.json
@@ -3,9 +3,21 @@
   "version": "0.1.1",
   "private": true,
   "scripts": {
-    "dev": "cross-env ENABLE_CLIENT_SERVER=true NODE_ENV=development rspack serve -c ./rspack.config.mjs",
     "build": "cross-env ENABLE_CLIENT_SERVER=false NODE_ENV=production rspack build -c ./rspack.config.mjs",
-    "build:analysis": "cross-env ENABLE_CLIENT_SERVER=true NODE_ENV=production rspack build -c ./rspack.config.mjs"
+    "build:analysis": "cross-env ENABLE_CLIENT_SERVER=true NODE_ENV=production rspack build -c ./rspack.config.mjs",
+    "dev": "cross-env ENABLE_CLIENT_SERVER=true NODE_ENV=development rspack serve -c ./rspack.config.mjs"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   },
   "dependencies": {
     "@arco-design/web-react": "^2.58.3",
@@ -25,17 +37,5 @@
     "@types/react-dom": "catalog:",
     "react-refresh": "^0.14.0",
     "web-vitals": "^2.1.4"
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
   }
 }

--- a/examples/rspack-layers-minimal/package.json
+++ b/examples/rspack-layers-minimal/package.json
@@ -3,8 +3,20 @@
   "version": "0.1.1",
   "private": true,
   "scripts": {
-    "dev": "ENABLE_CLIENT_SERVER=true NODE_ENV=development rspack serve -c ./rspack.config.mjs",
-    "build": "ENABLE_CLIENT_SERVER=false NODE_ENV=production rspack build -c ./rspack.config.mjs"
+    "build": "ENABLE_CLIENT_SERVER=false NODE_ENV=production rspack build -c ./rspack.config.mjs",
+    "dev": "ENABLE_CLIENT_SERVER=true NODE_ENV=development rspack serve -c ./rspack.config.mjs"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   },
   "dependencies": {
     "@arco-design/web-react": "^2.58.3",
@@ -24,17 +36,5 @@
     "@types/react-dom": "catalog:",
     "react-refresh": "^0.14.0",
     "web-vitals": "^2.1.4"
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
   }
 }

--- a/examples/rspack-minimal/package.json
+++ b/examples/rspack-minimal/package.json
@@ -3,11 +3,23 @@
   "version": "0.1.1",
   "private": true,
   "scripts": {
-    "dev": "ENABLE_CLIENT_SERVER=true NODE_ENV=development rspack serve -c ./rspack.config.mjs",
-    "build:s": "ENABLE_CLIENT_SERVER=false NODE_ENV=production rspack build -c ./rspack.config.mjs",
+    "build": "npm run build:s && npm run build:m",
     "build:analysis": "ENABLE_CLIENT_SERVER=true NODE_ENV=production rspack build -c ./rspack.config.mjs",
     "build:m": "ENABLE_CLIENT_SERVER=false NODE_ENV=production tsx build.ts",
-    "build": "npm run build:s && npm run build:m"
+    "build:s": "ENABLE_CLIENT_SERVER=false NODE_ENV=production rspack build -c ./rspack.config.mjs",
+    "dev": "ENABLE_CLIENT_SERVER=true NODE_ENV=development rspack serve -c ./rspack.config.mjs"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   },
   "dependencies": {
     "@arco-design/web-react": "^2.58.3",
@@ -28,17 +40,5 @@
     "react-refresh": "^0.14.0",
     "tsx": "^4.19.3",
     "web-vitals": "^2.1.4"
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   },
   "scripts": {
     "build": "pnpm --workspace-concurrency=10 --filter \"./packages/*\" --filter \"!./packages/document\" --filter \"./scripts/*\" run build",
-    "check-spell": "pnpx cspell && heading-case",
+    "check": "rs check",
     "check-dependency-version": "pnpx check-dependency-version-consistency . && echo",
+    "check-spell": "pnpx cspell && heading-case",
     "dev:doc": "cd packages/document && pnpm run dev",
     "e2e": "pnpm run e2e:base",
     "e2e:base": "cd ./e2e && cross-env NODE_OPTIONS=--max-old-space-size=8192 pnpm test",
@@ -18,7 +19,6 @@
     "prepare": "pnpm run build && rs hooks",
     "test": "cross-env NODE_OPTIONS=--max-old-space-size=8192 pnpm run ut",
     "test:all": "pnpm run test && pnpm run e2e",
-    "sort-package-json": "npx sort-package-json \"packages/*/package.json\"",
     "ut": "rstest run",
     "ut:watch": "rstest"
   },

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -7,19 +7,16 @@
     "directory": "packages/agent-cli"
   },
   "license": "MIT",
-  "engines": {
-    "node": ">=22.18.0"
-  },
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "rsdoctor-agent": "./bin/rsdoctor-agent.js"
+  },
   "files": [
     "dist",
     "bin"
   ],
-  "bin": {
-    "rsdoctor-agent": "./bin/rsdoctor-agent.js"
-  },
-  "type": "module",
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
@@ -33,6 +30,9 @@
     "@types/node": "catalog:",
     "cac": "^7.0.0",
     "typescript": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.18.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,6 +6,16 @@
     "url": "https://github.com/web-infra-dev/rsdoctor",
     "directory": "packages/cli"
   },
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "bin": {
     "rsdoctor": "./bin/rsdoctor"
   },
@@ -13,25 +23,12 @@
     "bin",
     "dist"
   ],
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    }
-  },
-  "license": "MIT",
-  "engines": {
-    "node": ">=22.18.0"
-  },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "scripts": {
-    "dev": "npm run start",
     "build": "rslib build",
+    "dev": "npm run start",
     "start": "rslib build -w",
     "test": "rstest run"
   },
-  "type": "module",
   "dependencies": {
     "@rsdoctor/core": "workspace:*",
     "@rsdoctor/shared": "workspace:*",
@@ -42,6 +39,9 @@
     "@types/node": "catalog:",
     "cac": "^7.0.0",
     "typescript": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.18.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,26 +1,23 @@
 {
   "name": "@rsdoctor/client",
   "version": "2.0.0-beta.0",
-  "main": "dist/index.html",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",
     "directory": "packages/client"
   },
+  "license": "MIT",
+  "main": "dist/index.html",
   "files": [
     "dist"
   ],
-  "license": "MIT",
-  "engines": {
-    "node": ">=22.18.0"
-  },
   "scripts": {
-    "dev": "rsbuild dev",
-    "start": "NODE_ENV=development rsbuild build -w",
     "build": "rsbuild build",
     "build:analysis": "ENABLE_DEVTOOLS_PLUGIN=true DEVTOOLS_DEV=true rsbuild build",
+    "dev": "rsbuild dev",
+    "inspect": "rsbuild inspect",
     "preview": "rsbuild preview",
-    "inspect": "rsbuild inspect"
+    "start": "NODE_ENV=development rsbuild build -w"
   },
   "devDependencies": {
     "@ant-design/icons": "6.3.2",
@@ -64,6 +61,9 @@
     "source-map-loader": "^5.0.0",
     "typescript": "catalog:",
     "url-parse": "1.5.10"
+  },
+  "engines": {
+    "node": ">=22.18.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,15 +7,6 @@
     "directory": "packages/core"
   },
   "license": "MIT",
-  "engines": {
-    "node": ">=22.18.0"
-  },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "static"
-  ],
   "type": "module",
   "exports": {
     ".": {
@@ -27,6 +18,8 @@
       "default": "./dist/proxy-loader.js"
     }
   },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "typesVersions": {
     "*": {
       ".": [
@@ -37,16 +30,21 @@
       ]
     }
   },
+  "files": [
+    "dist",
+    "static"
+  ],
   "scripts": {
-    "dev": "npm run start",
     "build": "rslib build",
+    "dev": "npm run start",
     "start": "rslib build -w",
     "test": "rstest run"
   },
   "dependencies": {
     "@babel/code-frame": "7.26.2",
-    "@rspack/lite-tapable": "catalog:",
+    "@rsdoctor/client": "workspace:*",
     "@rsdoctor/shared": "workspace:*",
+    "@rspack/lite-tapable": "catalog:",
     "@types/estree": "catalog:",
     "acorn": "^8.10.0",
     "acorn-import-attributes": "^1.9.5",
@@ -54,19 +52,18 @@
     "browserslist-load-config": "^1.0.3",
     "caniuse-lite": "^1.0.30001809",
     "connect-next": "catalog:",
+    "cors": "2.8.6",
     "envinfo": "7.21.0",
     "fs-extra": "catalog:",
     "get-port": "5.1.1",
+    "launch-editor": "^2.14.1",
     "lines-and-columns": "2.0.4",
     "open": "^11.0.1",
     "raw-body": "3.0.2",
     "rslog": "^2.1.3",
     "semver": "^7.8.5",
-    "source-map": "catalog:",
-    "@rsdoctor/client": "workspace:*",
-    "cors": "2.8.6",
-    "launch-editor": "^2.14.1",
     "sirv": "catalog:",
+    "source-map": "catalog:",
     "ws": "8.21.3"
   },
   "devDependencies": {
@@ -74,19 +71,19 @@
     "@rspack/core": "catalog:",
     "@scripts/test-helper": "workspace:*",
     "@types/babel__code-frame": "7.27.0",
+    "@types/cors": "2.8.19",
     "@types/envinfo": "7.8.4",
     "@types/fs-extra": "catalog:",
     "@types/node": "catalog:",
     "@types/semver": "^7.8.0",
+    "@types/ws": "^8.18.1",
     "babel-loader": "10.1.1",
     "filesize": "catalog:",
     "json-stream-stringify": "3.0.1",
     "string-loader": "0.0.1",
     "ts-loader": "^9.6.2",
     "tslib": "catalog:",
-    "typescript": "catalog:",
-    "@types/cors": "2.8.19",
-    "@types/ws": "^8.18.1"
+    "typescript": "catalog:"
   },
   "peerDependencies": {
     "@rspack/core": "^2.0.0"
@@ -95,6 +92,9 @@
     "@rspack/core": {
       "optional": true
     }
+  },
+  "engines": {
+    "node": ">=22.18.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -1,32 +1,34 @@
 {
   "name": "@rsdoctor/docs",
   "version": "2.0.0-beta.0",
-  "scripts": {
-    "dev": "cross-env RSPRESS_PERSISTENT_CACHE=false rspress dev",
-    "build": "cross-env RSPRESS_PERSISTENT_CACHE=false rspress build && sh build.sh",
-    "preview": "rspress preview"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",
     "directory": "packages/document"
   },
   "license": "MIT",
-  "engines": {
-    "node": ">=22.18.0"
-  },
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "docs",
     "src"
   ],
-  "type": "module",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
+  "scripts": {
+    "build": "cross-env RSPRESS_PERSISTENT_CACHE=false rspress build && sh build.sh",
+    "dev": "cross-env RSPRESS_PERSISTENT_CACHE=false rspress dev",
+    "preview": "rspress preview"
+  },
+  "dependencies": {
+    "@rspress/core": "2.0.19",
+    "@rstackjs/doc-ui": "1.14.11",
+    "clsx": "catalog:",
+    "react-markdown": "catalog:"
   },
   "devDependencies": {
+    "@rsbuild/plugin-sass": "catalog:",
+    "@rsdoctor/core": "workspace:*",
+    "@rsdoctor/shared": "workspace:*",
     "@rspress/plugin-algolia": "2.0.19",
     "@rspress/plugin-client-redirects": "2.0.19",
     "@rspress/plugin-rss": "2.0.5",
@@ -41,15 +43,13 @@
     "rsbuild-plugin-open-graph": "^1.1.3",
     "rspress-plugin-font-open-sans": "^1.0.4",
     "rspress-plugin-sitemap": "^1.2.1",
-    "typescript": "catalog:",
-    "@rsbuild/plugin-sass": "catalog:",
-    "@rsdoctor/core": "workspace:*",
-    "@rsdoctor/shared": "workspace:*"
+    "typescript": "catalog:"
   },
-  "dependencies": {
-    "@rstackjs/doc-ui": "1.14.11",
-    "clsx": "catalog:",
-    "react-markdown": "catalog:",
-    "@rspress/core": "2.0.19"
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,14 +7,6 @@
     "directory": "packages/shared"
   },
   "license": "MIT",
-  "engines": {
-    "node": ">=22.18.0"
-  },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
   "type": "module",
   "exports": {
     ".": {
@@ -38,6 +30,8 @@
       "default": "./dist/types/index.js"
     }
   },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "typesVersions": {
     "*": {
       ".": [
@@ -57,23 +51,26 @@
       ]
     }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rslib build",
     "start": "rslib build -w"
   },
   "dependencies": {
+    "@rspack/lite-tapable": "catalog:",
     "@types/estree": "catalog:",
     "@types/node": "catalog:",
-    "@rspack/lite-tapable": "catalog:",
     "buffer": "6.0.3",
     "connect-next": "catalog:",
     "path-browserify": "catalog:",
     "source-map": "catalog:"
   },
   "devDependencies": {
+    "@rspack/core": "catalog:",
     "@types/path-browserify": "catalog:",
     "@types/react": "catalog:",
-    "@rspack/core": "catalog:",
     "es-toolkit": "catalog:",
     "tslib": "catalog:",
     "typescript": "catalog:"
@@ -85,6 +82,9 @@
     "@rspack/core": {
       "optional": true
     }
+  },
+  "engines": {
+    "node": ">=22.18.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/shared/tests/graph/fixture/package.json
+++ b/packages/shared/tests/graph/fixture/package.json
@@ -1,6 +1,6 @@
 {
-  "private": true,
   "name": "@lodash/es",
   "version": "0.1.0",
+  "private": true,
   "type": "module"
 }

--- a/rstack.config.mts
+++ b/rstack.config.mts
@@ -29,6 +29,7 @@ define.lint(({ js, ts, globalIgnores }) => [
 
 define.fmt({
   singleQuote: true,
+  sortPackageJson: true,
   ignorePatterns: [
     'examples/*/index.html',
     'packages/core/tests/build/utils/bundles/**',


### PR DESCRIPTION
## Summary

This PR makes CI use the unified Rstack check command so linting and formatting are validated together.

It enables package.json sorting in the Rstack formatter configuration and normalizes the existing manifests, removing the standalone sorting script.