### PR TITLE
chore(deps): remove redundant pnpm overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ catalogs:
     '@rspack/core':
       specifier: ^2.1.10
       version: 2.1.10
+    '@rspack/lite-tapable':
+      specifier: ^1.1.5
+      version: 1.1.5
     '@rspack/plugin-react-refresh':
       specifier: ^2.0.2
       version: 2.0.2
@@ -105,6 +108,9 @@ catalogs:
     react-router-dom:
       specifier: 6.30.3
       version: 6.30.3
+    sirv:
+      specifier: 3.0.2
+      version: 3.0.2
     source-map:
       specifier: ^0.7.6
       version: 0.7.6
@@ -114,19 +120,9 @@ catalogs:
 
 overrides:
   '@remix-run/router': 1.23.4
-  '@rspack/lite-tapable': 1.1.5
-  call-bind-apply-helpers: 1.0.2
-  es-object-atoms: 1.1.2
-  get-intrinsic: 1.3.0
   minimatch: ^10.2.6
-  nanoid: 3.3.18
-  node-forge: 1.4.0
-  qs: 6.15.3
   rc-dialog: 9.1.0
   rc-tree: 5.7.2
-  sirv: 3.0.2
-  socket.io-parser: 4.2.7
-  tar: 7.5.22
   tslib: 2.8.1
 
 importers:
@@ -595,7 +591,7 @@ importers:
         specifier: 'catalog:'
         version: 6.30.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       sirv:
-        specifier: 3.0.2
+        specifier: 'catalog:'
         version: 3.0.2
       source-map-loader:
         specifier: ^5.0.0
@@ -619,7 +615,7 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@rspack/lite-tapable':
-        specifier: 1.1.5
+        specifier: 'catalog:'
         version: 1.1.5
       '@types/estree':
         specifier: 'catalog:'
@@ -673,7 +669,7 @@ importers:
         specifier: ^7.8.5
         version: 7.8.5
       sirv:
-        specifier: 3.0.2
+        specifier: 'catalog:'
         version: 3.0.2
       source-map:
         specifier: 'catalog:'
@@ -807,7 +803,7 @@ importers:
   packages/shared:
     dependencies:
       '@rspack/lite-tapable':
-        specifier: 1.1.5
+        specifier: 'catalog:'
         version: 1.1.5
       '@types/estree':
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -70,19 +70,9 @@ minimumReleaseAgeExclude:
 
 overrides:
   '@remix-run/router': 1.23.4
-  '@rspack/lite-tapable': 1.1.5
-  call-bind-apply-helpers: 1.0.2
-  es-object-atoms: 1.1.2
-  get-intrinsic: 1.3.0
   minimatch: ^10.2.6
-  nanoid: 3.3.18
-  node-forge: 1.4.0
-  qs: 6.15.3
   rc-dialog: 9.1.0
   rc-tree: 5.7.2
-  sirv: 3.0.2
-  socket.io-parser: 4.2.7
-  tar: 7.5.22
   tslib: 2.8.1
 
 strictDepBuilds: true


### PR DESCRIPTION
## Summary

This PR removes ten pnpm overrides that are already satisfied by the current dependency graph, reducing redundant dependency maintenance without changing resolved package versions. Overrides that still affect resolution or package deduplication remain in place.

## Related links

None