### PR TITLE
chore(build): simplify configuration and targeting Node.js 20

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - Node.js `22.18+`, package manager **pnpm `11.0+`** (enable via `corepack enable`)
 - `pnpm` workspace monorepo (topological build ordering)
-- TypeScript strict mode; target `node 16` for library output
+- TypeScript strict mode; target `node 20` for library output
 - Build toolchain: **Rslib** (based on Rsbuild/Rspack)
 - Lint/format: **Rstack CLI** (`rs lint` backed by Rslint, `rs fmt` based on Prettier)
 - Test runner: **Rstest** (`pnpm test`), E2E: **Playwright** (`pnpm e2e`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - Node.js `22.18+`, package manager **pnpm `11.0+`** (enable via `corepack enable`)
 - `pnpm` workspace monorepo (topological build ordering)
-- TypeScript strict mode; target `node 20` for library output
+- TypeScript strict mode
 - Build toolchain: **Rslib** (based on Rsbuild/Rspack)
 - Lint/format: **Rstack CLI** (`rs lint` backed by Rslint, `rs fmt` based on Prettier)
 - Test runner: **Rstest** (`pnpm test`), E2E: **Playwright** (`pnpm e2e`)

--- a/scripts/rslib.base.config.ts
+++ b/scripts/rslib.base.config.ts
@@ -1,29 +1,9 @@
 import { defineConfig, type LibConfig } from '@rslib/core';
 import { pluginPublint } from 'rsbuild-plugin-publint';
 
-const BUILD_TARGET = 'node 16' as const;
-
 export const pluginsConfig = [pluginPublint()];
 
-export const baseBuildConfig = defineConfig({
-  lib: [
-    {
-      bundle: false,
-      format: 'esm' as const,
-      syntax: [BUILD_TARGET],
-      dts: true,
-      redirect: {
-        dts: {
-          extension: true,
-        },
-      },
-    },
-  ],
-});
-
-export default baseBuildConfig;
-
-export const nodeMinifyConfig = {
+const nodeMinifyConfig = {
   js: true,
   css: false,
   jsOptions: {
@@ -38,7 +18,7 @@ export const nodeMinifyConfig = {
 
 export const esmConfig: LibConfig = {
   format: 'esm',
-  syntax: [BUILD_TARGET],
+  syntax: ['node 20'],
   dts: {
     build: true,
   },
@@ -49,16 +29,6 @@ export const esmConfig: LibConfig = {
     },
   },
 };
-
-export const esmPackageBundleless = defineConfig({
-  lib: [
-    {
-      ...esmConfig,
-      bundle: false,
-    },
-  ],
-  plugins: pluginsConfig,
-});
 
 export const esmPackage = defineConfig({
   lib: [esmConfig],

--- a/scripts/test-helper/rslib.config.ts
+++ b/scripts/test-helper/rslib.config.ts
@@ -1,3 +1,3 @@
-import baseConfig from '../rslib.base.config';
+import { esmPackage } from '../rslib.base.config';
 
-export default baseConfig;
+export default esmPackage;


### PR DESCRIPTION
## Summary

This PR simplifies the shared Rslib configuration after the ESM-only migration by removing unused default and bundleless variants and targeting Node.js 20 syntax. 