### PR TITLE
fix(client): polish analysis overview UI

### DIFF
--- a/packages/client/src/components/Alert/ecma-version-check.module.scss
+++ b/packages/client/src/components/Alert/ecma-version-check.module.scss
@@ -1,12 +1,19 @@
 .container {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+  gap: 20px;
   align-items: center;
   padding: 10px 20px;
 
+  > div {
+    min-width: 0;
+  }
+
   .box {
-    width: 290px;
+    width: 100%;
+    min-width: 0;
     display: flex;
+    align-items: center;
   }
 
   .title {
@@ -18,9 +25,21 @@
   }
 
   .content {
+    flex: 1;
+    min-width: 0;
     font-size: 14px;
     font-weight: 400;
     line-height: 16px;
     margin-left: 5px;
+  }
+}
+
+@media (max-width: 768px) {
+  .container {
+    grid-template-columns: minmax(0, 1fr);
+
+    > :global(.ant-btn) {
+      justify-self: end;
+    }
   }
 }

--- a/packages/client/src/components/Alert/ecma-version-check.tsx
+++ b/packages/client/src/components/Alert/ecma-version-check.tsx
@@ -13,7 +13,7 @@ import styles from './ecma-version-check.module.scss';
 const { Text } = Typography;
 
 export const ECMAVersionCheck: React.FC<LinkAlertProps> = ({ data }) => {
-  return data.map((d) => {
+  return data.map((d, index) => {
     const { code, link, error } = d;
     const { source, output } = error || {};
     const sourceMessage = source?.path
@@ -28,7 +28,7 @@ export const ECMAVersionCheck: React.FC<LinkAlertProps> = ({ data }) => {
 
     const navigate = useRuleIndexNavigate(code, link);
     return (
-      <div className={styles.container}>
+      <div className={styles.container} key={`${code}-${link}-${index}`}>
         <div>
           <div className={styles.title}>Source</div>
           <div className={styles.box}>

--- a/packages/client/src/components/Alerts/bundle-alert-data.ts
+++ b/packages/client/src/components/Alerts/bundle-alert-data.ts
@@ -1,0 +1,51 @@
+import { Rule } from '@rsdoctor/shared/types';
+
+export interface BundleAlertGroup {
+  key: string;
+  label: string;
+  data: Rule.RuleStoreDataItem[];
+  tag: string;
+}
+
+const BUILTIN_RULE_TABS = [
+  { key: 'E1001', label: 'Duplicate Packages' },
+  { key: 'E1002', label: 'Cross Chunks Package' },
+  { key: 'E1003', label: 'Loader Performance Optimization' },
+  { key: 'E1004', label: 'ECMA Version Check' },
+  { key: 'E1005', label: 'Default Import Check' },
+  { key: 'E1006', label: 'Module Mixed Chunks' },
+  { key: 'E1007', label: 'Tree Shaking Side Effects Only' },
+  { key: 'E1008', label: 'CJS Require Cannot Tree-Shake' },
+  { key: 'E1009', label: 'ESM Import Resolved to CJS' },
+];
+
+export function groupBundleAlerts(
+  dataSource: Rule.RuleStoreDataItem[],
+): BundleAlertGroup[] {
+  const groups: BundleAlertGroup[] = BUILTIN_RULE_TABS.map((tab) => ({
+    ...tab,
+    data: [],
+    tag: tab.key,
+  }));
+  const customRules: Rule.RuleStoreDataItem[] = [];
+
+  dataSource.forEach((alert) => {
+    const group = groups.find(({ key }) => key === alert.code);
+    if (group) {
+      group.data.push(alert);
+    } else if (alert.code === Rule.RuleMessageCodeEnumerated.Extend) {
+      customRules.push(alert);
+    }
+  });
+
+  if (customRules.length) {
+    groups.push({
+      key: 'CUSTOM_RULES',
+      label: 'Custom Rules',
+      data: customRules,
+      tag: 'Custom',
+    });
+  }
+
+  return groups;
+}

--- a/packages/client/src/components/Alerts/bundle-alert.module.scss
+++ b/packages/client/src/components/Alerts/bundle-alert.module.scss
@@ -22,14 +22,37 @@
 
   :global {
     // for bundle alerts
-    .ant-tabs-nav-list {
-      width: 98%;
-    }
-    .ant-tabs-tab {
-      flex: 1;
-    }
-    .ant-tabs-tab-btn {
-      width: 100%;
+    .ant-tabs > .ant-tabs-nav {
+      .ant-tabs-nav-wrap {
+        overflow-x: auto;
+        overflow-y: hidden;
+        overscroll-behavior-x: contain;
+        scrollbar-width: thin;
+
+        &::-webkit-scrollbar {
+          height: 6px;
+        }
+
+        &::-webkit-scrollbar-thumb {
+          background-color: var(--color-border);
+          border-radius: 3px;
+        }
+      }
+      .ant-tabs-nav-list {
+        width: max-content;
+        min-width: max-content;
+        flex: none;
+        transform: none !important;
+      }
+      .ant-tabs-tab {
+        flex: 0 0 auto;
+      }
+      .ant-tabs-tab-btn {
+        width: 100%;
+      }
+      .ant-tabs-nav-operations {
+        display: none;
+      }
     }
     .ant-tabs-content-holder,
     .ant-tabs-content,

--- a/packages/client/src/components/Alerts/bundle-alert.module.scss
+++ b/packages/client/src/components/Alerts/bundle-alert.module.scss
@@ -28,6 +28,14 @@
         overflow-y: hidden;
         overscroll-behavior-x: contain;
         scrollbar-width: thin;
+        touch-action: pan-x;
+        user-select: none;
+        cursor: grab;
+        -webkit-overflow-scrolling: touch;
+
+        &[data-dragging='true'] {
+          cursor: grabbing;
+        }
 
         &::-webkit-scrollbar {
           height: 6px;

--- a/packages/client/src/components/Alerts/bundle-alert.module.scss
+++ b/packages/client/src/components/Alerts/bundle-alert.module.scss
@@ -18,6 +18,7 @@
 .container {
   margin-top: -4px;
   height: 100%;
+  min-width: 0;
 
   :global {
     // for bundle alerts
@@ -29,6 +30,11 @@
     }
     .ant-tabs-tab-btn {
       width: 100%;
+    }
+    .ant-tabs-content-holder,
+    .ant-tabs-content,
+    .ant-tabs-tabpane {
+      min-width: 0;
     }
   }
 }

--- a/packages/client/src/components/Alerts/bundle-alert.tsx
+++ b/packages/client/src/components/Alerts/bundle-alert.tsx
@@ -21,6 +21,7 @@ import { SideEffectsOnlyImportsAlertCollapse } from './collapse-side-effects-onl
 import { CjsRequireAlertCollapse } from './collapse-cjs-require';
 import { EsmResolvedToCjsAlertCollapse } from './collapse-esm-cjs';
 import { groupBundleAlerts } from './bundle-alert-data';
+import { useHorizontalTabScroll } from './useHorizontalTabScroll';
 
 interface BundleAlertProps {
   title: string;
@@ -37,6 +38,7 @@ export const BundleAlert: React.FC<BundleAlertProps> = ({
   dataSource,
   extraData,
 }) => {
+  const horizontalTabScrollHandlers = useHorizontalTabScroll();
   const tabData = groupBundleAlerts(dataSource);
 
   tabData.sort(
@@ -186,7 +188,7 @@ export const BundleAlert: React.FC<BundleAlertProps> = ({
 
   return (
     <Card style={{ width: '100%', borderRadius: '12px' }}>
-      <div className={styles.container}>
+      <div className={styles.container} {...horizontalTabScrollHandlers}>
         <div className={styles.title}>{title}</div>
         {!hasRuleAlerts ? (
           <div

--- a/packages/client/src/components/Alerts/bundle-alert.tsx
+++ b/packages/client/src/components/Alerts/bundle-alert.tsx
@@ -20,6 +20,7 @@ import { ModuleMixedChunksAlertCollapse } from './collapse-module-mixed-chunks';
 import { SideEffectsOnlyImportsAlertCollapse } from './collapse-side-effects-only-imports';
 import { CjsRequireAlertCollapse } from './collapse-cjs-require';
 import { EsmResolvedToCjsAlertCollapse } from './collapse-esm-cjs';
+import { groupBundleAlerts } from './bundle-alert-data';
 
 interface BundleAlertProps {
   title: string;
@@ -31,79 +32,17 @@ interface BundleAlertProps {
   extraCom?: React.JSX.Element | undefined;
 }
 
-const BUILTIN_RULE_TABS = [
-  {
-    key: 'E1001',
-    label: 'Duplicate Packages',
-  },
-  {
-    key: 'E1002',
-    label: 'Cross Chunks Package',
-  },
-  {
-    key: 'E1003',
-    label: 'Loader Performance Optimization',
-  },
-  {
-    key: 'E1004',
-    label: 'ECMA Version Check',
-  },
-  {
-    key: 'E1005',
-    label: 'Default Import Check',
-  },
-  {
-    key: 'E1006',
-    label: 'Module Mixed Chunks',
-  },
-  {
-    key: 'E1007',
-    label: 'Tree Shaking Side Effects Only',
-  },
-  {
-    key: 'E1008',
-    label: 'CJS Require Cannot Tree-Shake',
-  },
-  {
-    key: 'E1009',
-    label: 'ESM Import Resolved to CJS',
-  },
-];
-
 export const BundleAlert: React.FC<BundleAlertProps> = ({
   title,
   dataSource,
   extraData,
 }) => {
-  const tabData: Array<{
-    key: string;
-    label: string;
-    data: Array<Rule.RuleStoreDataItem>;
-    tag: string;
-  }> = BUILTIN_RULE_TABS.map((tab) => ({ ...tab, data: [], tag: tab.key }));
-  const customRulesData: Array<Rule.RuleStoreDataItem> = [];
-
-  dataSource.forEach((data) => {
-    const target = tabData.find((td) => td.key === data.code);
-    if (target) {
-      target.data.push(data);
-    } else {
-      customRulesData.push(data);
-    }
-  });
-
-  if (customRulesData.length) {
-    tabData.push({
-      key: 'CUSTOM_RULES',
-      label: 'Custom Rules',
-      data: customRulesData,
-      tag: 'Custom',
-    });
-  }
+  const tabData = groupBundleAlerts(dataSource);
 
   tabData.sort(
     (a, b) => (b.data.length > 0 ? 1 : 0) - (a.data.length > 0 ? 1 : 0),
   );
+  const hasRuleAlerts = tabData.some(({ data }) => data.length > 0);
 
   const defaultActiveKey = tabData[0]?.key ?? 'E1001';
   const [activeKey, setActiveKey] = useState(defaultActiveKey);
@@ -249,7 +188,7 @@ export const BundleAlert: React.FC<BundleAlertProps> = ({
     <Card style={{ width: '100%', borderRadius: '12px' }}>
       <div className={styles.container}>
         <div className={styles.title}>{title}</div>
-        {!dataSource.length ? (
+        {!hasRuleAlerts ? (
           <div
             style={{
               minHeight: '480px',

--- a/packages/client/src/components/Alerts/useHorizontalTabScroll.ts
+++ b/packages/client/src/components/Alerts/useHorizontalTabScroll.ts
@@ -1,0 +1,146 @@
+import { useRef } from 'react';
+import type { HTMLAttributes } from 'react';
+
+const TAB_BAR_SELECTOR = '.ant-tabs-nav-wrap';
+const DRAG_THRESHOLD = 4;
+
+interface ScrollMetrics {
+  scrollLeft: number;
+  scrollWidth: number;
+  clientWidth: number;
+  deltaX: number;
+  deltaY: number;
+  deltaMode: number;
+}
+
+interface DragState {
+  element: HTMLElement;
+  pointerId: number;
+  startX: number;
+  startScrollLeft: number;
+  moved: boolean;
+}
+
+function getTabBar(target: EventTarget | null): HTMLElement | null {
+  if (!(target instanceof Element)) {
+    return null;
+  }
+
+  const tabBar = target.closest(TAB_BAR_SELECTOR);
+  return tabBar instanceof HTMLElement ? tabBar : null;
+}
+
+export function getNextHorizontalScrollLeft({
+  scrollLeft,
+  scrollWidth,
+  clientWidth,
+  deltaX,
+  deltaY,
+  deltaMode,
+}: ScrollMetrics): number {
+  const dominantDelta = Math.abs(deltaX) > Math.abs(deltaY) ? deltaX : deltaY;
+  const multiplier = deltaMode === 1 ? 16 : deltaMode === 2 ? clientWidth : 1;
+  const maxScrollLeft = Math.max(0, scrollWidth - clientWidth);
+
+  return Math.min(
+    maxScrollLeft,
+    Math.max(0, scrollLeft + dominantDelta * multiplier),
+  );
+}
+
+export function useHorizontalTabScroll(): HTMLAttributes<HTMLDivElement> {
+  const dragStateRef = useRef<DragState | null>(null);
+  const suppressClickRef = useRef(false);
+
+  const finishDragging = (pointerId: number, suppressClick: boolean) => {
+    const dragState = dragStateRef.current;
+    if (!dragState || dragState.pointerId !== pointerId) {
+      return;
+    }
+
+    delete dragState.element.dataset.dragging;
+    if (dragState.element.hasPointerCapture(pointerId)) {
+      dragState.element.releasePointerCapture(pointerId);
+    }
+    dragStateRef.current = null;
+
+    if (suppressClick && dragState.moved) {
+      suppressClickRef.current = true;
+      window.setTimeout(() => {
+        suppressClickRef.current = false;
+      });
+    }
+  };
+
+  return {
+    onWheel(event) {
+      const tabBar = getTabBar(event.target);
+      if (!tabBar) {
+        return;
+      }
+
+      const nextScrollLeft = getNextHorizontalScrollLeft({
+        scrollLeft: tabBar.scrollLeft,
+        scrollWidth: tabBar.scrollWidth,
+        clientWidth: tabBar.clientWidth,
+        deltaX: event.deltaX,
+        deltaY: event.deltaY,
+        deltaMode: event.deltaMode,
+      });
+
+      if (nextScrollLeft !== tabBar.scrollLeft) {
+        tabBar.scrollLeft = nextScrollLeft;
+        event.preventDefault();
+      }
+    },
+    onPointerDown(event) {
+      if (event.pointerType !== 'mouse' || event.button !== 0) {
+        return;
+      }
+
+      const tabBar = getTabBar(event.target);
+      if (!tabBar || tabBar.scrollWidth <= tabBar.clientWidth) {
+        return;
+      }
+
+      dragStateRef.current = {
+        element: tabBar,
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startScrollLeft: tabBar.scrollLeft,
+        moved: false,
+      };
+      tabBar.dataset.dragging = 'true';
+      tabBar.setPointerCapture(event.pointerId);
+    },
+    onPointerMove(event) {
+      const dragState = dragStateRef.current;
+      if (!dragState || dragState.pointerId !== event.pointerId) {
+        return;
+      }
+
+      const distance = event.clientX - dragState.startX;
+      if (Math.abs(distance) >= DRAG_THRESHOLD) {
+        dragState.moved = true;
+      }
+
+      if (dragState.moved) {
+        dragState.element.scrollLeft = dragState.startScrollLeft - distance;
+        event.preventDefault();
+      }
+    },
+    onPointerUp(event) {
+      finishDragging(event.pointerId, true);
+    },
+    onPointerCancel(event) {
+      finishDragging(event.pointerId, false);
+    },
+    onClickCapture(event) {
+      if (suppressClickRef.current && getTabBar(event.target)) {
+        suppressClickRef.current = false;
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    },
+  };
+}

--- a/packages/client/src/components/Card/size.module.scss
+++ b/packages/client/src/components/Card/size.module.scss
@@ -1,4 +1,20 @@
+.container {
+  width: 100%;
+  min-width: 0;
+
+  > :global(.ant-space-item:last-child) {
+    min-width: 0;
+    flex: 1;
+  }
+}
+
+.details {
+  min-width: 0;
+  margin-left: 10px;
+}
+
 .dataContainer {
+  min-width: 0;
   display: flex;
   flex-direction: column;
 
@@ -12,7 +28,11 @@
 
 .sizeMetrics {
   display: flex;
-  gap: 20px;
+  gap: clamp(8px, 1vw, 20px);
+
+  > * {
+    flex: 1;
+  }
 }
 
 .description {

--- a/packages/client/src/components/Card/size.module.scss
+++ b/packages/client/src/components/Card/size.module.scss
@@ -13,6 +13,25 @@
   margin-left: 10px;
 }
 
+.metricSelector {
+  font-size: 12px;
+  line-height: 18px;
+
+  &:global(.ant-segmented.ant-segmented-sm) {
+    padding: 1px;
+
+    :global(.ant-segmented-item-label) {
+      min-height: 18px;
+      padding: 0 5px;
+      line-height: 18px;
+    }
+  }
+}
+
+.metricValue {
+  margin-top: 2px;
+}
+
 .dataContainer {
   min-width: 0;
   display: flex;

--- a/packages/client/src/components/Card/size.module.scss
+++ b/packages/client/src/components/Card/size.module.scss
@@ -26,19 +26,11 @@
   }
 }
 
-.sizeMetrics {
-  display: flex;
-  gap: clamp(8px, 1vw, 20px);
-
-  > * {
-    flex: 1;
-  }
-}
-
 .description {
   font-size: 18px;
   font-weight: 500;
   line-height: 28px;
+  white-space: nowrap;
 
   @media (max-width: 1500px) {
     font-size: 14px;

--- a/packages/client/src/components/Card/size.tsx
+++ b/packages/client/src/components/Card/size.tsx
@@ -98,6 +98,7 @@ export const SizeCard: React.FC<SizeCardProps> = ({
             <div className={styles.details}>
               <Segmented
                 aria-label={`${type} size metric`}
+                className={styles.metricSelector}
                 options={[
                   { label: 'Size', value: 'size' },
                   { label: 'Gzip', value: 'gzip', disabled: !hasGzipSize },
@@ -106,7 +107,7 @@ export const SizeCard: React.FC<SizeCardProps> = ({
                 size="small"
                 onChange={(value) => setSizeMetric(value as SizeMetric)}
               />
-              <div className={styles.description}>
+              <div className={`${styles.description} ${styles.metricValue}`}>
                 {formatSize(selectedSize)}
               </div>
               <TextDrawer

--- a/packages/client/src/components/Card/size.tsx
+++ b/packages/client/src/components/Card/size.tsx
@@ -1,6 +1,6 @@
-import { Empty, Progress, Space, Tree } from 'antd';
+import { Empty, Progress, Segmented, Space, Tree } from 'antd';
 import { sumBy } from '@rsdoctor/shared/collection';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { RightOutlined } from '@ant-design/icons';
 
 import { formatSize } from 'src/utils';
@@ -14,6 +14,7 @@ import styles from './size.module.scss';
 
 const { DirectoryTree } = Tree;
 const height = 100;
+type SizeMetric = 'size' | 'gzip';
 
 export interface SizeCardProps {
   files: {
@@ -43,6 +44,7 @@ export const SizeCard: React.FC<SizeCardProps> = ({
   showProgress = false,
   type,
 }) => {
+  const [sizeMetric, setSizeMetric] = useState<SizeMetric>('size');
   const fileType =
     type.toLocaleLowerCase() as keyof Client.RsdoctorClientAssetsSummary;
   const sum = useMemo(() => {
@@ -53,6 +55,12 @@ export const SizeCard: React.FC<SizeCardProps> = ({
   }, [files]);
   const hasGzipSize = files.some((file) => file.gzipSize !== undefined);
 
+  useEffect(() => {
+    if (!hasGzipSize) {
+      setSizeMetric('size');
+    }
+  }, [hasGzipSize, type]);
+
   return (
     <ServerAPIProvider
       api={SDK.ServerAPI.API.GetAssetsSummary}
@@ -61,11 +69,21 @@ export const SizeCard: React.FC<SizeCardProps> = ({
       {(res) => {
         const type = fileType.includes('image') ? 'imgs' : fileType;
         const { treeData } = getFiles(res[type].total);
+        const totalGzipSize = sumBy(
+          res.all.total.files,
+          (file) => file.gzipSize ?? 0,
+        );
+        const selectedSize = sizeMetric === 'gzip' ? gzipSum : sum;
+        const selectedTotal = sizeMetric === 'gzip' ? totalGzipSize : total;
+        const percent = selectedTotal
+          ? +((selectedSize / selectedTotal) * 100).toFixed(2)
+          : 0;
+
         return (
           <Space className={styles.container} style={{ height }} align="center">
             <Progress
               type="circle"
-              percent={+((sum / total) * 100).toFixed(2)}
+              percent={percent}
               strokeColor={{ '0%': '#108ee9', '100%': '#108ee9' }}
               strokeWidth={12}
               format={(percent) => (
@@ -78,17 +96,18 @@ export const SizeCard: React.FC<SizeCardProps> = ({
               )}
             />
             <div className={styles.details}>
-              <div className={styles.sizeMetrics}>
-                <div className={styles.dataContainer}>
-                  <div className={styles.title}>Size</div>
-                  <div className={styles.description}>{formatSize(sum)}</div>
-                </div>
-                <div className={styles.dataContainer}>
-                  <div className={styles.title}>Gzipped</div>
-                  <div className={styles.description}>
-                    {hasGzipSize ? formatSize(gzipSum) : 'N/A'}
-                  </div>
-                </div>
+              <Segmented
+                aria-label={`${type} size metric`}
+                options={[
+                  { label: 'Size', value: 'size' },
+                  { label: 'Gzip', value: 'gzip', disabled: !hasGzipSize },
+                ]}
+                value={sizeMetric}
+                size="small"
+                onChange={(value) => setSizeMetric(value as SizeMetric)}
+              />
+              <div className={styles.description}>
+                {formatSize(selectedSize)}
               </div>
               <TextDrawer
                 buttonProps={{

--- a/packages/client/src/components/Card/size.tsx
+++ b/packages/client/src/components/Card/size.tsx
@@ -62,7 +62,7 @@ export const SizeCard: React.FC<SizeCardProps> = ({
         const type = fileType.includes('image') ? 'imgs' : fileType;
         const { treeData } = getFiles(res[type].total);
         return (
-          <Space style={{ height }} align="center">
+          <Space className={styles.container} style={{ height }} align="center">
             <Progress
               type="circle"
               percent={+((sum / total) * 100).toFixed(2)}
@@ -77,7 +77,7 @@ export const SizeCard: React.FC<SizeCardProps> = ({
                 </div>
               )}
             />
-            <div style={{ marginLeft: '10px' }}>
+            <div className={styles.details}>
               <div className={styles.sizeMetrics}>
                 <div className={styles.dataContainer}>
                   <div className={styles.title}>Size</div>

--- a/packages/client/src/components/Charts/TimelineCharts/axis.ts
+++ b/packages/client/src/components/Charts/TimelineCharts/axis.ts
@@ -1,0 +1,21 @@
+export interface TimelineExtent {
+  startTimestamp: number;
+  endTimestamp: number;
+}
+
+const TARGET_SPLIT_COUNT = 5;
+
+export function getTimelineAxisInterval(
+  extent?: TimelineExtent,
+): number | null {
+  if (!extent) {
+    return null;
+  }
+
+  const duration = extent.endTimestamp - extent.startTimestamp;
+  if (!Number.isFinite(duration) || duration <= 0) {
+    return null;
+  }
+
+  return Math.max(1, Math.ceil(duration / TARGET_SPLIT_COUNT));
+}

--- a/packages/client/src/components/Charts/TimelineCharts/index.tsx
+++ b/packages/client/src/components/Charts/TimelineCharts/index.tsx
@@ -14,6 +14,7 @@ import { ChartProps, DurationMetric, ITraceEventData } from '../types';
 import { groupBy } from '@rsdoctor/shared/collection';
 import { ChartTypes, TIMELINE_PALETTE_COLORS } from '../constants';
 import { useThemeToken } from 'src/utils';
+import { getTimelineAxisInterval, type TimelineExtent } from './axis';
 
 interface CoordSysType {
   x: number;
@@ -44,7 +45,7 @@ export const TimelineCom: React.FC<{
   // rslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   formatterFn: Function;
   chartType?: ChartTypes;
-  exts?: { endTimestamp: number; startTimestamp: number };
+  exts?: TimelineExtent;
 }> = memo(
   ({
     loaderData,
@@ -244,10 +245,7 @@ export const TimelineCom: React.FC<{
           containLabel: true,
         },
         xAxis: {
-          interval:
-            exts?.endTimestamp && exts?.startTimestamp
-              ? Math.floor((exts.endTimestamp - exts.startTimestamp) / 8)
-              : null,
+          interval: getTimelineAxisInterval(exts ?? undefined),
           position: 'top',
           splitLine: {
             show: true,
@@ -263,6 +261,7 @@ export const TimelineCom: React.FC<{
           axisLabel: {
             color: themeToken.colorTextSecondary,
             fontSize: 11,
+            hideOverlap: true,
             margin: 10,
             formatter(val: number) {
               return dayjs(val as number).format('HH:mm:ss:SSS');

--- a/packages/client/src/components/Configuration/builder.tsx
+++ b/packages/client/src/components/Configuration/builder.tsx
@@ -32,14 +32,14 @@ export const WebpackConfigurationViewerBase: React.FC<
       text={
         <div className={styles.title}>
           <span style={{ marginRight: '8px', fontSize: '13px' }}>
-            View Bundler Config
+            View Rspack Config
           </span>
           <RightOutlined style={{ fontSize: '10px' }} />
         </div>
       }
     >
       <Row>
-        <Title text={`Bundler Config Viewer`} />
+        <Title text="Rspack Config Viewer" />
         <Divider />
         <Space>
           <Typography.Text>Properties: </Typography.Text>
@@ -70,7 +70,7 @@ export const WebpackConfigurationViewerBase: React.FC<
         name={
           version && version !== 'unknown'
             ? `${name}@${version}`
-            : `webpack.config`
+            : 'rspack.config'
         }
         theme="monokai"
         src={

--- a/packages/client/src/pages/BundleSize/components/card.module.scss
+++ b/packages/client/src/pages/BundleSize/components/card.module.scss
@@ -1,6 +1,7 @@
 .container {
   display: flex;
   align-items: center;
+  min-width: 0;
   background-color: var(--color-bg-box);
   padding: 20px 0;
   margin-bottom: 20px;
@@ -9,18 +10,25 @@
 
   .chartsContainer {
     width: 100%;
-    display: flex;
-    justify-content: space-evenly;
+    min-width: 0;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
 
     .chart {
       display: flex;
       align-items: center;
       justify-content: center;
-      flex: 1;
+      min-width: 0;
+      padding: 0 20px;
+
+      & + .chart {
+        border-left: 1px solid var(--color-border-secondary);
+      }
     }
   }
 
   .summary {
+    flex: 0 0 210px;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -48,6 +56,57 @@
       margin: 4px 0;
       color: var(--text-color-secondary);
       font-variant-numeric: tabular-nums;
+    }
+  }
+}
+
+@media (max-width: 1600px) {
+  .container {
+    .chartsContainer {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      row-gap: 32px;
+
+      .chart:nth-child(odd) {
+        border-left: none;
+      }
+    }
+  }
+}
+
+@media (max-width: 980px) {
+  .container {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 20px;
+    padding: 20px;
+
+    > :global(.ant-divider-vertical) {
+      display: none;
+    }
+
+    .summary {
+      flex: none;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+      margin: 0;
+
+      > :first-child {
+        margin-bottom: 0 !important;
+      }
+    }
+  }
+}
+
+@media (max-width: 640px) {
+  .container {
+    .summary,
+    .chartsContainer {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .chartsContainer .chart {
+      border-left: none;
     }
   }
 }

--- a/packages/client/src/pages/BundleSize/components/card.module.scss
+++ b/packages/client/src/pages/BundleSize/components/card.module.scss
@@ -19,7 +19,7 @@
       align-items: center;
       justify-content: center;
       min-width: 0;
-      padding: 0 20px;
+      padding: 0 clamp(8px, 1vw, 20px);
 
       & + .chart {
         border-left: 1px solid var(--color-border-secondary);
@@ -60,7 +60,7 @@
   }
 }
 
-@media (max-width: 1600px) {
+@media (max-width: 1280px) {
   .container {
     .chartsContainer {
       grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/packages/client/src/pages/BundleSize/components/cards.tsx
+++ b/packages/client/src/pages/BundleSize/components/cards.tsx
@@ -19,7 +19,6 @@ import { TextDrawer } from '../../..//components/TextDrawer';
 import styles from './card.module.scss';
 
 const { DirectoryTree } = Tree;
-const { innerWidth } = window;
 
 interface CardProps {
   showProgress?: boolean;
@@ -98,7 +97,8 @@ const AssetCardContainer: React.FC<{
       boxProps={{
         style: {
           background: bgColor?.bgColor,
-          width: innerWidth > 1300 ? '80%' : '95%',
+          minWidth: 0,
+          width: '100%',
         },
       }}
     />
@@ -269,18 +269,9 @@ export const BundleCards: React.FC<{
             <Divider style={{ height: '200px' }} type="vertical" />
             <div className={styles.chartsContainer}>
               {arr.map((e, idx) => (
-                <>
-                  <div key={idx} className={styles.chart}>
-                    {e}
-                  </div>
-                  {idx !== arr.length - 1 ? (
-                    <Divider
-                      key={`${idx}-divider`}
-                      style={{ height: '200px' }}
-                      type="vertical"
-                    />
-                  ) : null}
-                </>
+                <div key={idx} className={styles.chart}>
+                  {e}
+                </div>
               ))}
             </div>
           </div>

--- a/packages/client/src/pages/ModuleAnalyze/dependency.tsx
+++ b/packages/client/src/pages/ModuleAnalyze/dependency.tsx
@@ -34,7 +34,7 @@ const DependencyTree: React.FC<{
         {treedata.length ? (
           <FileTree treeData={treedata} needJumpto cwd={cwd} />
         ) : (
-          <Empty />
+          <Empty description="No Data" />
         )}
       </Col>
     </Row>

--- a/packages/client/tests/components/Alerts/bundle-alert-data.test.ts
+++ b/packages/client/tests/components/Alerts/bundle-alert-data.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from '@rstest/core';
+import { Rule } from '@rsdoctor/shared/types';
+import { groupBundleAlerts } from 'src/components/Alerts/bundle-alert-data';
+
+function createAlert(
+  id: string,
+  code: Rule.RuleMessageCode,
+): Rule.RuleStoreDataItem {
+  return {
+    id,
+    code,
+    category: Rule.RuleMessageCategory.Bundle,
+    title: id,
+    description: id,
+    level: 'warn',
+    type: 'link',
+  };
+}
+
+describe('groupBundleAlerts', () => {
+  it('keeps overlay errors out of custom rules', () => {
+    const builtin = createAlert('builtin', 'E1004');
+    const custom = createAlert('custom', Rule.RuleMessageCodeEnumerated.Extend);
+    const overlay = createAlert(
+      'overlay',
+      Rule.RuleMessageCodeEnumerated.Overlay,
+    );
+
+    const groups = groupBundleAlerts([builtin, custom, overlay]);
+
+    expect(groups.find(({ key }) => key === 'E1004')?.data).toEqual([builtin]);
+    expect(groups.find(({ key }) => key === 'CUSTOM_RULES')?.data).toEqual([
+      custom,
+    ]);
+    expect(groups.flatMap(({ data }) => data)).not.toContain(overlay);
+  });
+});

--- a/packages/client/tests/components/Alerts/horizontal-tab-scroll.test.ts
+++ b/packages/client/tests/components/Alerts/horizontal-tab-scroll.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from '@rstest/core';
+import { getNextHorizontalScrollLeft } from 'src/components/Alerts/useHorizontalTabScroll';
+
+describe('getNextHorizontalScrollLeft', () => {
+  const scrollMetrics = {
+    scrollLeft: 100,
+    scrollWidth: 1_000,
+    clientWidth: 400,
+    deltaX: 0,
+    deltaY: 0,
+    deltaMode: 0,
+  };
+
+  it('maps a vertical mouse wheel to horizontal scrolling', () => {
+    expect(getNextHorizontalScrollLeft({ ...scrollMetrics, deltaY: 80 })).toBe(
+      180,
+    );
+  });
+
+  it('uses the dominant trackpad axis', () => {
+    expect(
+      getNextHorizontalScrollLeft({
+        ...scrollMetrics,
+        deltaX: -60,
+        deltaY: 10,
+      }),
+    ).toBe(40);
+  });
+
+  it('keeps scrolling within the available range', () => {
+    expect(
+      getNextHorizontalScrollLeft({ ...scrollMetrics, deltaY: -1_000 }),
+    ).toBe(0);
+    expect(
+      getNextHorizontalScrollLeft({ ...scrollMetrics, deltaY: 1_000 }),
+    ).toBe(600);
+  });
+});

--- a/packages/client/tests/components/Charts/timelineAxis.test.ts
+++ b/packages/client/tests/components/Charts/timelineAxis.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from '@rstest/core';
+import { getTimelineAxisInterval } from 'src/components/Charts/TimelineCharts/axis';
+
+describe('getTimelineAxisInterval', () => {
+  it('limits a short timeline to about five intervals', () => {
+    expect(
+      getTimelineAxisInterval({ startTimestamp: 537, endTimestamp: 563 }),
+    ).toBe(6);
+  });
+
+  it('keeps millisecond precision for very short timelines', () => {
+    expect(
+      getTimelineAxisInterval({ startTimestamp: 100, endTimestamp: 103 }),
+    ).toBe(1);
+  });
+
+  it('lets ECharts choose the interval for missing or invalid extents', () => {
+    expect(getTimelineAxisInterval()).toBeNull();
+    expect(
+      getTimelineAxisInterval({ startTimestamp: 100, endTimestamp: 100 }),
+    ).toBeNull();
+  });
+});

--- a/packages/core/src/sdk/server/index.ts
+++ b/packages/core/src/sdk/server/index.ts
@@ -423,9 +423,7 @@ export class RsdoctorServer implements SDK.RsdoctorServerInstance {
     const localhostUrl = `http://localhost:${this.port}${relativeUrl}`;
     await openBrowser(localhostUrl, !needEncodeURI);
     if (this._printServerUrl) {
-      logger.info(
-        `${chalk.green(`${this.sdk.name} compiler's`)} analyzer running on: ${chalk.cyan(url)}`,
-      );
+      logger.info(`Analyzer running on: ${chalk.cyan(url)}`);
     }
   }
 

--- a/packages/document/docs/en/guide/usage/plugins-analysis.mdx
+++ b/packages/document/docs/en/guide/usage/plugins-analysis.mdx
@@ -27,9 +27,9 @@ The meanings of the fields in the data statistics table on the page are as follo
 
 ## Usage instructions
 
-### View bundler config
+### View Rspack config
 
-To inspect the project's Rspack configuration, click `View Bundler Config` in the upper-right corner of the card. The resulting panel contains the serialized **Bundler Config**:
+To inspect the project's Rspack configuration, click `View Rspack Config` in the upper-right corner of the card. The resulting panel contains the serialized **Rspack Config**:
 
 <img
   src="https://assets.rspack.rs/others/assets/rsdoctor/plugins-analysis-config.png"

--- a/packages/document/docs/en/guide/usage/project-overall.mdx
+++ b/packages/document/docs/en/guide/usage/project-overall.mdx
@@ -26,9 +26,9 @@ In the main page of **Rsdoctor**, we can see a card named `Project Overall`, whi
 
 ## Usage
 
-### View bundler config
+### View Rspack config
 
-To inspect the project's Rspack configuration, click `View Bundler Config` in the top-right corner of the card. The popup contains the serialized [Rspack configuration](https://rspack.rs/config/):
+To inspect the project's Rspack configuration, click `View Rspack Config` in the top-right corner of the card. The popup contains the serialized [Rspack configuration](https://rspack.rs/config/):
 
 <img
   src="https://assets.rspack.rs/others/assets/rsdoctor/project-overall-config.jpg"

--- a/packages/document/docs/zh/guide/usage/plugins-analysis.mdx
+++ b/packages/document/docs/zh/guide/usage/plugins-analysis.mdx
@@ -27,9 +27,9 @@ plugin 耗时中会计算 Rsdoctor 的内部插件耗时。
 
 ## 使用说明
 
-### View bundler config
+### View Rspack config
 
-如需查看项目的 Rspack 配置，请点击卡片右上角的 `View Bundler Config`。弹出的面板会展示序列化后的 **Bundler Config**：
+如需查看项目的 Rspack 配置，请点击卡片右上角的 `View Rspack Config`。弹出的面板会展示序列化后的 **Rspack Config**：
 
 <img
   src="https://assets.rspack.rs/others/assets/rsdoctor/plugins-analysis-config.png"

--- a/packages/document/docs/zh/guide/usage/project-overall.mdx
+++ b/packages/document/docs/zh/guide/usage/project-overall.mdx
@@ -26,9 +26,9 @@
 
 ## 使用说明
 
-### View bundler config
+### View Rspack config
 
-如需查看项目的 Rspack 配置，请点击卡片右上角的 `View Bundler Config`。弹窗中会展示序列化后的 [Rspack 配置](https://rspack.rs/zh/config/)：
+如需查看项目的 Rspack 配置，请点击卡片右上角的 `View Rspack Config`。弹窗中会展示序列化后的 [Rspack 配置](https://rspack.rs/zh/config/)：
 
 <img
   src="https://assets.rspack.rs/others/assets/rsdoctor/project-overall-config.jpg"


### PR DESCRIPTION
## Summary

This PR includes 8 commits across 22 files, with 547 additions and 136 deletions:

1. Fixed Bundle Size overview overflow while preserving a four-column desktop layout and responsive two-/one-column layouts.
2. Improved Bundle Alerts:
   - Custom Rules now includes only extended rules.
   - Tabs support touch gestures, mouse dragging, wheel scrolling, and a visible scrollbar.
   - Fixed detail overflow and missing ECMA list keys.
3. Added a `Size / Gzip` toggle that updates both the displayed value and chart percentage, with refined typography and spacing.
4. Reduced timeline label density and prevented overlaps; renamed the config action to `View Rspack Config` and updated the English and Chinese docs.
5. Additional changes:
   - Changed the dependency-tree empty state to `No Data`.
   - Removed the compiler name from the analyzer URL log.
   - Added tests for Custom Rules grouping, horizontal scrolling, and timeline intervals.

## Related Links

None