### PR TITLE
fix(core): summarize ECMA version warnings

### DIFF
--- a/packages/core/src/inner-plugins/plugins/rules.ts
+++ b/packages/core/src/inner-plugins/plugins/rules.ts
@@ -5,6 +5,7 @@ import { pull } from '@rsdoctor/shared/collection';
 import { Plugin } from '@rsdoctor/shared/types';
 import type { RspackError } from '@rspack/core';
 import { time, timeEnd } from '@/logger';
+import { summarizeRuleWarnings } from '../utils/ruleWarnings';
 
 export class InternalRulesPlugin extends InternalBasePlugin<Plugin.BaseCompiler> {
   public readonly name = 'rules';
@@ -51,6 +52,7 @@ export class InternalRulesPlugin extends InternalBasePlugin<Plugin.BaseCompiler>
 
       const errors = validateErrors.filter((item) => item.level === 'Error');
       const warnings = validateErrors.filter((item) => item.level === 'Warn');
+      const compilationWarnings = summarizeRuleWarnings(warnings);
       const toRspackError = (err: DevToolError) =>
         err.toError() as unknown as RspackError;
 
@@ -76,7 +78,7 @@ export class InternalRulesPlugin extends InternalBasePlugin<Plugin.BaseCompiler>
       }
 
       if (Array.isArray(compilation.warnings)) {
-        warnings.forEach((err) => {
+        compilationWarnings.forEach((err) => {
           compilation.warnings.push(toRspackError(err));
         });
       }

--- a/packages/core/src/inner-plugins/utils/ruleWarnings.ts
+++ b/packages/core/src/inner-plugins/utils/ruleWarnings.ts
@@ -35,16 +35,16 @@ function createEcmaVersionWarningSummary(
     ...new Set(warnings.map(formatLocation).filter(Boolean) as string[]),
   ];
   const displayedLocations = locations.slice(0, MAX_DISPLAYED_LOCATIONS);
-  const remainingIssueCount = issueCount - displayedLocations.length;
+  const remainingFileCount = locations.length - displayedLocations.length;
   const message = [
     `Found ${issueCount} incompatible syntax ${
       issueCount === 1 ? 'issue' : 'issues'
     }${target ? ` for "${target}"` : ''}.`,
     displayedLocations.length
       ? `Affected outputs: ${displayedLocations.join(', ')}${
-          remainingIssueCount > 0
-            ? `, ... (+${remainingIssueCount} more ${
-                remainingIssueCount === 1 ? 'issue' : 'issues'
+          remainingFileCount > 0
+            ? `, ... (+${remainingFileCount} more ${
+                remainingFileCount === 1 ? 'file' : 'files'
               })`
             : ''
         }`

--- a/packages/core/src/inner-plugins/utils/ruleWarnings.ts
+++ b/packages/core/src/inner-plugins/utils/ruleWarnings.ts
@@ -1,0 +1,94 @@
+import { DevToolError } from '@/error';
+
+const ECMA_VERSION_CHECK_CODE = 'E1004';
+const MAX_DISPLAYED_LOCATIONS = 3;
+
+interface SyntaxLocation {
+  path?: string;
+  line?: number;
+  column?: number;
+}
+
+function formatLocation(error: DevToolError): string | undefined {
+  const syntaxError = error.detail?.error;
+  const location = (syntaxError?.output ?? syntaxError?.source) as
+    SyntaxLocation | undefined;
+
+  if (!location?.path) {
+    return undefined;
+  }
+
+  const position = [location.line, location.column]
+    .filter((value) => typeof value === 'number')
+    .join(':');
+
+  return position ? `${location.path}:${position}` : location.path;
+}
+
+function createEcmaVersionWarningSummary(
+  warnings: DevToolError[],
+): DevToolError {
+  const firstWarning = warnings[0];
+  const target = firstWarning.message.match(/"([^"]+)"/)?.[1];
+  const issueCount = warnings.length;
+  const locations = [
+    ...new Set(warnings.map(formatLocation).filter(Boolean) as string[]),
+  ];
+  const displayedLocations = locations.slice(0, MAX_DISPLAYED_LOCATIONS);
+  const remainingIssueCount = issueCount - displayedLocations.length;
+  const message = [
+    `Found ${issueCount} incompatible syntax ${
+      issueCount === 1 ? 'issue' : 'issues'
+    }${target ? ` for "${target}"` : ''}.`,
+    displayedLocations.length
+      ? `Affected outputs: ${displayedLocations.join(', ')}${
+          remainingIssueCount > 0
+            ? `, ... (+${remainingIssueCount} more ${
+                remainingIssueCount === 1 ? 'issue' : 'issues'
+              })`
+            : ''
+        }`
+      : undefined,
+    'View the Rsdoctor report for source-level details.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return new DevToolError(firstWarning.title, message, {
+    category: firstWarning.category,
+    code: firstWarning.code,
+    controller: {
+      noColor: true,
+    },
+    detail: firstWarning.detail,
+    level: firstWarning.level,
+  });
+}
+
+export function summarizeRuleWarnings(
+  warnings: DevToolError[],
+): DevToolError[] {
+  const ecmaVersionWarnings = warnings.filter(
+    ({ code }) => code === ECMA_VERSION_CHECK_CODE,
+  );
+
+  if (!ecmaVersionWarnings.length) {
+    return warnings;
+  }
+
+  const summary = createEcmaVersionWarningSummary(ecmaVersionWarnings);
+  let summaryAdded = false;
+
+  return warnings.flatMap((warning) => {
+    if (warning.code !== ECMA_VERSION_CHECK_CODE) {
+      return [warning];
+    }
+
+    if (summaryAdded) {
+      return [];
+    }
+
+    summaryAdded = true;
+    return [summary];
+  });
+}

--- a/packages/core/tests/plugins/rule-warnings.test.ts
+++ b/packages/core/tests/plugins/rule-warnings.test.ts
@@ -66,9 +66,23 @@ describe('summarizeRuleWarnings', () => {
     const [summary] = summarizeRuleWarnings(warnings);
 
     expect(summary.message).toContain(
-      'Affected outputs: src/module-0.js:1, src/module-1.js:2, src/module-2.js:3, ... (+2 more issues)',
+      'Affected outputs: src/module-0.js:1, src/module-1.js:2, src/module-2.js:3, ... (+2 more files)',
     );
     expect(summary.message).not.toContain('src/module-3.js');
+  });
+
+  it('does not count duplicate locations as additional files', () => {
+    const warnings = [
+      createWarning('E1004', { path: 'dist/main.js' }),
+      createWarning('E1004', { path: 'dist/main.js' }),
+      createWarning('E1004', { path: 'dist/async.js' }),
+      createWarning('E1004', { path: 'dist/vendor.js' }),
+      createWarning('E1004', { path: 'dist/runtime.js' }),
+    ];
+
+    const [summary] = summarizeRuleWarnings(warnings);
+
+    expect(summary.message).toContain('... (+1 more file)');
   });
 
   it('returns the original array when there are no E1004 warnings', () => {

--- a/packages/core/tests/plugins/rule-warnings.test.ts
+++ b/packages/core/tests/plugins/rule-warnings.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'rstack/test';
+import { DevToolError } from '@/error';
+import { summarizeRuleWarnings } from '../../src/inner-plugins/utils/ruleWarnings';
+
+function createWarning(
+  code: string,
+  output?: { path: string; line?: number; column?: number },
+  source?: { path: string; line?: number; column?: number },
+) {
+  return new DevToolError(
+    'ECMA-VERSION-CHECK',
+    'Found syntax that does not match "ecmaVersion <= 3"',
+    {
+      code,
+      detail: {
+        error: { output, source },
+      },
+      level: 'Warn',
+    },
+  );
+}
+
+describe('summarizeRuleWarnings', () => {
+  it('summarizes E1004 warnings without changing other rule warnings', () => {
+    const first = createWarning('E1004', {
+      path: 'dist/main.js',
+      line: 2,
+      column: 4,
+    });
+    const otherRule = createWarning('E1001');
+    const second = createWarning('E1004', {
+      path: 'dist/async.js',
+      line: 1,
+      column: 2,
+    });
+
+    const result = summarizeRuleWarnings([first, otherRule, second]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].code).toBe('E1004');
+    expect(result[0].message).toBe(
+      [
+        'Found 2 incompatible syntax issues for "ecmaVersion <= 3".',
+        'Affected outputs: dist/main.js:2:4, dist/async.js:1:2',
+        'View the Rsdoctor report for source-level details.',
+      ].join('\n'),
+    );
+    expect(result[0].toString()).toBe(
+      [
+        '[E1004:Warn:ECMA-VERSION-CHECK] Found 2 incompatible syntax issues for "ecmaVersion <= 3".',
+        'Affected outputs: dist/main.js:2:4, dist/async.js:1:2',
+        'View the Rsdoctor report for source-level details.',
+      ].join('\n'),
+    );
+    expect(result[1]).toBe(otherRule);
+  });
+
+  it('shows at most three locations and falls back to source paths', () => {
+    const warnings = Array.from({ length: 5 }, (_, index) =>
+      createWarning('E1004', undefined, {
+        path: `src/module-${index}.js`,
+        line: index + 1,
+      }),
+    );
+
+    const [summary] = summarizeRuleWarnings(warnings);
+
+    expect(summary.message).toContain(
+      'Affected outputs: src/module-0.js:1, src/module-1.js:2, src/module-2.js:3, ... (+2 more issues)',
+    );
+    expect(summary.message).not.toContain('src/module-3.js');
+  });
+
+  it('returns the original array when there are no E1004 warnings', () => {
+    const warnings = [createWarning('E1001')];
+
+    expect(summarizeRuleWarnings(warnings)).toBe(warnings);
+  });
+});


### PR DESCRIPTION
## Summary

Repeated E1004 diagnostics currently flood build output with identical warnings and hide the affected files. This PR collapses E1004 compiler warnings into one summary with the issue count and up to three output locations, while preserving every detailed diagnostic in the Rsdoctor report.

## Related links

None