### PR TITLE
fix(client): conditionally show source map alert

### DIFF
--- a/packages/client/src/components/Charts/TreeMap.tsx
+++ b/packages/client/src/components/Charts/TreeMap.tsx
@@ -560,7 +560,7 @@ export const TreeMap: React.FC<TreeMapProps> = memo(
 
     return option ? (
       <div className={Styles.mainArea}>
-        {showAlert && <TreemapAlert />}
+        {showAlert && sizeType === 'parsed' && <TreemapAlert />}
         <div className={Styles.chartRoot}>
           <EChartsReactCore
             ref={chartRef}

--- a/packages/client/src/components/Charts/TreeMap.tsx
+++ b/packages/client/src/components/Charts/TreeMap.tsx
@@ -18,6 +18,7 @@ import {
   FullscreenExitOutlined,
 } from '@ant-design/icons';
 import type { ComposeOption, EChartsType } from 'echarts/core';
+import { Rspack } from '@rsdoctor/shared/common-browser';
 import { formatSize, usePersistedState, useThemeToken } from 'src/utils';
 import { SDK } from '@rsdoctor/shared/types';
 import { ServerAPIProvider } from 'src/components/Manifest';
@@ -65,6 +66,7 @@ export type SizeType = TreeMapSizeType;
 interface TreeMapProps {
   treeData: TreeNode[];
   sizeType: SizeType;
+  showAlert?: boolean;
   style?: React.CSSProperties;
   onChartClick?: (params: ECElementEvent) => void;
   highlightNodeId?: number;
@@ -138,6 +140,7 @@ export const TreeMap: React.FC<TreeMapProps> = memo(
   ({
     treeData,
     sizeType,
+    showAlert,
     onChartClick,
     highlightNodeId,
     centerNodeId,
@@ -557,7 +560,7 @@ export const TreeMap: React.FC<TreeMapProps> = memo(
 
     return option ? (
       <div className={Styles.mainArea}>
-        <TreemapAlert />
+        {showAlert && <TreemapAlert />}
         <div className={Styles.chartRoot}>
           <EChartsReactCore
             ref={chartRef}
@@ -632,12 +635,16 @@ export const AssetTreemapWithFilter: React.FC<{
   return (
     <ServerAPIProvider api={SDK.ServerAPI.API.GetProjectInfo}>
       {(projectInfo) => {
+        const { isLynx, isEvalSourceMap } = Rspack.checkSourceMapSupport(
+          projectInfo.configs,
+        );
         return (
           <AssetTreemapWithFilterInner
             treeData={treeData}
             onChartClick={onChartClick}
             bundledSize={bundledSize}
             rootPath={projectInfo.root}
+            showAlert={isLynx || isEvalSourceMap}
           />
         );
       }}
@@ -650,7 +657,8 @@ const AssetTreemapWithFilterInner: React.FC<{
   onChartClick?: (params: ECElementEvent) => void;
   bundledSize?: boolean;
   rootPath: string;
-}> = ({ treeData, onChartClick, bundledSize = true, rootPath }) => {
+  showAlert?: boolean;
+}> = ({ treeData, onChartClick, bundledSize = true, rootPath, showAlert }) => {
   const assetNames = useMemo(
     () => treeData.map((item) => item.name),
     [treeData],
@@ -1009,6 +1017,7 @@ const AssetTreemapWithFilterInner: React.FC<{
       <TreeMap
         treeData={filteredTreeData}
         sizeType={sizeType}
+        showAlert={showAlert}
         onChartClick={handleChartClick}
         highlightNodeId={highlightNodeId}
         centerNodeId={centerNodeId}

--- a/packages/shared/src/common/rspack.ts
+++ b/packages/shared/src/common/rspack.ts
@@ -19,13 +19,17 @@ export function checkSourceMapSupport(configs: SDK.BundlerConfigData[]) {
     return {
       isRspack: false,
       hasSourceMap: false,
+      isLynx: false,
+      isEvalSourceMap: false,
     };
   }
 
-  const isRspack =
-    configs[0].name === 'rspack' && configs[0]?.config?.name !== 'lynx';
-  const devtool = configs[0].config?.devtool;
-  const plugins = configs[0].config?.plugins as string[];
+  const config = configs[0].config;
+  const isLynx = config?.name === 'lynx';
+  const isRspack = configs[0].name === 'rspack' && !isLynx;
+  const devtool = config?.devtool;
+  const isEvalSourceMap = typeof devtool === 'string' && /eval/i.test(devtool);
+  const plugins = config?.plugins as string[];
   const hasLynxSourcemapPlugin = plugins?.filter(
     (plugin) => plugin && plugin.includes('SourceMapDevToolPlugin'),
   );
@@ -33,11 +37,13 @@ export function checkSourceMapSupport(configs: SDK.BundlerConfigData[]) {
   const hasSourceMap =
     (typeof devtool === 'string' &&
       devtool.includes('source-map') &&
-      !devtool.includes('eval')) ||
+      !isEvalSourceMap) ||
     !!hasLynxSourcemapPlugin?.length;
 
   return {
     isRspack,
     hasSourceMap,
+    isLynx,
+    isEvalSourceMap,
   };
 }

--- a/packages/shared/tests/common/rspack.test.ts
+++ b/packages/shared/tests/common/rspack.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'rstack/test';
+import { Rspack } from '../../src/common-browser';
+import type { SDK } from '../../src/types';
+
+const createConfig = (
+  config: SDK.BundlerConfigData['config'],
+): SDK.BundlerConfigData => ({
+  name: 'rspack',
+  version: '1.0.0',
+  config,
+  root: '/',
+});
+
+describe('checkSourceMapSupport', () => {
+  it('identifies Lynx projects', () => {
+    expect(
+      Rspack.checkSourceMapSupport([createConfig({ name: 'lynx' })]),
+    ).toMatchObject({
+      isRspack: false,
+      isLynx: true,
+      isEvalSourceMap: false,
+    });
+  });
+
+  it.each([
+    'eval',
+    'eval-source-map',
+    'eval-cheap-module-source-map',
+    'inline-eval-source-map',
+  ])('identifies the %s devtool as an eval source map', (devtool) => {
+    expect(
+      Rspack.checkSourceMapSupport([createConfig({ devtool })]),
+    ).toMatchObject({
+      hasSourceMap: false,
+      isEvalSourceMap: true,
+    });
+  });
+
+  it.each([false, 'source-map', 'cheap-module-source-map'])(
+    'does not identify the %s devtool as an eval source map',
+    (devtool) => {
+      expect(
+        Rspack.checkSourceMapSupport([createConfig({ devtool })]),
+      ).toMatchObject({
+        isEvalSourceMap: false,
+      });
+    },
+  );
+});


### PR DESCRIPTION
## Summary

This PR limits parsed-size source map guidance to Lynx projects and builds whose `devtool` contains `eval`. Other source map configurations no longer show irrelevant guidance.

## Related Links

None