### PR TITLE
fix(client): normalize Lynx module hashes in bundle diff

### DIFF
--- a/packages/client/src/pages/Resources/BundleDiff/DiffContainer/moduleDiff.ts
+++ b/packages/client/src/pages/Resources/BundleDiff/DiffContainer/moduleDiff.ts
@@ -5,9 +5,10 @@ export function getModuleDiffKey(module: {
   identifier?: string;
   path?: string;
 }): string {
-  const identifier = module.identifier || module.path || '';
+  const normalize = (value: string | undefined) =>
+    value
+      ?.replace(moduleHashSuffixPattern, '')
+      .replace(moduleHashPattern, '') || '';
 
-  return identifier
-    .replace(moduleHashSuffixPattern, '')
-    .replace(moduleHashPattern, '');
+  return normalize(module.identifier) || normalize(module.path);
 }

--- a/packages/client/src/pages/Resources/BundleDiff/DiffContainer/moduleDiff.ts
+++ b/packages/client/src/pages/Resources/BundleDiff/DiffContainer/moduleDiff.ts
@@ -1,0 +1,13 @@
+const moduleHashPattern = /[a-fA-F0-9]{20,}/;
+const moduleHashSuffixPattern = /\|[a-fA-F0-9]{16,}$/;
+
+export function getModuleDiffKey(module: {
+  identifier?: string;
+  path?: string;
+}): string {
+  const identifier = module.identifier || module.path || '';
+
+  return identifier
+    .replace(moduleHashSuffixPattern, '')
+    .replace(moduleHashPattern, '');
+}

--- a/packages/client/src/pages/Resources/BundleDiff/DiffContainer/modules.tsx
+++ b/packages/client/src/pages/Resources/BundleDiff/DiffContainer/modules.tsx
@@ -22,7 +22,8 @@ import { KeywordInput } from '../../../../components/Form/keyword';
 import { ViewChanges } from './changes';
 import { UpdateType } from './constants';
 import { Badge as Bdg } from '../../../../components/Badge';
-import { ModuleHashPattern, getTargetColumnPropsForModuleRow } from './row';
+import { getModuleDiffKey } from './moduleDiff';
+import { getTargetColumnPropsForModuleRow } from './row';
 import { Graph } from '@rsdoctor/shared/common-browser';
 
 export function getUpdateType(e: BundleDiffTableModulesData): UpdateType {
@@ -111,9 +112,7 @@ export const Modules: React.FC<BundleDiffComponentCardProps> = ({
     const res: Record<string, BundleDiffTableModulesData> = {};
 
     bModules.forEach((mod) => {
-      const modPath =
-        mod.identifier?.replace(ModuleHashPattern, '') ||
-        mod.path?.replace(ModuleHashPattern, '');
+      const modPath = getModuleDiffKey(mod);
 
       if (!res[modPath]) {
         res[modPath] = {
@@ -126,9 +125,7 @@ export const Modules: React.FC<BundleDiffComponentCardProps> = ({
     });
 
     cModules.forEach((mod) => {
-      const modPath =
-        mod.identifier?.replace(ModuleHashPattern, '') ||
-        mod.path?.replace(ModuleHashPattern, '');
+      const modPath = getModuleDiffKey(mod);
 
       if (!res[modPath]) {
         res[modPath] = {

--- a/packages/client/src/pages/Resources/BundleDiff/DiffContainer/row.tsx
+++ b/packages/client/src/pages/Resources/BundleDiff/DiffContainer/row.tsx
@@ -33,10 +33,9 @@ import {
   BundleDiffTableModulesData,
 } from './types';
 import { UpdateType } from './constants';
+import { getModuleDiffKey } from './moduleDiff';
 import { formatDiffSize } from './utils';
 import { Graph } from '@rsdoctor/shared/common-browser';
-
-export const ModuleHashPattern = /[a-fA-F0-9]{20,}/;
 
 export const getSizeColumnPropsForModuleRow = (
   key: 'baseline' | 'current',
@@ -219,9 +218,7 @@ export const ModuleRowForAsset: React.FC<
 
     // group by module.path
     mods.forEach((mod) => {
-      const modPath =
-        mod.identifier?.replace(ModuleHashPattern, '') ||
-        mod.path?.replace(ModuleHashPattern, '');
+      const modPath = getModuleDiffKey(mod);
       let t: BundleDiffTableModulesData = map.get(modPath)!;
 
       if (!t) {

--- a/packages/client/tests/pages/Resources/BundleDiff/moduleDiff.test.ts
+++ b/packages/client/tests/pages/Resources/BundleDiff/moduleDiff.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from '@rstest/core';
+import { getModuleDiffKey } from '../../../../src/pages/Resources/BundleDiff/DiffContainer/moduleDiff';
+
+describe('getModuleDiffKey', () => {
+  it('removes Lynx module hash suffixes', () => {
+    expect(
+      getModuleDiffKey({
+        identifier: 'src/index.tsx|react:background|2403f25f21c75a9b',
+      }),
+    ).toBe('src/index.tsx|react:background');
+  });
+
+  it('matches modules when only their hash suffix changes', () => {
+    const baseline = getModuleDiffKey({
+      identifier: 'src/index.tsx|react:main-thread|4f54cd8870fbdd74',
+    });
+    const current = getModuleDiffKey({
+      identifier: 'src/index.tsx|react:main-thread|8b64892fb455b7bf',
+    });
+
+    expect(current).toBe(baseline);
+  });
+
+  it('preserves hexadecimal strings in module paths', () => {
+    expect(getModuleDiffKey({ path: 'src/0123456789abcdef/index.ts' })).toBe(
+      'src/0123456789abcdef/index.ts',
+    );
+  });
+});

--- a/packages/client/tests/pages/Resources/BundleDiff/moduleDiff.test.ts
+++ b/packages/client/tests/pages/Resources/BundleDiff/moduleDiff.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from '@rstest/core';
-import { getModuleDiffKey } from '../../../../src/pages/Resources/BundleDiff/DiffContainer/moduleDiff';
+import { describe, expect, it } from 'rstack/test';
+import { getModuleDiffKey } from 'src/pages/Resources/BundleDiff/DiffContainer/moduleDiff';
 
 describe('getModuleDiffKey', () => {
   it('removes Lynx module hash suffixes', () => {

--- a/packages/client/tests/pages/Resources/BundleDiff/moduleDiff.test.ts
+++ b/packages/client/tests/pages/Resources/BundleDiff/moduleDiff.test.ts
@@ -26,4 +26,20 @@ describe('getModuleDiffKey', () => {
       'src/0123456789abcdef/index.ts',
     );
   });
+
+  it('falls back to the path when normalizing the identifier removes it', () => {
+    expect(
+      getModuleDiffKey({
+        identifier: '0123456789abcdef0123',
+        path: 'src/index.tsx',
+      }),
+    ).toBe('src/index.tsx');
+
+    expect(
+      getModuleDiffKey({
+        identifier: '|0123456789abcdef',
+        path: 'src/App.tsx',
+      }),
+    ).toBe('src/App.tsx');
+  });
 });


### PR DESCRIPTION
## Summary

Lynx module identifiers can include 16-character hash suffixes, causing unchanged modules to appear as added and removed in bundle comparisons.

This PR normalizes structured module hash suffixes during matching while preserving hexadecimal segments in real module paths.