### PR TITLE
fix(components): normalize Lynx module hashes in bundle diff

### DIFF
--- a/packages/components/src/pages/Resources/BundleDiff/DiffContainer/moduleDiff.test.ts
+++ b/packages/components/src/pages/Resources/BundleDiff/DiffContainer/moduleDiff.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from '@rstest/core';
+import { getModuleDiffKey } from './moduleDiff';
+
+describe('getModuleDiffKey', () => {
+  it('removes Lynx module hash suffixes', () => {
+    expect(
+      getModuleDiffKey({
+        webpackId: 'src/index.tsx|react:background|2403f25f21c75a9b',
+      }),
+    ).toBe('src/index.tsx|react:background');
+  });
+
+  it('matches modules when only their hash suffix changes', () => {
+    expect(
+      getModuleDiffKey({
+        webpackId: 'src/index.tsx|react:background|2403f25f21c75a9b',
+      }),
+    ).toBe(
+      getModuleDiffKey({
+        webpackId: 'src/index.tsx|react:background|763a598f996fe14b',
+      }),
+    );
+  });
+
+  it('preserves 16-character hexadecimal segments in module paths', () => {
+    expect(
+      getModuleDiffKey({
+        webpackId: 'src/0123456789abcdef/index.ts',
+      }),
+    ).toBe('src/0123456789abcdef/index.ts');
+  });
+
+  it('falls back to the path when normalizing the webpack ID removes it', () => {
+    expect(
+      getModuleDiffKey({
+        webpackId: '0123456789abcdef0123',
+        path: 'src/index.tsx',
+      }),
+    ).toBe('src/index.tsx');
+
+    expect(
+      getModuleDiffKey({
+        webpackId: '|0123456789abcdef',
+        path: 'src/App.tsx',
+      }),
+    ).toBe('src/App.tsx');
+  });
+});

--- a/packages/components/src/pages/Resources/BundleDiff/DiffContainer/moduleDiff.ts
+++ b/packages/components/src/pages/Resources/BundleDiff/DiffContainer/moduleDiff.ts
@@ -1,0 +1,14 @@
+const moduleHashPattern = /[a-fA-F0-9]{20,}/;
+const moduleHashSuffixPattern = /\|[a-fA-F0-9]{16,}$/;
+
+export function getModuleDiffKey(module: {
+  webpackId?: string;
+  path?: string;
+}): string {
+  const normalize = (value: string | undefined) =>
+    value
+      ?.replace(moduleHashSuffixPattern, '')
+      .replace(moduleHashPattern, '') || '';
+
+  return normalize(module.webpackId) || normalize(module.path);
+}

--- a/packages/components/src/pages/Resources/BundleDiff/DiffContainer/modules.tsx
+++ b/packages/components/src/pages/Resources/BundleDiff/DiffContainer/modules.tsx
@@ -22,8 +22,9 @@ import { KeywordInput } from '../../../../components/Form/keyword';
 import { ViewChanges } from './changes';
 import { UpdateType } from './constants';
 import { Badge as Bdg } from '../../../../components/Badge';
-import { ModuleHashPattern, getTargetColumnPropsForModuleRow } from './row';
+import { getTargetColumnPropsForModuleRow } from './row';
 import { Graph } from '@rsdoctor/utils/common';
+import { getModuleDiffKey } from './moduleDiff';
 
 export function getUpdateType(e: BundleDiffTableModulesData): UpdateType {
   if (e.baseline && !e.current) {
@@ -111,9 +112,7 @@ export const Modules: React.FC<BundleDiffComponentCardProps> = ({
     const res: Record<string, BundleDiffTableModulesData> = {};
 
     bModules.forEach((mod) => {
-      const modPath =
-        mod.webpackId?.replace(ModuleHashPattern, '') ||
-        mod.path?.replace(ModuleHashPattern, '');
+      const modPath = getModuleDiffKey(mod);
 
       if (!res[modPath]) {
         res[modPath] = {
@@ -126,9 +125,7 @@ export const Modules: React.FC<BundleDiffComponentCardProps> = ({
     });
 
     cModules.forEach((mod) => {
-      const modPath =
-        mod.webpackId?.replace(ModuleHashPattern, '') ||
-        mod.path?.replace(ModuleHashPattern, '');
+      const modPath = getModuleDiffKey(mod);
 
       if (!res[modPath]) {
         res[modPath] = {

--- a/packages/components/src/pages/Resources/BundleDiff/DiffContainer/row.tsx
+++ b/packages/components/src/pages/Resources/BundleDiff/DiffContainer/row.tsx
@@ -35,8 +35,7 @@ import {
 import { UpdateType } from './constants';
 import { formatDiffSize } from './utils';
 import { Graph } from '@rsdoctor/utils/common';
-
-export const ModuleHashPattern = /[a-fA-F0-9]{20,}/;
+import { getModuleDiffKey } from './moduleDiff';
 
 export const getSizeColumnPropsForModuleRow = (
   key: 'baseline' | 'current',
@@ -219,9 +218,7 @@ export const ModuleRowForAsset: React.FC<
 
     // group by module.path
     mods.forEach((mod) => {
-      const modPath =
-        mod.webpackId?.replace(ModuleHashPattern, '') ||
-        mod.path?.replace(ModuleHashPattern, '');
+      const modPath = getModuleDiffKey(mod);
       let t: BundleDiffTableModulesData = map.get(modPath)!;
 
       if (!t) {

--- a/packages/components/tests/pages/Resources/BundleDiff/moduleDiff.test.ts
+++ b/packages/components/tests/pages/Resources/BundleDiff/moduleDiff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@rstest/core';
-import { getModuleDiffKey } from './moduleDiff';
+import { getModuleDiffKey } from '../../../../src/pages/Resources/BundleDiff/DiffContainer/moduleDiff';
 
 describe('getModuleDiffKey', () => {
   it('removes Lynx module hash suffixes', () => {

--- a/packages/components/tests/pages/Resources/BundleDiff/moduleDiff.test.ts
+++ b/packages/components/tests/pages/Resources/BundleDiff/moduleDiff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@rstest/core';
-import { getModuleDiffKey } from '../../../../src/pages/Resources/BundleDiff/DiffContainer/moduleDiff';
+import { getModuleDiffKey } from 'src/pages/Resources/BundleDiff/DiffContainer/moduleDiff';
 
 describe('getModuleDiffKey', () => {
   it('removes Lynx module hash suffixes', () => {


### PR DESCRIPTION
## Summary

Lynx module IDs can include unstable 16-character hash suffixes, causing unchanged modules to appear as added and removed in v1.x bundle diff. This backports the matching normalization from #1972 and falls back to the module path when identifier normalization is empty.

## Related Links

https://github.com/web-infra-dev/rsdoctor/pull/1972