### PR TITLE
docs: separate blog topics and reorder guide sections

### DIFF
--- a/packages/document/docs/en/guide/_meta.json
+++ b/packages/document/docs/en/guide/_meta.json
@@ -16,11 +16,6 @@
   },
   {
     "type": "dir-section-header",
-    "name": "more",
-    "label": "More"
-  },
-  {
-    "type": "dir-section-header",
     "name": "migration",
     "label": "Migration"
   },
@@ -28,5 +23,10 @@
     "type": "dir-section-header",
     "name": "v1",
     "label": "Rsdoctor 1.x Archive"
+  },
+  {
+    "type": "dir-section-header",
+    "name": "more",
+    "label": "More"
   }
 ]

--- a/packages/document/docs/zh/guide/_meta.json
+++ b/packages/document/docs/zh/guide/_meta.json
@@ -16,11 +16,6 @@
   },
   {
     "type": "dir-section-header",
-    "name": "more",
-    "label": "更多"
-  },
-  {
-    "type": "dir-section-header",
     "name": "migration",
     "label": "迁移"
   },
@@ -28,5 +23,10 @@
     "type": "dir-section-header",
     "name": "v1",
     "label": "Rsdoctor 1.x 归档"
+  },
+  {
+    "type": "dir-section-header",
+    "name": "more",
+    "label": "更多"
   }
 ]

--- a/packages/document/theme/components/BlogList/index.module.scss
+++ b/packages/document/theme/components/BlogList/index.module.scss
@@ -1,5 +1,13 @@
-.list {
+.section {
   margin: 40px 0;
+
+  + .section {
+    margin-top: 64px;
+  }
+}
+
+.list {
+  margin: 24px 0 0;
 
   .title {
     margin: 0;

--- a/packages/document/theme/components/BlogList/index.tsx
+++ b/packages/document/theme/components/BlogList/index.tsx
@@ -4,6 +4,11 @@ import { useSyncExternalStore } from 'react';
 import { posts } from './posts';
 import styles from './index.module.scss';
 
+const sections = [
+  { path: 'release/', en: 'Release Notes', zh: 'Release 公告' },
+  { path: 'topic/', en: 'Topics', zh: '专题' },
+];
+
 const reducedMotionQuery = '(prefers-reduced-motion: reduce)';
 const subscribeToMotionPreference = (onChange: () => void) => {
   const media = window.matchMedia(reducedMotionQuery);
@@ -30,32 +35,39 @@ export function BlogList({ lang }: { lang: 'en' | 'zh' }) {
   return (
     <>
       <BlogBackground showBackground={!reducedMotion} />
-      <BaseBlogList
-        className={styles.list}
-        lang={lang}
-        interactive={!reducedMotion}
-        hideDocLayoutSidebarAndOutline={false}
-        posts={posts.map((post) => ({
-          id: post.path,
-          authors: post.authors,
-          href: `${lang === 'zh' ? '/zh' : ''}/blog/${post.path}`,
-          title: (
-            <>
-              {post.date ? (
-                <time className={styles.meta} dateTime={post.date}>
-                  {dateFormatter(post.date)}
-                </time>
-              ) : (
-                <span className={styles.meta}>
-                  {lang === 'zh' ? '专题' : 'Topic'}
-                </span>
-              )}
-              <h2 className={styles.title}>{post[lang].title}</h2>
-            </>
-          ),
-          description: post[lang].description,
-        }))}
-      />
+      {sections.map((section) => (
+        <section key={section.path} className={styles.section}>
+          <h2>{section[lang]}</h2>
+          <BaseBlogList
+            className={styles.list}
+            lang={lang}
+            interactive={!reducedMotion}
+            hideDocLayoutSidebarAndOutline={false}
+            posts={posts
+              .filter((post) => post.path.startsWith(section.path))
+              .map((post) => ({
+                id: post.path,
+                authors: post.authors,
+                href: `${lang === 'zh' ? '/zh' : ''}/blog/${post.path}`,
+                title: (
+                  <>
+                    {post.date ? (
+                      <time className={styles.meta} dateTime={post.date}>
+                        {dateFormatter(post.date)}
+                      </time>
+                    ) : (
+                      <span className={styles.meta}>
+                        {lang === 'zh' ? '专题' : 'Topic'}
+                      </span>
+                    )}
+                    <h3 className={styles.title}>{post[lang].title}</h3>
+                  </>
+                ),
+                description: post[lang].description,
+              }))}
+          />
+        </section>
+      ))}
     </>
   );
 }


### PR DESCRIPTION
## Summary

- Separate release notes and topic articles into distinct sections on the English and Chinese blog pages so readers can browse each category independently.
- Move Migration and Rsdoctor 1.x Archive above More in both guide sidebars.

## Related Links

- Follow-up to https://github.com/web-infra-dev/rsdoctor/pull/1977