### PR TITLE
release: v2.0.0-beta.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/cli",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/client",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/core",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/docs",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/shared",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",


### PR DESCRIPTION
## Summary

Prepare the Rsdoctor 2.0.0-beta.1 release by bumping CLI, client, core, docs, and shared from 2.0.0-beta.0. The independently versioned agent-cli remains at 0.1.0.

## Related Links

None.