### PR TITLE
feat(core): add compiler indexes to brief JSON reports

### DIFF
--- a/packages/core/src/sdk/multiple/controller.ts
+++ b/packages/core/src/sdk/multiple/controller.ts
@@ -80,13 +80,10 @@ export class RsdoctorSDKController {
       return path.join(rootOutputDir, existing.directory);
     }
 
-    const name =
-      slave.name
-        .replace(
-          slave.isChild ? /[^a-zA-Z0-9_$.-]+/g : /[^a-zA-Z0-9_$-]+/g,
-          '-',
-        )
-        .replace(/^[-.]+|[-.]+$/g, '') || `compiler-${slave.id}`;
+    const name = slave.isChild
+      ? slave.name.replace(/\s+/g, '-')
+      : slave.name.replace(/[^a-zA-Z0-9_$-]+/g, '-').replace(/^-+|-+$/g, '') ||
+        `compiler-${slave.id}`;
     const folder = slave.isChild ? '.slaves' : 'compilers';
     const occupied = new Set(
       [...this.compilerDirectories.values()].map(({ directory }) =>

--- a/packages/core/src/sdk/multiple/controller.ts
+++ b/packages/core/src/sdk/multiple/controller.ts
@@ -1,6 +1,8 @@
 import { Constants, Manifest } from '@rsdoctor/shared/types';
 import path from 'node:path';
+import fs from 'node:fs';
 import { RsdoctorPrimarySDK } from './primary';
+import { writeJsonAtomic } from '../utils/writeJson';
 
 function toUrlPath(filePath: string) {
   return filePath
@@ -19,6 +21,16 @@ export class RsdoctorSDKController {
   private outputOwner?: RsdoctorPrimarySDK;
 
   private refreshManifestTask = Promise.resolve();
+
+  private readonly compilerDirectories = new Map<
+    RsdoctorPrimarySDK,
+    { name: string; directory: string }
+  >();
+
+  private readonly briefReports = new Map<
+    RsdoctorPrimarySDK,
+    { filePath: string; metadata: string }
+  >();
 
   public root = '';
 
@@ -63,18 +75,87 @@ export class RsdoctorSDKController {
 
     const rootOutputDir =
       this.outputDir || this.master?.outputDir || slave.outputDir;
-    if (slave.isChild) {
-      return path.join(
-        rootOutputDir,
-        '.slaves',
-        slave.name.replace(/\s+/g, '-'),
-      );
+    const existing = this.compilerDirectories.get(slave);
+    if (existing?.name === slave.name) {
+      return path.join(rootOutputDir, existing.directory);
     }
 
     const name =
-      slave.name.replace(/[^a-zA-Z0-9_$-]+/g, '-').replace(/^-+|-+$/g, '') ||
-      `compiler-${slave.id}`;
-    return path.join(rootOutputDir, 'compilers', name);
+      slave.name
+        .replace(
+          slave.isChild ? /[^a-zA-Z0-9_$.-]+/g : /[^a-zA-Z0-9_$-]+/g,
+          '-',
+        )
+        .replace(/^[-.]+|[-.]+$/g, '') || `compiler-${slave.id}`;
+    const folder = slave.isChild ? '.slaves' : 'compilers';
+    const occupied = new Set(
+      [...this.compilerDirectories.values()].map(({ directory }) =>
+        directory.toLowerCase(),
+      ),
+    );
+    let directory = path.join(folder, name);
+    let suffix = 2;
+    while (occupied.has(directory.toLowerCase())) {
+      directory = path.join(folder, `${name}-${suffix++}`);
+    }
+    this.compilerDirectories.set(slave, { name: slave.name, directory });
+    return path.join(rootOutputDir, directory);
+  }
+
+  writeBriefJson(
+    current: RsdoctorPrimarySDK,
+    data: Manifest.RsdoctorBriefData,
+  ) {
+    const compilers = this.getActiveSlaves().flatMap((sdk) => {
+      const filePath = sdk.getBriefJsonPath(this.getCompilerOutputDir(sdk));
+      return filePath ? [{ sdk, filePath }] : [];
+    });
+    const paths = new Set<string>();
+    for (const { filePath } of compilers) {
+      const key = filePath.toLowerCase();
+      if (paths.has(key)) {
+        throw new Error(`Compiler JSON output paths overlap: ${filePath}`);
+      }
+      paths.add(key);
+    }
+
+    // Keep data writes and metadata refreshes synchronous so a refresh cannot
+    // overwrite a newer watch build in the same process. Cache only metadata.
+    for (const { sdk, filePath } of compilers) {
+      const series: Manifest.RsdoctorBriefSeriesData[] = compilers.map(
+        ({ sdk: item, filePath: target }) => ({
+          name: item.name,
+          displayName: item.displayName,
+          dataFile: path
+            .relative(path.dirname(filePath), target)
+            .split(path.sep)
+            .join('/'),
+          stage: item.stage,
+          compilerPath: item.compilerPath,
+          parentCompilerPath: item.parentCompilerPath,
+          isChild: item.isChild,
+        }),
+      );
+      const metadata = { name: sdk.name, series };
+      const signature = JSON.stringify(metadata);
+      const previous = this.briefReports.get(sdk);
+      if (sdk !== current) {
+        if (
+          !previous ||
+          previous.filePath !== filePath ||
+          !fs.existsSync(filePath)
+        ) {
+          continue;
+        }
+        if (previous.metadata === signature) {
+          continue;
+        }
+      }
+      const report: Manifest.RsdoctorBriefData =
+        sdk === current ? data : JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      writeJsonAtomic(filePath, { ...report, ...metadata });
+      this.briefReports.set(sdk, { filePath, metadata: signature });
+    }
   }
 
   getSeriesData(serverUrl = false) {

--- a/packages/core/src/sdk/multiple/primary.ts
+++ b/packages/core/src/sdk/multiple/primary.ts
@@ -87,6 +87,10 @@ export class RsdoctorPrimarySDK
     return this.parent.master === this;
   }
 
+  protected writeBriefJson(data: Manifest.RsdoctorBriefData): void {
+    this.parent.writeBriefJson(this, data);
+  }
+
   protected async writePieces(
     _storeData: Common.PlainObject,
     options?: SDK.WriteStoreOptionsType,

--- a/packages/core/src/sdk/sdk/index.ts
+++ b/packages/core/src/sdk/sdk/index.ts
@@ -15,6 +15,7 @@ import { Algorithm } from '@rsdoctor/shared/common-browser';
 import { Lodash } from '@rsdoctor/shared/common-browser';
 import { findRoot } from '../utils';
 import { decycle } from '@rsdoctor/shared/common-browser';
+import { writeJsonAtomic } from '../utils/writeJson';
 
 export * from '../utils/openBrowser';
 export * from '../utils/base';
@@ -394,6 +395,23 @@ export class RsdoctorSDK<
     }
   }
 
+  public getBriefJsonPath(outputDir = this.outputDir): string | undefined {
+    if (
+      this.extraConfig?.mode !== 'brief' ||
+      !this.extraConfig.brief?.type?.includes('json')
+    ) {
+      return undefined;
+    }
+    return path.resolve(
+      outputDir,
+      this.extraConfig.brief.jsonOptions?.fileName ?? 'rsdoctor-data.json',
+    );
+  }
+
+  protected writeBriefJson(data: Manifest.RsdoctorBriefData): void {
+    writeJsonAtomic(this.getBriefJsonPath()!, data);
+  }
+
   public async writeStore(options?: SDK.WriteStoreOptionsType) {
     logger.debug(`sdk.writeStore has run.`, '[SDK.writeStore][end]');
     let htmlPath = '';
@@ -410,15 +428,7 @@ export class RsdoctorSDK<
           clientRoutes,
         };
 
-        fs.mkdirSync(this.outputDir, { recursive: true });
-        fs.writeFileSync(
-          path.resolve(
-            this.outputDir,
-            this.extraConfig.brief.jsonOptions?.fileName ??
-              'rsdoctor-data.json',
-          ),
-          JSON.stringify(jsonData),
-        );
+        this.writeBriefJson(jsonData);
       }
       if (this.extraConfig.brief?.type?.includes('html')) {
         htmlPath = this.inlineScriptsAndStyles(clientHtmlPath);

--- a/packages/core/src/sdk/utils/writeJson.ts
+++ b/packages/core/src/sdk/utils/writeJson.ts
@@ -1,0 +1,15 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+export function writeJsonAtomic(filePath: string, data: unknown): void {
+  const content = JSON.stringify(data);
+  const temporaryPath = `${filePath}.${randomUUID()}.tmp`;
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  try {
+    fs.writeFileSync(temporaryPath, content);
+    fs.renameSync(temporaryPath, filePath);
+  } finally {
+    fs.rmSync(temporaryPath, { force: true });
+  }
+}

--- a/packages/core/tests/rspack-plugin/brief-json.test.ts
+++ b/packages/core/tests/rspack-plugin/brief-json.test.ts
@@ -1,0 +1,76 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { rspack } from '@rspack/core';
+import type { Manifest } from '@rsdoctor/shared/types';
+import { RsdoctorRspackPlugin } from '@/rspack-plugin';
+import { it, expect } from 'rstack/test';
+
+it('writes discoverable and isolated JSON for a real multi-compiler build', async () => {
+  const root = fs.mkdtempSync(path.join(tmpdir(), 'rsdoctor-rspack-json-'));
+  const reportDir = path.join(root, 'report');
+  const plugin = new RsdoctorRspackPlugin({
+    disableClientServer: true,
+    output: { reportDir, mode: 'brief', options: { type: ['json'] } },
+  });
+  const names = ['client', 'server'];
+  for (const name of names) {
+    fs.writeFileSync(path.join(root, `${name}.js`), `console.log('${name}');`);
+  }
+  const compiler = rspack(
+    names.map((name) => ({
+      name,
+      mode: 'development',
+      devtool: false,
+      context: root,
+      entry: `./${name}.js`,
+      output: { path: path.join(root, 'assets', name) },
+      plugins: [plugin],
+    })),
+  );
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      compiler.run((error, stats) => {
+        if (error) reject(error);
+        else if (!stats || stats.hasErrors())
+          reject(
+            new Error(
+              stats?.toString({ errors: true }) ?? 'Missing build stats',
+            ),
+          );
+        else resolve();
+      });
+    });
+    const entryFile = path.join(reportDir, 'rsdoctor-data.json');
+    const report: Manifest.RsdoctorBriefData = JSON.parse(
+      fs.readFileSync(entryFile, 'utf8'),
+    );
+    expect(report.series?.map((item) => item.name)).toEqual(names);
+    for (const item of report.series!) {
+      const filePath = path.resolve(reportDir, item.dataFile);
+      const data: Manifest.RsdoctorBriefData = JSON.parse(
+        fs.readFileSync(filePath, 'utf8'),
+      );
+      expect(data.name).toBe(item.name);
+      expect(data.series).toHaveLength(2);
+      const moduleNames = data.data.moduleGraph.modules.map((module) =>
+        path.basename(module.path),
+      );
+      expect(moduleNames).toContain(`${item.name}.js`);
+      expect(moduleNames).not.toContain(
+        `${item.name === 'client' ? 'server' : 'client'}.js`,
+      );
+    }
+  } finally {
+    try {
+      await new Promise<void>((resolve, reject) =>
+        compiler.close((error) => (error ? reject(error) : resolve())),
+      );
+    } finally {
+      delete globalThis.__rsdoctor_sdk__;
+      delete globalThis.__rsdoctor_sdks__;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+});

--- a/packages/core/tests/sdk/sdk/core/brief-json-output.test.ts
+++ b/packages/core/tests/sdk/sdk/core/brief-json-output.test.ts
@@ -14,7 +14,7 @@ describe('brief json output', () => {
     if (outputDir) await File.fse.remove(outputDir);
   });
 
-  it('should write compact JSON without formatting whitespace', async () => {
+  it('should preserve the standalone JSON shape and compact formatting', async () => {
     target = await createSDK({
       noServer: true,
       mode: 'brief',
@@ -30,6 +30,8 @@ describe('brief json output', () => {
     const jsonDataPath = path.join(outputDir, 'rsdoctor-data.json');
     const content = fs.readFileSync(jsonDataPath, 'utf-8');
 
-    expect(content).toBe(JSON.stringify(JSON.parse(content)));
+    const report = JSON.parse(content);
+    expect(Object.keys(report).sort()).toEqual(['clientRoutes', 'data']);
+    expect(content).toBe(JSON.stringify(report));
   });
 });

--- a/packages/core/tests/sdk/sdk/core/brief-multiple-output.test.ts
+++ b/packages/core/tests/sdk/sdk/core/brief-multiple-output.test.ts
@@ -172,6 +172,27 @@ describe('multi-compiler brief JSON', () => {
     }
   });
 
+  it('preserves legacy child directory names while isolating collisions', async () => {
+    const client = createCompiler('client');
+    const child = createCompiler('child worker-0-', { isChild: true });
+    const sibling = createCompiler('child-worker-0-', { isChild: true });
+    await Promise.all([client, child, sibling].map((sdk) => sdk.writeStore()));
+
+    const childFile = path.join(
+      outputDir,
+      '.slaves',
+      'child-worker-0-',
+      'rsdoctor-data.json',
+    );
+    expect(child.getBriefJsonPath()).toBe(childFile);
+    expect(readReport(childFile).name).toBe(child.name);
+    expect(sibling.getBriefJsonPath()).not.toBe(childFile);
+    expect(readReport(sibling.getBriefJsonPath()!).name).toBe(sibling.name);
+    expect(readReport(client.getBriefJsonPath()!).series?.[1].dataFile).toBe(
+      '.slaves/child-worker-0-/rsdoctor-data.json',
+    );
+  });
+
   it('rejects custom filenames that resolve to the same output file', async () => {
     const client = createCompiler('client');
     await client.writeStore();

--- a/packages/core/tests/sdk/sdk/core/brief-multiple-output.test.ts
+++ b/packages/core/tests/sdk/sdk/core/brief-multiple-output.test.ts
@@ -2,9 +2,9 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, beforeEach, describe, expect, it, rs } from 'rstack/test';
-import { Manifest, SDK } from '@rsdoctor/shared/types';
+import { type Manifest, SDK } from '@rsdoctor/shared/types';
 import { RsdoctorSDKController } from '@/sdk/multiple/controller';
-import { RsdoctorSDK } from '@/sdk';
+import type { RsdoctorSDK } from '@/sdk';
 
 describe('multi-compiler brief JSON', () => {
   let outputDir: string;
@@ -52,8 +52,22 @@ describe('multi-compiler brief JSON', () => {
     return sdk;
   }
 
-  function readReport(filePath: string): Manifest.RsdoctorBriefData {
+  function readReport(
+    source: string | RsdoctorSDK,
+  ): Manifest.RsdoctorBriefData {
+    const filePath =
+      typeof source === 'string' ? source : source.getBriefJsonPath()!;
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  }
+
+  function expectSeries(filePath: string, names: string[]) {
+    const { series } = readReport(filePath);
+    expect(series?.map((item) => item.name)).toEqual(names);
+    for (const { name, dataFile } of series!) {
+      expect(
+        readReport(path.resolve(path.dirname(filePath), dataFile)).name,
+      ).toBe(name);
+    }
   }
 
   it.each([false, true])(
@@ -66,26 +80,18 @@ describe('multi-compiler brief JSON', () => {
       }
 
       for (const sdk of [client, server]) {
-        const report = readReport(sdk.getBriefJsonPath()!);
-        expect(report.name).toBe(sdk.name);
-        expect(report.data.summary.costs[0].name).toBe(sdk.name);
-        expect(report.clientRoutes).toEqual(sdk.getClientRoutes());
-        expect(report.series?.map((item) => item.name)).toEqual([
-          'client',
-          'server',
-        ]);
-        for (const item of report.series!) {
-          const target = path.resolve(
-            path.dirname(sdk.getBriefJsonPath()!),
-            item.dataFile,
-          );
-          expect(readReport(target).name).toBe(item.name);
-        }
+        const report = readReport(sdk);
+        expect(report).toMatchObject({
+          name: sdk.name,
+          data: { summary: { costs: [{ name: sdk.name }] } },
+          clientRoutes: sdk.getClientRoutes(),
+        });
+        expectSeries(sdk.getBriefJsonPath()!, ['client', 'server']);
       }
-      expect(readReport(client.getBriefJsonPath()!).series?.[1].dataFile).toBe(
+      expect(readReport(client).series?.[1].dataFile).toBe(
         'compilers/server/rsdoctor-data.json',
       );
-      expect(readReport(server.getBriefJsonPath()!).series?.[0].dataFile).toBe(
+      expect(readReport(server).series?.[0].dataFile).toBe(
         '../../rsdoctor-data.json',
       );
     },
@@ -94,11 +100,11 @@ describe('multi-compiler brief JSON', () => {
   it('refreshes earlier reports for late child compilers without restoring old build data', async () => {
     const client = createCompiler('client');
     await client.writeStore();
-    expect(readReport(client.getBriefJsonPath()!).series).toHaveLength(1);
+    expect(readReport(client).series).toHaveLength(1);
 
     const child = createCompiler('child.worker', { isChild: true });
     await child.writeStore();
-    const clientReport = readReport(client.getBriefJsonPath()!);
+    const clientReport = readReport(client);
     expect(clientReport.series?.[1]).toMatchObject({
       name: 'child.worker',
       dataFile: '.slaves/child.worker/rsdoctor-data.json',
@@ -111,10 +117,12 @@ describe('multi-compiler brief JSON', () => {
     await client.writeStore();
     const server = createCompiler('server');
     await server.writeStore();
-    expect(
-      readReport(client.getBriefJsonPath()!).data.summary.costs,
-    ).toContainEqual({ name: 'rebuilt', startAt: 0, costs: 42 });
-    expect(readReport(child.getBriefJsonPath()!).series).toHaveLength(3);
+    expect(readReport(client).data.summary.costs).toContainEqual({
+      name: 'rebuilt',
+      startAt: 0,
+      costs: 42,
+    });
+    expect(readReport(child).series).toHaveLength(3);
 
     const read = rs.spyOn(fs, 'readFileSync');
     await client.writeStore();
@@ -133,107 +141,78 @@ describe('multi-compiler brief JSON', () => {
     await client.writeStore();
     await server.writeStore();
 
-    const movedDir = path.join(outputDir, 'moved');
-    fs.mkdirSync(movedDir);
-    fs.renameSync(path.join(outputDir, 'data'), path.join(movedDir, 'data'));
-    fs.renameSync(
-      path.join(outputDir, 'compilers'),
-      path.join(movedDir, 'compilers'),
-    );
-    const movedFile = path.join(movedDir, 'data/client data.json');
-    const report = readReport(movedFile);
-    expect(report.series).toHaveLength(2);
-    for (const item of report.series!) {
-      const target = path.resolve(path.dirname(movedFile), item.dataFile);
-      const targetReport = readReport(target);
-      expect(targetReport.name).toBe(item.name);
-      for (const sibling of targetReport.series!) {
-        expect(
-          readReport(path.resolve(path.dirname(target), sibling.dataFile)).name,
-        ).toBe(sibling.name);
+    const movedDir = `${outputDir}-moved`;
+    fs.renameSync(outputDir, movedDir);
+    outputDir = movedDir;
+    for (const file of [
+      'data/client data.json',
+      'compilers/server/data/server.json',
+    ]) {
+      expectSeries(path.join(outputDir, file), ['client', 'server']);
+    }
+  });
+
+  it.each([
+    {
+      names: [
+        'web/client',
+        'web:client',
+        'web-client-2',
+        'WEB-CLIENT',
+        'web/client',
+      ],
+      isChild: false,
+    },
+    { names: ['child worker-0-', 'child-worker-0-'], isChild: true },
+  ])(
+    'isolates colliding directory names (child: $isChild)',
+    async ({ names, isChild }) => {
+      const client = createCompiler('client');
+      const compilers = names.map((name) => createCompiler(name, { isChild }));
+      await Promise.all([client, ...compilers].map((sdk) => sdk.writeStore()));
+
+      const paths = compilers.map((sdk) =>
+        sdk.getBriefJsonPath()!.toLowerCase(),
+      );
+      expect(new Set(paths).size).toBe(compilers.length);
+      for (const sdk of compilers) {
+        expect(readReport(sdk).name).toBe(sdk.name);
       }
-    }
-  });
-
-  it('isolates duplicate, sanitized and case-insensitive directory names', async () => {
-    const compilers = [
-      'client',
-      'web/client',
-      'web:client',
-      'web-client-2',
-      'WEB-CLIENT',
-      'web/client',
-    ].map((name) => createCompiler(name));
-    await Promise.all(compilers.map((sdk) => sdk.writeStore()));
-    const paths = compilers.map((sdk) => sdk.getBriefJsonPath()!.toLowerCase());
-    expect(new Set(paths).size).toBe(compilers.length);
-    for (const sdk of compilers) {
-      expect(readReport(sdk.getBriefJsonPath()!).name).toBe(sdk.name);
-    }
-  });
-
-  it('preserves legacy child directory names while isolating collisions', async () => {
-    const client = createCompiler('client');
-    const child = createCompiler('child worker-0-', { isChild: true });
-    const sibling = createCompiler('child-worker-0-', { isChild: true });
-    await Promise.all([client, child, sibling].map((sdk) => sdk.writeStore()));
-
-    const childFile = path.join(
-      outputDir,
-      '.slaves',
-      'child-worker-0-',
-      'rsdoctor-data.json',
-    );
-    expect(child.getBriefJsonPath()).toBe(childFile);
-    expect(readReport(childFile).name).toBe(child.name);
-    expect(sibling.getBriefJsonPath()).not.toBe(childFile);
-    expect(readReport(sibling.getBriefJsonPath()!).name).toBe(sibling.name);
-    expect(readReport(client.getBriefJsonPath()!).series?.[1].dataFile).toBe(
-      '.slaves/child-worker-0-/rsdoctor-data.json',
-    );
-  });
+      expectSeries(client.getBriefJsonPath()!, [
+        'client',
+        ...compilers.map((sdk) => sdk.name),
+      ]);
+      if (isChild) {
+        expect(readReport(client).series?.[1].dataFile).toBe(
+          '.slaves/child-worker-0-/rsdoctor-data.json',
+        );
+      }
+    },
+  );
 
   it('rejects custom filenames that resolve to the same output file', async () => {
     const client = createCompiler('client');
     await client.writeStore();
-    const original = fs.readFileSync(client.getBriefJsonPath()!, 'utf8');
+    const original = readReport(client);
     const server = createCompiler('server', {
       fileName: '../../rsdoctor-data.json',
     });
     await expect(server.writeStore()).rejects.toThrow(
       'Compiler JSON output paths overlap',
     );
-    expect(fs.readFileSync(client.getBriefJsonPath()!, 'utf8')).toBe(original);
+    expect(readReport(client)).toEqual(original);
   });
 
   it('keeps the previous JSON intact and cleans temporary files when replacement fails', async () => {
     const client = createCompiler('client');
     await client.writeStore();
-    const original = fs.readFileSync(client.getBriefJsonPath()!, 'utf8');
+    const original = readReport(client);
     rs.spyOn(fs, 'renameSync').mockImplementationOnce(() => {
       throw new Error('replacement failed');
     });
     await expect(client.writeStore()).rejects.toThrow('replacement failed');
-    expect(fs.readFileSync(client.getBriefJsonPath()!, 'utf8')).toBe(original);
+    expect(readReport(client)).toEqual(original);
     expect(fs.readdirSync(outputDir)).toEqual(['rsdoctor-data.json']);
     await client.writeStore();
-  });
-
-  it('preserves the standalone SDK JSON shape', async () => {
-    const sdk = new RsdoctorSDK({
-      name: 'standalone',
-      root: outputDir,
-      config: { noServer: true, mode: 'brief', brief: { type: ['json'] } },
-    });
-    try {
-      sdk.setOutputDir(outputDir);
-      await sdk.writeStore();
-      expect(Object.keys(readReport(sdk.getBriefJsonPath()!)).sort()).toEqual([
-        'clientRoutes',
-        'data',
-      ]);
-    } finally {
-      await sdk.dispose();
-    }
   });
 });

--- a/packages/core/tests/sdk/sdk/core/brief-multiple-output.test.ts
+++ b/packages/core/tests/sdk/sdk/core/brief-multiple-output.test.ts
@@ -1,0 +1,218 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it, rs } from 'rstack/test';
+import { Manifest, SDK } from '@rsdoctor/shared/types';
+import { RsdoctorSDKController } from '@/sdk/multiple/controller';
+import { RsdoctorSDK } from '@/sdk';
+
+describe('multi-compiler brief JSON', () => {
+  let outputDir: string;
+  let controller: RsdoctorSDKController;
+
+  beforeEach(() => {
+    outputDir = fs.mkdtempSync(path.join(tmpdir(), 'rsdoctor-multiple-json-'));
+    controller = new RsdoctorSDKController(outputDir);
+  });
+
+  afterEach(async () => {
+    await Promise.all(controller.slaves.map((sdk) => sdk.dispose()));
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  function createCompiler(
+    name: string,
+    options: {
+      fileName?: string;
+      type?: Array<'json' | 'html'>;
+      isChild?: boolean;
+    } = {},
+  ) {
+    const sdk = controller.createSlave({
+      name,
+      compilerPath: name,
+      parentCompilerPath: options.isChild ? 'client' : undefined,
+      isChild: options.isChild,
+      type: SDK.ToDataType.Normal,
+      extraConfig: {
+        noServer: true,
+        mode: 'brief',
+        brief: {
+          type: options.type ?? ['json'],
+          jsonOptions: { fileName: options.fileName ?? 'rsdoctor-data.json' },
+        },
+      },
+    });
+    controller.registerSlave(sdk);
+    controller.setOutputDir(sdk, outputDir);
+    sdk.setOutputDir(controller.getCompilerOutputDir(sdk));
+    sdk.reportSummaryData({
+      costs: [{ name, startAt: 0, costs: controller.slaves.length }],
+    });
+    return sdk;
+  }
+
+  function readReport(filePath: string): Manifest.RsdoctorBriefData {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  }
+
+  it.each([false, true])(
+    'preserves each compiler when server finishes first: %s',
+    async (serverFirst) => {
+      const client = createCompiler('client');
+      const server = createCompiler('server');
+      for (const sdk of serverFirst ? [server, client] : [client, server]) {
+        await sdk.writeStore();
+      }
+
+      for (const sdk of [client, server]) {
+        const report = readReport(sdk.getBriefJsonPath()!);
+        expect(report.name).toBe(sdk.name);
+        expect(report.data.summary.costs[0].name).toBe(sdk.name);
+        expect(report.clientRoutes).toEqual(sdk.getClientRoutes());
+        expect(report.series?.map((item) => item.name)).toEqual([
+          'client',
+          'server',
+        ]);
+        for (const item of report.series!) {
+          const target = path.resolve(
+            path.dirname(sdk.getBriefJsonPath()!),
+            item.dataFile,
+          );
+          expect(readReport(target).name).toBe(item.name);
+        }
+      }
+      expect(readReport(client.getBriefJsonPath()!).series?.[1].dataFile).toBe(
+        'compilers/server/rsdoctor-data.json',
+      );
+      expect(readReport(server.getBriefJsonPath()!).series?.[0].dataFile).toBe(
+        '../../rsdoctor-data.json',
+      );
+    },
+  );
+
+  it('refreshes earlier reports for late child compilers without restoring old build data', async () => {
+    const client = createCompiler('client');
+    await client.writeStore();
+    expect(readReport(client.getBriefJsonPath()!).series).toHaveLength(1);
+
+    const child = createCompiler('child.worker', { isChild: true });
+    await child.writeStore();
+    const clientReport = readReport(client.getBriefJsonPath()!);
+    expect(clientReport.series?.[1]).toMatchObject({
+      name: 'child.worker',
+      dataFile: '.slaves/child.worker/rsdoctor-data.json',
+      parentCompilerPath: 'client',
+      isChild: true,
+    });
+    client.reportSummaryData({
+      costs: [{ name: 'rebuilt', startAt: 0, costs: 42 }],
+    });
+    await client.writeStore();
+    const server = createCompiler('server');
+    await server.writeStore();
+    expect(
+      readReport(client.getBriefJsonPath()!).data.summary.costs,
+    ).toContainEqual({ name: 'rebuilt', startAt: 0, costs: 42 });
+    expect(readReport(child.getBriefJsonPath()!).series).toHaveLength(3);
+
+    const read = rs.spyOn(fs, 'readFileSync');
+    await client.writeStore();
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it('uses custom JSON paths for mixed output and remains portable after moving the directory', async () => {
+    const client = createCompiler('client', {
+      fileName: 'data/client data.json',
+      type: ['json', 'html'],
+    });
+    const server = createCompiler('server', { fileName: 'data/server.json' });
+    createCompiler('html-only', { type: ['html'] });
+    client.reportFileName = 'report.html';
+    rs.spyOn(client, 'inlineScriptsAndStyles').mockReturnValue('report.html');
+    await client.writeStore();
+    await server.writeStore();
+
+    const movedDir = path.join(outputDir, 'moved');
+    fs.mkdirSync(movedDir);
+    fs.renameSync(path.join(outputDir, 'data'), path.join(movedDir, 'data'));
+    fs.renameSync(
+      path.join(outputDir, 'compilers'),
+      path.join(movedDir, 'compilers'),
+    );
+    const movedFile = path.join(movedDir, 'data/client data.json');
+    const report = readReport(movedFile);
+    expect(report.series).toHaveLength(2);
+    for (const item of report.series!) {
+      const target = path.resolve(path.dirname(movedFile), item.dataFile);
+      const targetReport = readReport(target);
+      expect(targetReport.name).toBe(item.name);
+      for (const sibling of targetReport.series!) {
+        expect(
+          readReport(path.resolve(path.dirname(target), sibling.dataFile)).name,
+        ).toBe(sibling.name);
+      }
+    }
+  });
+
+  it('isolates duplicate, sanitized and case-insensitive directory names', async () => {
+    const compilers = [
+      'client',
+      'web/client',
+      'web:client',
+      'web-client-2',
+      'WEB-CLIENT',
+      'web/client',
+    ].map((name) => createCompiler(name));
+    await Promise.all(compilers.map((sdk) => sdk.writeStore()));
+    const paths = compilers.map((sdk) => sdk.getBriefJsonPath()!.toLowerCase());
+    expect(new Set(paths).size).toBe(compilers.length);
+    for (const sdk of compilers) {
+      expect(readReport(sdk.getBriefJsonPath()!).name).toBe(sdk.name);
+    }
+  });
+
+  it('rejects custom filenames that resolve to the same output file', async () => {
+    const client = createCompiler('client');
+    await client.writeStore();
+    const original = fs.readFileSync(client.getBriefJsonPath()!, 'utf8');
+    const server = createCompiler('server', {
+      fileName: '../../rsdoctor-data.json',
+    });
+    await expect(server.writeStore()).rejects.toThrow(
+      'Compiler JSON output paths overlap',
+    );
+    expect(fs.readFileSync(client.getBriefJsonPath()!, 'utf8')).toBe(original);
+  });
+
+  it('keeps the previous JSON intact and cleans temporary files when replacement fails', async () => {
+    const client = createCompiler('client');
+    await client.writeStore();
+    const original = fs.readFileSync(client.getBriefJsonPath()!, 'utf8');
+    rs.spyOn(fs, 'renameSync').mockImplementationOnce(() => {
+      throw new Error('replacement failed');
+    });
+    await expect(client.writeStore()).rejects.toThrow('replacement failed');
+    expect(fs.readFileSync(client.getBriefJsonPath()!, 'utf8')).toBe(original);
+    expect(fs.readdirSync(outputDir)).toEqual(['rsdoctor-data.json']);
+    await client.writeStore();
+  });
+
+  it('preserves the standalone SDK JSON shape', async () => {
+    const sdk = new RsdoctorSDK({
+      name: 'standalone',
+      root: outputDir,
+      config: { noServer: true, mode: 'brief', brief: { type: ['json'] } },
+    });
+    try {
+      sdk.setOutputDir(outputDir);
+      await sdk.writeStore();
+      expect(Object.keys(readReport(sdk.getBriefJsonPath()!)).sort()).toEqual([
+        'clientRoutes',
+        'data',
+      ]);
+    } finally {
+      await sdk.dispose();
+    }
+  });
+});

--- a/packages/shared/src/types/manifest.ts
+++ b/packages/shared/src/types/manifest.ts
@@ -31,6 +31,23 @@ export interface RsdoctorManifestSeriesData {
   isChild?: boolean;
 }
 
+export interface RsdoctorBriefSeriesData extends Omit<
+  RsdoctorManifestSeriesData,
+  'path' | 'origin'
+> {
+  /** File path relative to the JSON file containing this entry, using / separators. */
+  dataFile: string;
+}
+
+export interface RsdoctorBriefData {
+  data: BuilderStoreData;
+  clientRoutes: RsdoctorManifestClientRoutes[];
+  /** Current compiler name. Absent in older reports. */
+  name?: string;
+  /** Compilers configured to emit brief JSON in this report. */
+  series?: RsdoctorBriefSeriesData[];
+}
+
 export interface RsdoctorManifestWithShardingFiles extends Omit<
   RsdoctorManifest,
   'data'


### PR DESCRIPTION
## Summary

Brief JSON reports currently contain no compiler index, so consumers cannot discover sibling compiler data from a single report. This PR adds the current compiler name and a `series` index with relative JSON paths, preserving the existing `data` and `clientRoutes` fields. It refreshes earlier reports when compiler metadata changes, isolates colliding compiler directory names, and writes JSON atomically.

This is the data-output foundation for #1885; agent-cli compiler discovery and selection will follow in a separate PR.

<img width="989" height="428" alt="image" src="https://github.com/user-attachments/assets/b3b47269-ce83-462e-aec0-c466eebe984c" />

## Related links

- https://github.com/web-infra-dev/rsdoctor/issues/1885