### PR TITLE
fix(core): normalize loader fallback options

### DIFF
--- a/.changeset/fix-loader-fallback.md
+++ b/.changeset/fix-loader-fallback.md
@@ -1,0 +1,5 @@
+---
+'@rsdoctor/core': patch
+---
+
+Normalize loader fallback options before passing them to the resolver to prevent build failures with string and false values.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -93,13 +93,14 @@
     "prebundle": "prebundle"
   },
   "dependencies": {
+    "@rsbuild/plugin-check-syntax": "catalog:",
     "@rsdoctor/graph": "workspace:*",
     "@rsdoctor/sdk": "workspace:*",
     "@rsdoctor/types": "workspace:*",
     "@rsdoctor/utils": "workspace:*",
-    "browserslist-load-config": "^1.0.2",
-    "@rsbuild/plugin-check-syntax": "catalog:",
     "@rspack/resolver": "catalog:",
+    "browserslist-load-config": "^1.0.2",
+    "enhanced-resolve": "^5.20.0",
     "es-toolkit": "catalog:",
     "filesize": "catalog:",
     "fs-extra": "catalog:",

--- a/packages/core/src/inner-plugins/utils/loader.ts
+++ b/packages/core/src/inner-plugins/utils/loader.ts
@@ -1,4 +1,5 @@
 import { ResolverFactory } from '@rspack/resolver';
+import enhancedResolve from 'enhanced-resolve';
 import { omit } from 'es-toolkit/compat';
 import path from 'path';
 import { logger } from '@rsdoctor/utils/logger';
@@ -75,18 +76,13 @@ export type CompatibleResolve = Omit<
   fallback?: NonNullable<Plugin.Configuration['resolve']>['fallback'];
 };
 
-function normalizeFallback(fallback: CompatibleResolve['fallback']) {
+function normalizeFallback(
+  fallback: Exclude<CompatibleResolve['fallback'], unknown[]>,
+) {
   if (!fallback) return undefined;
 
-  const entries = Array.isArray(fallback)
-    ? fallback.map(
-        ({ name, alias, onlyModule }) =>
-          [onlyModule ? `${name}$` : name, alias] as const,
-      )
-    : Object.entries(fallback);
-
   return Object.fromEntries(
-    entries.map(([name, value]) => [
+    Object.entries(fallback).map(([name, value]) => [
       name,
       // The native resolver represents ignored requests with null.
       (Array.isArray(value) ? value : [value]).map((item) =>
@@ -103,7 +99,7 @@ export function interceptLoader<T extends Plugin.BuildRuleSetRule>(
   cwd = process.cwd(),
   resolveLoader?: CompatibleResolve,
 ): T[] {
-  const loaderResolver = new ResolverFactory({
+  const resolverOptions = {
     conditionNames: ['loader', 'require', 'node'],
     exportsFields: ['exports'],
     mainFiles: ['index'],
@@ -111,15 +107,26 @@ export function interceptLoader<T extends Plugin.BuildRuleSetRule>(
     extensions: ['js', '.json'],
     modules: ['node_modules'],
     ...resolveLoader,
-    fallback: normalizeFallback(resolveLoader?.fallback),
-  });
+  };
+  const fallback = resolveLoader?.fallback;
+  // Webpack's ordered rules can contain duplicate and overlapping matchers.
+  const resolveSync = Array.isArray(fallback)
+    ? enhancedResolve.create.sync({ ...resolverOptions, fallback })
+    : (() => {
+        const resolver = new ResolverFactory({
+          ...resolverOptions,
+          fallback: normalizeFallback(fallback),
+        });
+        return (directory: string, request: string) =>
+          resolver.sync(directory, request).path;
+      })();
 
   const resolve = (target: string) => {
     try {
-      const result = loaderResolver.sync(cwd, target);
+      const result = resolveSync(cwd, target);
 
-      if (result.path) {
-        return result.path;
+      if (result) {
+        return result;
       }
     } catch {
       // ..

--- a/packages/core/src/inner-plugins/utils/loader.ts
+++ b/packages/core/src/inner-plugins/utils/loader.ts
@@ -72,7 +72,29 @@ export type CompatibleResolve = Omit<
   'mainFields'
 > & {
   mainFields?: string[];
+  fallback?: NonNullable<Plugin.Configuration['resolve']>['fallback'];
 };
+
+function normalizeFallback(fallback: CompatibleResolve['fallback']) {
+  if (!fallback) return undefined;
+
+  const entries = Array.isArray(fallback)
+    ? fallback.map(
+        ({ name, alias, onlyModule }) =>
+          [onlyModule ? `${name}$` : name, alias] as const,
+      )
+    : Object.entries(fallback);
+
+  return Object.fromEntries(
+    entries.map(([name, value]) => [
+      name,
+      // The native resolver represents ignored requests with null.
+      (Array.isArray(value) ? value : [value]).map((item) =>
+        item === false ? null : item,
+      ),
+    ]),
+  );
+}
 
 export function interceptLoader<T extends Plugin.BuildRuleSetRule>(
   rules: T[],
@@ -89,6 +111,7 @@ export function interceptLoader<T extends Plugin.BuildRuleSetRule>(
     extensions: ['js', '.json'],
     modules: ['node_modules'],
     ...resolveLoader,
+    fallback: normalizeFallback(resolveLoader?.fallback),
   });
 
   const resolve = (target: string) => {

--- a/packages/core/tests/plugins/loader.test.ts
+++ b/packages/core/tests/plugins/loader.test.ts
@@ -2,7 +2,7 @@ import { Loader } from '@rsdoctor/utils/common';
 import { describe, it, expect } from '@rstest/core';
 import path from 'path';
 import { ProxyLoaderInternalOptions } from '@/types';
-import { interceptLoader } from '@/inner-plugins/utils';
+import { interceptLoader, type CompatibleResolve } from '@/inner-plugins/utils';
 
 describe('test src/utils/loader.ts', () => {
   describe('interceptLoader()', () => {
@@ -319,6 +319,75 @@ describe('test src/utils/loader.ts', () => {
           },
         },
       ]);
+    });
+
+    it.each([
+      { fallback: resolvedStringLoader },
+      { fallback: [resolvedStringLoader] },
+      { fallback: ['/missing/loader.js', resolvedStringLoader] },
+      { fallback: [false as const, resolvedStringLoader] },
+      { fallback: false as const },
+    ])('normalizes resolveLoader.fallback value $fallback', ({ fallback }) => {
+      const result = interceptLoader(
+        [{ loader: 'missing-loader' }],
+        proxyLoaderPath,
+        internalOptions,
+        exampleWebpackPath,
+        { fallback: { 'missing-loader': fallback } },
+      );
+
+      expect(result).toMatchObject([
+        {
+          options: {
+            [Loader.LoaderInternalPropertyName]: {
+              loader:
+                fallback === false ||
+                (Array.isArray(fallback) && fallback[0] === false)
+                  ? 'missing-loader'
+                  : resolvedStringLoader,
+            },
+          },
+        },
+      ]);
+    });
+
+    it.each([false, undefined, {}] satisfies CompatibleResolve['fallback'][])(
+      'accepts empty or disabled resolveLoader.fallback %j',
+      (fallback) => {
+        expect(() =>
+          interceptLoader(
+            [{ loader: stringLoader }],
+            proxyLoaderPath,
+            internalOptions,
+            exampleWebpackPath,
+            { fallback },
+          ),
+        ).not.toThrow();
+      },
+    );
+
+    it('supports webpack fallback entries with exact matching', () => {
+      const result = interceptLoader(
+        [{ loader: 'missing-loader' }, { loader: 'missing-loader/subpath' }],
+        proxyLoaderPath,
+        internalOptions,
+        exampleWebpackPath,
+        {
+          fallback: [
+            {
+              name: 'missing-loader',
+              alias: resolvedStringLoader,
+              onlyModule: true,
+            },
+          ],
+        },
+      );
+
+      expect(result).toMatchObject(
+        [resolvedStringLoader, 'missing-loader/subpath'].map((loader) => ({
+          options: { [Loader.LoaderInternalPropertyName]: { loader } },
+        })),
+      );
     });
 
     it('builtin:swc-loader test', () => {

--- a/packages/core/tests/plugins/loader.test.ts
+++ b/packages/core/tests/plugins/loader.test.ts
@@ -390,6 +390,75 @@ describe('test src/utils/loader.ts', () => {
       );
     });
 
+    it.each([
+      {
+        aliases: [resolvedStringLoader, resolvedBabelLoader],
+        expected: resolvedStringLoader,
+      },
+      {
+        aliases: ['/missing/loader.js', resolvedStringLoader],
+        expected: 'missing-loader',
+      },
+      {
+        aliases: [false as const, resolvedStringLoader],
+        expected: 'missing-loader',
+      },
+    ])(
+      'preserves duplicate fallback order: $aliases',
+      ({ aliases, expected }) => {
+        const result = interceptLoader(
+          [{ loader: 'missing-loader' }],
+          proxyLoaderPath,
+          internalOptions,
+          exampleWebpackPath,
+          {
+            fallback: aliases.map((alias) => ({
+              name: 'missing-loader',
+              alias,
+            })),
+          },
+        );
+
+        expect(result).toMatchObject([
+          {
+            options: {
+              [Loader.LoaderInternalPropertyName]: { loader: expected },
+            },
+          },
+        ]);
+      },
+    );
+
+    it('preserves interleaved exact and prefix fallback order', () => {
+      const result = interceptLoader(
+        [{ loader: 'missing-loader' }],
+        proxyLoaderPath,
+        internalOptions,
+        exampleWebpackPath,
+        {
+          fallback: [
+            { name: 'missing-loader', alias: 'missing-loader' },
+            {
+              name: 'missing-loader',
+              alias: resolvedStringLoader,
+              onlyModule: true,
+            },
+            { name: 'missing-loader', alias: resolvedBabelLoader },
+          ],
+        },
+      );
+
+      expect(result).toMatchObject([
+        {
+          options: {
+            [Loader.LoaderInternalPropertyName]: {
+              loader: resolvedStringLoader,
+            },
+          },
+        },
+      ]);
+    });
+
     it('builtin:swc-loader test', () => {
       expect(
         interceptLoader(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,7 +189,7 @@ importers:
         version: 3.9.4
       rsbuild-plugin-publint:
         specifier: ^0.3.4
-        version: 0.3.4(@rsbuild/core@2.1.4(core-js@3.49.0))
+        version: 0.3.4(@rsbuild/core@2.0.11(core-js@3.49.0))
 
   e2e:
     devDependencies:
@@ -885,6 +885,9 @@ importers:
       browserslist-load-config:
         specifier: ^1.0.2
         version: 1.0.3
+      enhanced-resolve:
+        specifier: ^5.20.0
+        version: 5.20.0
       es-toolkit:
         specifier: 'catalog:'
         version: 1.49.0
@@ -5601,10 +5604,6 @@ packages:
   engine.io@6.6.2:
     resolution: {integrity: sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==}
     engines: {node: '>=10.2.0'}
-
-  enhanced-resolve@5.12.0:
-    resolution: {integrity: sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==}
-    engines: {node: '>=10.13.0'}
 
   enhanced-resolve@5.20.0:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
@@ -15080,11 +15079,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  enhanced-resolve@5.12.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.3.3
-
   enhanced-resolve@5.20.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -18888,12 +18882,12 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.4(core-js@3.49.0)
 
-  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.1.4(core-js@3.49.0)):
+  rsbuild-plugin-publint@0.3.4(@rsbuild/core@2.0.11(core-js@3.49.0)):
     dependencies:
       picocolors: 1.1.1
       publint: 0.3.17
     optionalDependencies:
-      '@rsbuild/core': 2.1.4(core-js@3.49.0)
+      '@rsbuild/core': 2.0.11(core-js@3.49.0)
 
   rsbuild-plugin-rsc@0.0.3(@rsbuild/core@2.0.0(core-js@3.49.0))(react-server-dom-rspack@0.0.2(@rspack/core@2.1.2(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
     dependencies:
@@ -19676,7 +19670,7 @@ snapshots:
   ts-loader@9.4.2(typescript@6.0.3)(webpack@5.105.4(@swc/core@1.15.11(@swc/helpers@0.5.23))):
     dependencies:
       chalk: 4.1.2
-      enhanced-resolve: 5.12.0
+      enhanced-resolve: 5.20.0
       micromatch: 4.0.8
       semver: 7.7.2
       typescript: 6.0.3
@@ -19685,7 +19679,7 @@ snapshots:
   ts-loader@9.4.2(typescript@6.0.3)(webpack@5.105.4):
     dependencies:
       chalk: 4.1.2
-      enhanced-resolve: 5.12.0
+      enhanced-resolve: 5.20.0
       micromatch: 4.0.8
       semver: 7.7.2
       typescript: 6.0.3


### PR DESCRIPTION
## Summary

Valid `resolveLoader.fallback` values can cause Rsdoctor 1.x builds to fail when passed directly to `@rspack/resolver`. Normalize dictionary values to the native resolver format, and use `enhanced-resolve` for Webpack's array-form rules to preserve duplicate matchers, declaration order, ignored requests, and exact matching.

## Related Links

Fixes #1986