### PR TITLE
chore: update pull request template and skills

### DIFF
--- a/.agents/skills/pr-creator/SKILL.md
+++ b/.agents/skills/pr-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-creator
-description: Use when asked to create a pull request for this repository. It helps the PR follow the repository's branch safety rules, title convention, pull request template, and concise English writing style.
+description: Create a pull request using repository branch rules, title conventions, templates, and concise English descriptions.
 metadata:
   internal: true
 ---
@@ -17,7 +17,7 @@ metadata:
    Do not revert unrelated user changes.
    Before creating the PR, ensure the intended changes are committed and never commit directly on the default branch.
 
-3. If `.github/PULL_REQUEST_TEMPLATE.md` exists, read it and follow its structure.
+3. Read the repository's PR template when available and follow its current headings and guidance.
 
 4. Draft the PR title in the repository's standard format. If the repository uses Conventional Commits, common patterns include:
    - `feat(core): add ...`
@@ -29,21 +29,13 @@ metadata:
    - `release: v1.2.0`
 
 5. Write the PR body in concise, clear English.
-   - In `Summary`, explain the change context first: the user-facing problem, maintenance goal, or compatibility constraint that makes the change necessary.
-   - Prioritize high-signal information: public API changes, behavior changes, breaking changes, migration notes, and important compatibility implications.
-   - Then describe the main implementation change only as much as needed to understand the review.
-   - Keep the PR body concise and review-oriented: use 1-4 short standalone sentences for typical changes, covering why it matters, what changed, and any reviewer-important impact.
-   - Omit incidental updates to tests, documentation, and supporting artifacts from the PR description; mention them only when they are the PR's primary purpose or carry reviewer-relevant risk.
-   - Avoid low-signal sections such as `Test plan` or `Validation`, routine verification commands, generated file lists, or obvious implementation details unless the repository template explicitly requires them or the change has unusual validation risk.
-   - Good background examples:
-     - `This PR adds support for custom logger injection so CLI output can be isolated per instance.`
-     - `This PR fixes incorrect padding in URL labels to keep terminal output aligned across different label lengths.`
-     - `This PR updates the English docs to clarify how the extraction option works and when to enable it.`
+   - Explain the problem or motivation and why it matters, then describe the approach and resulting behavior.
+   - Include API, compatibility, or migration details when they help reviewers assess the change.
+   - Keep typical descriptions to a few short sentences. Focus on the key changes rather than a file-by-file summary.
+   - Mention tests, documentation, and validation only when required by the template, central to the change, or relevant to review risk.
 
-6. Fill `Related Links` with issue links, design docs, related PRs, or discussion pages.
-   If the PR upgrades an npm dependency, add a link to the upgraded version's release notes or tag page when available.
-   Example: `https://github.com/web-infra-dev/rspack/releases/tag/v1.0.0`
-   If there is no relevant link, omit the entire `Related Links` section from the PR body.
+6. Include relevant issue, discussion, or design links alongside the context they support, following the template's guidance.
+   For dependency upgrades, link to the target version's release notes or tag when available.
 
 7. Push the branch only after re-checking the branch name. Never push the default branch directly.
 

--- a/.agents/skills/release-rsdoctor/SKILL.md
+++ b/.agents/skills/release-rsdoctor/SKILL.md
@@ -39,7 +39,4 @@ If the version is missing, ask for it before making changes.
 
 7. Push the branch, then create a GitHub PR with `gh pr create`. Use the same text for the PR title: `release: v<version>`
 
-8. If `.github/PULL_REQUEST_TEMPLATE.md` exists, keep its structure.
-   Fill it with:
-   - `Summary`: `Release v<version>.`
-   - `Related Links`: `https://github.com/web-infra-dev/rsdoctor/releases/tag/v<version>`
+8. Read the repository's PR template when available and follow its current headings and guidance. Explain that the PR prepares release `v<version>` by updating the fixed group's package versions and lockfile. Include the release link: `https://github.com/web-infra-dev/rsdoctor/releases/tag/v<version>`.

--- a/.agents/skills/rstack-cli-docs/SKILL.md
+++ b/.agents/skills/rstack-cli-docs/SKILL.md
@@ -3,7 +3,7 @@ name: rstack-cli-docs
 description: Consult installed, version-matched Rstack docs only for user-facing `rs` command behavior, `rstack.config.*` semantics, or public `rstack` APIs. Do not use for purely internal implementation, tests, performance, or repository maintenance.
 ---
 
-# Rstack CLI Docs
+# Rstack CLI docs
 
 Rstack CLI is the `rstack` package, exposed through the `rs` binaries. It provides one CLI, one
 config file, and a consistent workflow for the Rstack JavaScript toolchain.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
-## Summary
+## Motivation
 
-## Related links
+<!-- Explain the problem or motivation and why it matters. Include relevant context and links to issues or discussions. -->
 
-<!--- Provide links of related issues or pages -->
+## Changes
+
+<!-- Describe how this PR addresses the motivation and what behavior changes. Focus on the key approach rather than a file-by-file summary. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,9 +89,7 @@ types → utils → graph → sdk → core → rspack-plugin / webpack-plugin �
 - Branch off `main`; never commit directly to `main`.
 - PR title must follow **Conventional Commits**: `type(scope): description`.
 - Common scopes: `core`, `rspack-plugin`, `webpack-plugin`, `sdk`, `cli`, `ai`, `graph`, `utils`, `components`, `client`, `deps`.
-- PR body must follow `.github/PULL_REQUEST_TEMPLATE.md` with two sections:
-  - `## Summary` — what changed and why.
-  - `## Related Links` — issue links, docs, related PRs, or `None`.
+- Read `.github/PULL_REQUEST_TEMPLATE.md` and follow its current headings and guidance.
 
 ## Conventions for AI agents
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,7 +11,7 @@
       "source": "rstackjs/agent-skills",
       "sourceType": "github",
       "skillPath": ".agents/skills/pr-creator/SKILL.md",
-      "computedHash": "c115b708a4c627af4b6dbaca0cfa0ae0fb0153f122bd2229f7803c803fa97c67"
+      "computedHash": "ed4ca0b83b380c9a4a350047ef5f2616c0446b2830d59e3a06839cb827fd39b4"
     },
     "release-blog-writer": {
       "source": "rstackjs/agent-skills",
@@ -23,7 +23,7 @@
       "source": "rstackjs/rstack",
       "sourceType": "github",
       "skillPath": ".agents/skills/rstack-cli-docs/SKILL.md",
-      "computedHash": "3bd67c05c2cb4121edd24be65d118e0e7402177bca8a0f1b5bb0ce55dee5e61c"
+      "computedHash": "8b5451af88d29195dc2f257543013ad66aa14a7791e401ab4cffdb11941cf27a"
     }
   }
 }


### PR DESCRIPTION
## Motivation

PR descriptions should foreground the problem and context, following [Rspack #15584](https://github.com/web-infra-dev/rspack/pull/15584).

## Changes

Use Motivation and Changes in the PR template and refresh project skills with `npx skills`. Update the repository and release guidance to follow the current template instead of hardcoding its headings.