### PR TITLE
fix(components): improve bundle summary layout and alert navigation

### DIFF
--- a/.changeset/tidy-bundle-summary.md
+++ b/.changeset/tidy-bundle-summary.md
@@ -1,0 +1,5 @@
+---
+'@rsdoctor/client': patch
+---
+
+Keep bundle summary cards compact across laptop and desktop screens, align size selectors and metrics to the right, and prevent selectors from overflowing narrow report panels. Preserve alert tab clicks when the tab bar can be dragged horizontally.

--- a/.changeset/tidy-bundle-summary.md
+++ b/.changeset/tidy-bundle-summary.md
@@ -1,5 +1,0 @@
----
-'@rsdoctor/client': patch
----
-
-Keep bundle summary cards compact across laptop and desktop screens, align size selectors and metrics to the right, and prevent selectors from overflowing narrow report panels. Preserve alert tab clicks when the tab bar can be dragged horizontally.

--- a/e2e/cases/doctor-rspack/linter-rule-render.test.ts
+++ b/e2e/cases/doctor-rspack/linter-rule-render.test.ts
@@ -75,30 +75,53 @@ test('linter rule render check', async ({ page }) => {
   await page.goto(pathToFileURL(reportPath).href);
   core.debug(`reportPath:: ${reportPath}`);
 
-  const ecmaVersionButton = await page.$('[data-node-key="E1004"]');
-  core.debug(`ecmaVersionButton:: ${ecmaVersionButton}`);
+  const ecmaTab = page.getByRole('tab', { name: /ECMA Version Check/ });
+  await expect(ecmaTab).toHaveAttribute('aria-selected', 'true');
 
-  // TODO: fix this test case
-  // await ecmaVersionButton?.click();
-  // // ignore output text check because there's no .map file for track the source code
-  // const source = await page.$('.e2e-ecma-source');
-  // const error = await page.$('.e2e-ecma-error');
+  const emptyTab = page.getByRole('tab', { name: /Duplicate Packages/ });
+  await emptyTab.click();
+  await expect(emptyTab).toHaveAttribute('aria-selected', 'true');
+  await expect(page.getByRole('tabpanel')).toContainText('No Data');
 
-  // core.debug(`source:: ${source}`);
-  // core.debug(`error:: ${error}`);
+  await ecmaTab.click();
+  await expect(ecmaTab).toHaveAttribute('aria-selected', 'true');
+  await expect(page.getByRole('tabpanel')).toContainText('ECMA Version Check');
 
-  // const sourceText = await source?.textContent();
-  // const errorText = await error?.textContent();
+  await page.goto(`${pathToFileURL(reportPath).href}#/bundle/size`);
+  const charts = page.locator('[class*="chartsContainer"] > div');
+  await expect(charts).toHaveCount(4);
 
-  // core.debug(`sourceText:: ${sourceText}`);
-  // core.debug(`errorText:: ${errorText}`);
+  const expectCardsToFit = async () => {
+    await expect
+      .poll(() =>
+        charts.evaluateAll((cards) =>
+          cards.every((card) => {
+            const bounds = card.getBoundingClientRect();
+            const selector = card
+              .querySelector('[class*="metricSelector"]')!
+              .getBoundingClientRect();
+            const progress = card
+              .querySelector('.ant-progress')!
+              .getBoundingClientRect();
+            return (
+              selector.right <= bounds.right && progress.right <= selector.left
+            );
+          }),
+        ),
+      )
+      .toBe(true);
+  };
 
-  // expect(sourceText).toBe(
-  //   '/cases/doctor-rspack/dist/linter-rule-render/main.js:1:2',
-  // );
-  // expect(errorText).toBe(
-  //   `Find some syntax that does not match "ecmaVersion <= ${ecmaVersion}"`,
-  // );
+  for (const width of [1280, 1440, 1600, 1920]) {
+    await page.setViewportSize({ width, height: 900 });
+    await expectCardsToFit();
+  }
+
+  // A wide viewport can still contain a narrow report panel.
+  await charts.first().evaluate((chart) => {
+    chart.parentElement!.parentElement!.parentElement!.style.width = '1216px';
+  });
+  await expectCardsToFit();
 });
 
 function fileExists(filePath: string) {

--- a/e2e/cases/doctor-rspack/linter-rule-render.test.ts
+++ b/e2e/cases/doctor-rspack/linter-rule-render.test.ts
@@ -103,8 +103,21 @@ test('linter rule render check', async ({ page }) => {
             const progress = card
               .querySelector('.ant-progress')!
               .getBoundingClientRect();
+            const modeSelector = card
+              .querySelector('[class*="cardTitle"] .ant-segmented')
+              ?.getBoundingClientRect();
+            const value = card
+              .querySelector('[class*="metricValue"]')!
+              .getBoundingClientRect();
+            const details = card.querySelector('[class*="details"]')!;
             return (
-              selector.right <= bounds.right && progress.right <= selector.left
+              selector.right <= bounds.right &&
+              progress.right <= selector.left &&
+              (!modeSelector ||
+                (modeSelector.right <= bounds.right &&
+                  Math.abs(modeSelector.left - selector.left) <= 1)) &&
+              Math.abs(value.left - selector.left) <= 1 &&
+              getComputedStyle(details).textAlign === 'left'
             );
           }),
         ),
@@ -112,7 +125,7 @@ test('linter rule render check', async ({ page }) => {
       .toBe(true);
   };
 
-  for (const width of [1280, 1440, 1600, 1920]) {
+  for (const width of [1280, 1366, 1440, 1536, 1600, 1920, 2560]) {
     await page.setViewportSize({ width, height: 900 });
     await expectCardsToFit();
   }

--- a/e2e/cases/doctor-rspack/linter-rule-render.test.ts
+++ b/e2e/cases/doctor-rspack/linter-rule-render.test.ts
@@ -87,6 +87,28 @@ test('linter rule render check', async ({ page }) => {
   await expect(ecmaTab).toHaveAttribute('aria-selected', 'true');
   await expect(page.getByRole('tabpanel')).toContainText('ECMA Version Check');
 
+  // Keep the sidebar beside the main content when browser chrome narrows a laptop viewport.
+  for (const width of [960, 1100, 1280, 1440, 1920]) {
+    await page.setViewportSize({ width, height: 900 });
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const main = document
+            .querySelector('main[class*="mainColumn"]')!
+            .getBoundingClientRect();
+          const aside = document
+            .querySelector('aside')!
+            .getBoundingClientRect();
+          return (
+            Math.abs(main.top - aside.top) < 1 &&
+            main.right < aside.left &&
+            document.documentElement.scrollWidth <= innerWidth
+          );
+        }),
+      )
+      .toBe(true);
+  }
+
   await page.goto(`${pathToFileURL(reportPath).href}#/bundle/size`);
   const charts = page.locator('[class*="chartsContainer"] > div');
   await expect(charts).toHaveCount(4);
@@ -110,9 +132,27 @@ test('linter rule render check', async ({ page }) => {
               .querySelector('[class*="metricValue"]')!
               .getBoundingClientRect();
             const details = card.querySelector('[class*="details"]')!;
+            const percentage = card.querySelector(
+              '[class*="percentContainer"]',
+            )!;
+            const fileRow = card.querySelector('[class*="fileCount"]')!;
+            const label = fileRow
+              .querySelector('button > span')!
+              .getBoundingClientRect();
+            const count = fileRow
+              .querySelector(':scope > span')!
+              .getBoundingClientRect();
+            const percentageFont = parseFloat(
+              getComputedStyle(percentage).fontSize,
+            );
             return (
+              percentageFont <= (progress.width <= 81 ? 12 : 14) &&
+              Math.abs(
+                label.top + label.height / 2 - count.top - count.height / 2,
+              ) <= 1 &&
               selector.right <= bounds.right &&
-              progress.right <= selector.left &&
+              (progress.right <= selector.left ||
+                progress.bottom <= selector.top) &&
               (!modeSelector ||
                 (modeSelector.right <= bounds.right &&
                   Math.abs(modeSelector.left - selector.left) <= 1)) &&
@@ -125,9 +165,22 @@ test('linter rule render check', async ({ page }) => {
       .toBe(true);
   };
 
-  for (const width of [1280, 1366, 1440, 1536, 1600, 1920, 2560]) {
+  for (const width of [960, 1100, 1280, 1366, 1440, 1536, 1600, 1920, 2560]) {
     await page.setViewportSize({ width, height: 900 });
     await expectCardsToFit();
+    await expect
+      .poll(() =>
+        charts.evaluateAll((cards) =>
+          cards.every(
+            (card) =>
+              Math.abs(
+                card.getBoundingClientRect().top -
+                  cards[0].getBoundingClientRect().top,
+              ) < 1,
+          ),
+        ),
+      )
+      .toBe(true);
   }
 
   // A wide viewport can still contain a narrow report panel.

--- a/packages/client/src/components/Alerts/useHorizontalTabScroll.ts
+++ b/packages/client/src/components/Alerts/useHorizontalTabScroll.ts
@@ -110,8 +110,6 @@ export function useHorizontalTabScroll(): HTMLAttributes<HTMLDivElement> {
         startScrollLeft: tabBar.scrollLeft,
         moved: false,
       };
-      tabBar.dataset.dragging = 'true';
-      tabBar.setPointerCapture(event.pointerId);
     },
     onPointerMove(event) {
       const dragState = dragStateRef.current;
@@ -120,8 +118,10 @@ export function useHorizontalTabScroll(): HTMLAttributes<HTMLDivElement> {
       }
 
       const distance = event.clientX - dragState.startX;
-      if (Math.abs(distance) >= DRAG_THRESHOLD) {
+      if (!dragState.moved && Math.abs(distance) >= DRAG_THRESHOLD) {
         dragState.moved = true;
+        dragState.element.dataset.dragging = 'true';
+        dragState.element.setPointerCapture(event.pointerId);
       }
 
       if (dragState.moved) {

--- a/packages/client/src/components/Card/size.module.scss
+++ b/packages/client/src/components/Card/size.module.scss
@@ -1,16 +1,16 @@
 .container {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) max-content;
+  grid-template-columns: var(--asset-chart-size) minmax(0, 1fr);
   align-items: center;
   gap: 12px;
-  min-height: 140px;
+  min-height: 120px;
   width: 100%;
   min-width: 0;
 }
 
 .details {
   min-width: 0;
-  text-align: right;
+  text-align: left;
 }
 
 .metricSelector {
@@ -29,7 +29,7 @@
 }
 
 .metricValue {
-  margin-top: 2px;
+  margin: 6px 0 12px;
 }
 
 .dataContainer {
@@ -59,9 +59,14 @@
 .percentContainer {
   display: flex;
   flex-direction: column;
-  font-size: 20px;
+  align-items: center;
+  font-size: 16px;
+  line-height: 22px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-color);
 
   .percentDescription {
+    color: var(--text-color-secondary);
     font-size: 12px;
     font-weight: 400;
     line-height: 20px;

--- a/packages/client/src/components/Card/size.module.scss
+++ b/packages/client/src/components/Card/size.module.scss
@@ -29,46 +29,62 @@
 }
 
 .metricValue {
-  margin: 6px 0 12px;
+  margin: 6px 0 8px;
 }
 
-.dataContainer {
-  min-width: 0;
+.fileCount {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 20px;
+}
 
-  .title {
-    font-size: 12px;
-    font-weight: 400;
-    line-height: 20px;
-    margin-bottom: 2px;
-  }
+.filesLink:global(.ant-btn) {
+  height: 20px;
+  line-height: 20px;
+  gap: 5px;
 }
 
 .description {
-  font-size: 18px;
-  font-weight: 500;
-  line-height: 28px;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 22px;
   white-space: nowrap;
-
-  @media (max-width: 1500px) {
-    font-size: 14px;
-  }
 }
 
 .percentContainer {
   display: flex;
   flex-direction: column;
   align-items: center;
-  font-size: 16px;
-  line-height: 22px;
+  font-size: clamp(12px, calc(var(--asset-chart-size) * 0.15), 14px);
+  line-height: 1.4;
+  white-space: nowrap;
   font-variant-numeric: tabular-nums;
   color: var(--text-color);
 
   .percentDescription {
     color: var(--text-color-secondary);
-    font-size: 12px;
+    font-size: clamp(10px, calc(var(--asset-chart-size) * 0.125), 12px);
     font-weight: 400;
-    line-height: 20px;
+    line-height: 1.4;
+  }
+}
+
+@container asset-card (max-width: 235px) {
+  .container {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 12px;
+
+    > :global(.ant-progress) {
+      justify-self: center;
+      line-height: 1;
+    }
+  }
+
+  .details {
+    border-top: 1px solid var(--color-border-secondary);
+    padding-top: 12px;
   }
 }

--- a/packages/client/src/components/Card/size.module.scss
+++ b/packages/client/src/components/Card/size.module.scss
@@ -1,16 +1,16 @@
 .container {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  align-items: center;
+  gap: 12px;
+  min-height: 140px;
   width: 100%;
   min-width: 0;
-
-  > :global(.ant-space-item:last-child) {
-    min-width: 0;
-    flex: 1;
-  }
 }
 
 .details {
   min-width: 0;
-  margin-left: 10px;
+  text-align: right;
 }
 
 .metricSelector {

--- a/packages/client/src/components/Card/size.tsx
+++ b/packages/client/src/components/Card/size.tsx
@@ -1,4 +1,4 @@
-import { Empty, Progress, Segmented, Space, Tree } from 'antd';
+import { Empty, Progress, Segmented, Tree } from 'antd';
 import { sumBy } from '@rsdoctor/shared/collection';
 import React, { useEffect, useMemo, useState } from 'react';
 import { RightOutlined } from '@ant-design/icons';
@@ -38,12 +38,7 @@ export interface bgColorType {
   tagBgColor: string;
 }
 
-export const SizeCard: React.FC<SizeCardProps> = ({
-  files,
-  total,
-  showProgress = false,
-  type,
-}) => {
+export const SizeCard: React.FC<SizeCardProps> = ({ files, total, type }) => {
   const [contentRef, { width }] = useElementSize();
   const [sizeMetric, setSizeMetric] = useState<SizeMetric>('size');
   const fileType =
@@ -136,55 +131,49 @@ export const SizeCard: React.FC<SizeCardProps> = ({
                 <div className={`${styles.description} ${styles.metricValue}`}>
                   {formatSize(selectedSize)}
                 </div>
-                <TextDrawer
-                  buttonProps={{
-                    size: 'small',
-                  }}
-                  buttonStyle={{
-                    fontSize: 'inherit',
-                  }}
-                  drawerProps={{
-                    title: 'Files',
-                  }}
-                  text={
-                    <Space
-                      style={{ textAlign: showProgress ? 'left' : 'center' }}
-                      align="end"
-                    >
-                      <Space direction="vertical">
-                        <div className={styles.dataContainer}>
-                          <div className={styles.title}>
-                            <span style={{ marginRight: '5px' }}>Files</span>
-                            <RightOutlined />
-                          </div>
-                        </div>
-                      </Space>
-                    </Space>
-                  }
-                >
-                  {treeData.length ? (
-                    <DirectoryTree
-                      defaultExpandAll
-                      selectable={false}
-                      treeData={treeData}
-                      rootStyle={{
-                        minHeight: '800px',
-                        border: '1px solid rgba(235, 237, 241)',
-                      }}
-                    />
-                  ) : (
-                    <div
-                      style={{
-                        position: 'relative',
-                        top: '50%',
-                        transform: 'translateY(-50%)',
-                      }}
-                    >
-                      <Empty style={{ height: '100%' }} />
-                    </div>
-                  )}
-                </TextDrawer>
-                <div className={styles.description}>{files.length}</div>
+                <div className={styles.fileCount}>
+                  <TextDrawer
+                    buttonProps={{
+                      size: 'small',
+                      className: styles.filesLink,
+                    }}
+                    buttonStyle={{
+                      fontSize: 'inherit',
+                    }}
+                    drawerProps={{
+                      title: 'Files',
+                    }}
+                    text={
+                      <>
+                        <span>Files</span>
+                        <RightOutlined />
+                      </>
+                    }
+                  >
+                    {treeData.length ? (
+                      <DirectoryTree
+                        defaultExpandAll
+                        selectable={false}
+                        treeData={treeData}
+                        rootStyle={{
+                          minHeight: '800px',
+                          border: '1px solid rgba(235, 237, 241)',
+                        }}
+                      />
+                    ) : (
+                      <div
+                        style={{
+                          position: 'relative',
+                          top: '50%',
+                          transform: 'translateY(-50%)',
+                        }}
+                      >
+                        <Empty style={{ height: '100%' }} />
+                      </div>
+                    )}
+                  </TextDrawer>
+                  <span>{files.length}</span>
+                </div>
               </div>
             </>
           );

--- a/packages/client/src/components/Card/size.tsx
+++ b/packages/client/src/components/Card/size.tsx
@@ -109,7 +109,7 @@ export const SizeCard: React.FC<SizeCardProps> = ({
                 strokeWidth={12}
                 format={(percent) => (
                   <div className={styles.percentContainer}>
-                    <span style={{ marginTop: '10px' }}>{percent}%</span>
+                    <span>{percent}%</span>
                     <span className={styles.percentDescription}>
                       total {type}
                     </span>

--- a/packages/client/src/components/Card/size.tsx
+++ b/packages/client/src/components/Card/size.tsx
@@ -3,7 +3,7 @@ import { sumBy } from '@rsdoctor/shared/collection';
 import React, { useEffect, useMemo, useState } from 'react';
 import { RightOutlined } from '@ant-design/icons';
 
-import { formatSize } from 'src/utils';
+import { formatSize, useElementSize } from 'src/utils';
 import { TextDrawer } from '../TextDrawer';
 import { getFiles } from '../Overall';
 import { ServerAPIProvider } from '../Manifest';
@@ -13,7 +13,6 @@ import { SDK, Client } from '@rsdoctor/shared/types';
 import styles from './size.module.scss';
 
 const { DirectoryTree } = Tree;
-const height = 100;
 type SizeMetric = 'size' | 'gzip' | 'brotli';
 
 export interface SizeCardProps {
@@ -45,6 +44,7 @@ export const SizeCard: React.FC<SizeCardProps> = ({
   showProgress = false,
   type,
 }) => {
+  const [contentRef, { width }] = useElementSize();
   const [sizeMetric, setSizeMetric] = useState<SizeMetric>('size');
   const fileType =
     type.toLocaleLowerCase() as keyof Client.RsdoctorClientAssetsSummary;
@@ -71,122 +71,125 @@ export const SizeCard: React.FC<SizeCardProps> = ({
   }, [hasGzipSize, hasBrotliSize, sizeMetric, type]);
 
   return (
-    <ServerAPIProvider
-      api={SDK.ServerAPI.API.GetAssetsSummary}
-      body={{ withFileContent: false }}
-    >
-      {(res) => {
-        const type = fileType.includes('image') ? 'imgs' : fileType;
-        const { treeData } = getFiles(res[type].total);
-        const totalGzipSize = sumBy(
-          res.all.total.files,
-          (file) => file.gzipSize ?? 0,
-        );
-        const selectedSize =
-          sizeMetric === 'brotli'
-            ? brotliSum
-            : sizeMetric === 'gzip'
-              ? gzipSum
-              : sum;
-        const selectedTotal =
-          sizeMetric === 'brotli'
-            ? sumBy(res.all.total.files, (file) => file.brotliSize ?? 0)
-            : sizeMetric === 'gzip'
-              ? totalGzipSize
-              : total;
-        const percent = selectedTotal
-          ? +((selectedSize / selectedTotal) * 100).toFixed(2)
-          : 0;
+    <div ref={contentRef} className={styles.container}>
+      <ServerAPIProvider
+        api={SDK.ServerAPI.API.GetAssetsSummary}
+        body={{ withFileContent: false }}
+      >
+        {(res) => {
+          const type = fileType.includes('image') ? 'imgs' : fileType;
+          const { treeData } = getFiles(res[type].total);
+          const totalGzipSize = sumBy(
+            res.all.total.files,
+            (file) => file.gzipSize ?? 0,
+          );
+          const selectedSize =
+            sizeMetric === 'brotli'
+              ? brotliSum
+              : sizeMetric === 'gzip'
+                ? gzipSum
+                : sum;
+          const selectedTotal =
+            sizeMetric === 'brotli'
+              ? sumBy(res.all.total.files, (file) => file.brotliSize ?? 0)
+              : sizeMetric === 'gzip'
+                ? totalGzipSize
+                : total;
+          const percent = selectedTotal
+            ? +((selectedSize / selectedTotal) * 100).toFixed(2)
+            : 0;
 
-        return (
-          <Space className={styles.container} style={{ height }} align="center">
-            <Progress
-              type="circle"
-              percent={percent}
-              strokeColor={{ '0%': '#108ee9', '100%': '#108ee9' }}
-              strokeWidth={12}
-              format={(percent) => (
-                <div className={styles.percentContainer}>
-                  <span style={{ marginTop: '10px' }}>{percent}%</span>
-                  <span className={styles.percentDescription}>
-                    total {type}
-                  </span>
-                </div>
-              )}
-            />
-            <div className={styles.details}>
-              <Segmented
-                aria-label={`${type} size metric`}
-                className={styles.metricSelector}
-                options={[
-                  { label: 'Size', value: 'size' },
-                  { label: 'Gzip', value: 'gzip', disabled: !hasGzipSize },
-                  {
-                    label: 'Brotli',
-                    value: 'brotli',
-                    disabled: !hasBrotliSize,
-                  },
-                ]}
-                value={sizeMetric}
-                size="small"
-                onChange={(value) => setSizeMetric(value as SizeMetric)}
-              />
-              <div className={`${styles.description} ${styles.metricValue}`}>
-                {formatSize(selectedSize)}
-              </div>
-              <TextDrawer
-                buttonProps={{
-                  size: 'small',
-                }}
-                buttonStyle={{
-                  fontSize: 'inherit',
-                }}
-                drawerProps={{
-                  title: 'Files',
-                }}
-                text={
-                  <Space
-                    style={{ textAlign: showProgress ? 'left' : 'center' }}
-                    align="end"
-                  >
-                    <Space direction="vertical">
-                      <div className={styles.dataContainer}>
-                        <div className={styles.title}>
-                          <span style={{ marginRight: '5px' }}>Files</span>
-                          <RightOutlined />
-                        </div>
-                      </div>
-                    </Space>
-                  </Space>
-                }
-              >
-                {treeData.length ? (
-                  <DirectoryTree
-                    defaultExpandAll
-                    selectable={false}
-                    treeData={treeData}
-                    rootStyle={{
-                      minHeight: '800px',
-                      border: '1px solid rgba(235, 237, 241)',
-                    }}
-                  />
-                ) : (
-                  <div
-                    style={{
-                      position: 'relative',
-                      top: '50%',
-                      transform: 'translateY(-50%)',
-                    }}
-                  >
-                    <Empty style={{ height: '100%' }} />
+          return (
+            <>
+              <Progress
+                type="circle"
+                size={Math.max(80, Math.min(120, width - 156))}
+                percent={percent}
+                strokeColor={{ '0%': '#108ee9', '100%': '#108ee9' }}
+                strokeWidth={12}
+                format={(percent) => (
+                  <div className={styles.percentContainer}>
+                    <span style={{ marginTop: '10px' }}>{percent}%</span>
+                    <span className={styles.percentDescription}>
+                      total {type}
+                    </span>
                   </div>
                 )}
-              </TextDrawer>
-              <div className={styles.description}>{files.length}</div>
-            </div>
-          </Space>
-        );
-      }}
-    </ServerAPIProvider>
+              />
+              <div className={styles.details}>
+                <Segmented
+                  aria-label={`${type} size metric`}
+                  className={styles.metricSelector}
+                  options={[
+                    { label: 'Size', value: 'size' },
+                    { label: 'Gzip', value: 'gzip', disabled: !hasGzipSize },
+                    {
+                      label: 'Brotli',
+                      value: 'brotli',
+                      disabled: !hasBrotliSize,
+                    },
+                  ]}
+                  value={sizeMetric}
+                  size="small"
+                  onChange={(value) => setSizeMetric(value as SizeMetric)}
+                />
+                <div className={`${styles.description} ${styles.metricValue}`}>
+                  {formatSize(selectedSize)}
+                </div>
+                <TextDrawer
+                  buttonProps={{
+                    size: 'small',
+                  }}
+                  buttonStyle={{
+                    fontSize: 'inherit',
+                  }}
+                  drawerProps={{
+                    title: 'Files',
+                  }}
+                  text={
+                    <Space
+                      style={{ textAlign: showProgress ? 'left' : 'center' }}
+                      align="end"
+                    >
+                      <Space direction="vertical">
+                        <div className={styles.dataContainer}>
+                          <div className={styles.title}>
+                            <span style={{ marginRight: '5px' }}>Files</span>
+                            <RightOutlined />
+                          </div>
+                        </div>
+                      </Space>
+                    </Space>
+                  }
+                >
+                  {treeData.length ? (
+                    <DirectoryTree
+                      defaultExpandAll
+                      selectable={false}
+                      treeData={treeData}
+                      rootStyle={{
+                        minHeight: '800px',
+                        border: '1px solid rgba(235, 237, 241)',
+                      }}
+                    />
+                  ) : (
+                    <div
+                      style={{
+                        position: 'relative',
+                        top: '50%',
+                        transform: 'translateY(-50%)',
+                      }}
+                    >
+                      <Empty style={{ height: '100%' }} />
+                    </div>
+                  )}
+                </TextDrawer>
+                <div className={styles.description}>{files.length}</div>
+              </div>
+            </>
+          );
+        }}
+      </ServerAPIProvider>
+    </div>
   );
 };

--- a/packages/client/src/components/Overall/bundle.module.scss
+++ b/packages/client/src/components/Overall/bundle.module.scss
@@ -1,5 +1,7 @@
 .title {
-  height: 40px;
+  min-height: 40px;
+  flex-wrap: wrap;
+  gap: 4px 8px;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/packages/client/src/components/Overall/bundle.tsx
+++ b/packages/client/src/components/Overall/bundle.tsx
@@ -11,7 +11,7 @@ import { FolderOpenTwoTone, RightOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 
 import { getFileCom } from '../FileTree';
-import { formatSize, useI18n } from '../../utils';
+import { formatSize, useI18n, useElementSize } from '../../utils';
 import { TextDrawer } from '../TextDrawer';
 import { Card } from '../Card';
 import { ServerAPIProvider } from '../Manifest';
@@ -136,6 +136,7 @@ const BundleDescriptions = ({
   res: Client.RsdoctorClientAssetsSummary;
   view: viewType;
 }) => {
+  const [containerRef, { width }] = useElementSize();
   const fileItems: DescriptionsProps['items'] = [
     {
       key: 'js-files-count',
@@ -266,14 +267,16 @@ const BundleDescriptions = ({
   ];
 
   return (
-    <Descriptions
-      layout={'vertical'}
-      className={listStyles.bundleOverall}
-      size="small"
-      column={3}
-      colon={false}
-      items={view === 'files' ? fileItems : sizeItems}
-    />
+    <div ref={containerRef}>
+      <Descriptions
+        layout={'vertical'}
+        className={listStyles.bundleOverall}
+        size="small"
+        column={width < 300 ? 2 : 3}
+        colon={false}
+        items={view === 'files' ? fileItems : sizeItems}
+      />
+    </div>
   );
 };
 
@@ -297,7 +300,7 @@ export const BundleOverall: React.FC<{
       {(res) => {
         const totalSizeStr = formatSize(res.all.total.size);
         return (
-          <Card className={cardStyles.card} style={{ height: '316px' }}>
+          <Card className={cardStyles.card} style={{ minHeight: '316px' }}>
             <div>
               <div className={styles.title}>
                 <span>{t('Bundle Overall')}</span>

--- a/packages/client/src/components/Overall/project.module.scss
+++ b/packages/client/src/components/Overall/project.module.scss
@@ -1,5 +1,6 @@
 .overview {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 12px;
   margin-bottom: 19px;
 }
@@ -20,9 +21,20 @@
   }
 }
 
-@media (max-width: 980px) {
+@container main-column (max-width: 759px) {
+  .overview > div {
+    padding: 12px 10px;
+
+    :global(.ant-avatar) {
+      width: 24px;
+      height: 24px;
+      flex-shrink: 0;
+    }
+  }
+}
+
+@container main-column (max-width: 619px) {
   .overview {
-    display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/packages/client/src/pages/BundleSize/components/card.module.scss
+++ b/packages/client/src/pages/BundleSize/components/card.module.scss
@@ -1,38 +1,34 @@
+.responsiveContainer {
+  container: bundle-summary / inline-size;
+}
+
 .container {
-  display: flex;
+  display: grid;
+  grid-template-columns: 210px minmax(0, 1fr);
   align-items: center;
-  min-width: 0;
+  gap: 20px;
   background-color: var(--color-bg-box);
-  padding: 20px 0;
+  padding: 20px;
   margin-bottom: 20px;
   border: 1px solid var(--color-border-secondary);
   border-radius: var(--border-radius-lg);
 
   .chartsContainer {
-    width: 100%;
-    min-width: 0;
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
 
-    .chart {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      min-width: 0;
-      padding: 0 clamp(8px, 1vw, 20px);
-
-      & + .chart {
-        border-left: 1px solid var(--color-border-secondary);
-      }
-    }
+  .chart {
+    min-width: 0;
+    padding: 0 clamp(12px, 1.5vw, 32px);
+    border-left: 1px solid var(--color-border-secondary);
   }
 
   .summary {
-    flex: 0 0 210px;
+    min-width: 0;
     display: flex;
     flex-direction: column;
     justify-content: center;
-    margin: 0 20px;
 
     .description {
       font-size: 20px;
@@ -60,67 +56,78 @@
   }
 }
 
-@media (max-width: 1280px) {
-  .container {
-    .chartsContainer {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      row-gap: 32px;
-
-      .chart:nth-child(odd) {
-        border-left: none;
-      }
-    }
-  }
-}
-
-@media (max-width: 980px) {
-  .container {
-    align-items: stretch;
-    flex-direction: column;
-    gap: 20px;
-    padding: 20px;
-
-    > :global(.ant-divider-vertical) {
-      display: none;
-    }
-
-    .summary {
-      flex: none;
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 12px;
-      margin: 0;
-
-      > :first-child {
-        margin-bottom: 0 !important;
-      }
-    }
-  }
-}
-
-@media (max-width: 640px) {
-  .container {
-    .summary,
-    .chartsContainer {
-      grid-template-columns: minmax(0, 1fr);
-    }
-
-    .chartsContainer .chart {
-      border-left: none;
-    }
-  }
-}
-
 .cardTitle {
   display: flex;
+  flex-wrap: wrap;
+  gap: 4px 8px;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 25px;
+  min-height: 48px;
+  margin-bottom: 12px;
 
   .title {
     font-size: 14px;
     font-weight: 500;
     line-height: 20px;
     color: var(--text-color);
+  }
+}
+
+@container bundle-summary (min-width: 1520px) {
+  .cardTitle {
+    min-height: 28px;
+    margin-bottom: 20px;
+  }
+}
+
+@container bundle-summary (max-width: 1519px) {
+  .container {
+    grid-template-columns: 190px minmax(0, 1fr);
+    gap: 12px;
+    padding: 16px 12px;
+
+    .chart {
+      padding: 0 8px;
+    }
+  }
+}
+
+@container bundle-summary (max-width: 1199px) {
+  .container {
+    grid-template-columns: minmax(0, 1fr);
+
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .chartsContainer {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 20px 0;
+    }
+
+    .chart:nth-child(odd) {
+      border-left: 0;
+    }
+  }
+}
+
+@container bundle-summary (max-width: 519px) {
+  .container {
+    .summary,
+    .chartsContainer {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .chart {
+      border-left: 0;
+    }
+  }
+}
+
+@container bundle-summary (min-width: 1200px) and (max-width: 1519px) {
+  .container .chart {
+    padding: 0 6px;
   }
 }

--- a/packages/client/src/pages/BundleSize/components/card.module.scss
+++ b/packages/client/src/pages/BundleSize/components/card.module.scss
@@ -19,6 +19,8 @@
   }
 
   .chart {
+    container: asset-card / inline-size;
+    --asset-chart-size: clamp(80px, calc(100cqw - 156px), 120px);
     min-width: 0;
     padding: 0 clamp(12px, 1.5vw, 32px);
     border-left: 1px solid var(--color-border-secondary);
@@ -57,13 +59,17 @@
 }
 
 .cardTitle {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px 8px;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: var(--asset-chart-size) minmax(0, 1fr);
+  gap: 12px;
   align-items: center;
-  min-height: 48px;
-  margin-bottom: 12px;
+  min-height: 28px;
+  margin-bottom: 16px;
+
+  > :global(.ant-segmented) {
+    justify-self: start;
+    max-width: 100%;
+  }
 
   .title {
     font-size: 14px;
@@ -73,10 +79,10 @@
   }
 }
 
-@container bundle-summary (min-width: 1520px) {
-  .cardTitle {
-    min-height: 28px;
-    margin-bottom: 20px;
+@container asset-card (max-width: 299px) {
+  .cardTitle
+    :global(.ant-segmented.ant-segmented-sm .ant-segmented-item-label) {
+    padding-inline: 2px;
   }
 }
 

--- a/packages/client/src/pages/BundleSize/components/card.module.scss
+++ b/packages/client/src/pages/BundleSize/components/card.module.scss
@@ -16,14 +16,16 @@
   .chartsContainer {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 8px;
   }
 
   .chart {
     container: asset-card / inline-size;
     --asset-chart-size: clamp(80px, calc(100cqw - 156px), 120px);
     min-width: 0;
-    padding: 0 clamp(12px, 1.5vw, 32px);
-    border-left: 1px solid var(--color-border-secondary);
+    padding: 12px clamp(8px, 1vw, 20px);
+    border: 1px solid var(--color-border-secondary);
+    border-radius: 10px;
   }
 
   .summary {
@@ -67,6 +69,7 @@
   margin-bottom: 16px;
 
   > :global(.ant-segmented) {
+    font-size: 12px;
     justify-self: start;
     max-width: 100%;
   }
@@ -93,12 +96,12 @@
     padding: 16px 12px;
 
     .chart {
-      padding: 0 8px;
+      padding: 12px 8px;
     }
   }
 }
 
-@container bundle-summary (max-width: 1199px) {
+@container bundle-summary (max-width: 879px) {
   .container {
     grid-template-columns: minmax(0, 1fr);
 
@@ -110,11 +113,7 @@
 
     .chartsContainer {
       grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 20px 0;
-    }
-
-    .chart:nth-child(odd) {
-      border-left: 0;
+      gap: 8px;
     }
   }
 }
@@ -125,15 +124,21 @@
     .chartsContainer {
       grid-template-columns: minmax(0, 1fr);
     }
-
-    .chart {
-      border-left: 0;
-    }
   }
 }
 
 @container bundle-summary (min-width: 1200px) and (max-width: 1519px) {
   .container .chart {
-    padding: 0 6px;
+    padding: 12px 6px;
+  }
+}
+
+@container asset-card (max-width: 235px) {
+  .cardTitle {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 4px;
+    min-height: 48px;
+    margin-bottom: 12px;
+    align-content: start;
   }
 }

--- a/packages/client/src/pages/BundleSize/components/cards.tsx
+++ b/packages/client/src/pages/BundleSize/components/cards.tsx
@@ -1,6 +1,6 @@
 /* rslint-disable react/jsx-key */
 import React, { memo, useState, useMemo } from 'react';
-import { Divider, Segmented, Avatar, Tree } from 'antd';
+import { Segmented, Avatar, Tree } from 'antd';
 import { Client, SDK } from '@rsdoctor/shared/types';
 import { RightOutlined, FileFilled, GoldenFilled } from '@ant-design/icons';
 
@@ -189,90 +189,91 @@ export const BundleCards: React.FC<{
       {(res) => {
         const { treeData } = getFiles(res['all'].total);
         return (
-          <div className={styles.container}>
-            <div className={styles.summary}>
-              <Overview
-                title={
-                  <TextDrawer
-                    buttonProps={{
-                      size: 'small',
-                    }}
-                    buttonStyle={{
-                      fontSize: 'inherit',
-                    }}
-                    drawerProps={{
-                      title: 'Files',
-                    }}
-                    text={
-                      <div style={{ color: 'var(--text-color-secondary)' }}>
-                        <span style={{ marginRight: '5px' }}>Total Files</span>
-                        <RightOutlined />
-                      </div>
-                    }
-                  >
-                    <DirectoryTree
-                      defaultExpandAll
-                      selectable={false}
-                      treeData={treeData}
-                      rootStyle={{
-                        minHeight: '800px',
-                        border: '1px solid var(--color-border)',
+          <div className={styles.responsiveContainer}>
+            <div className={styles.container}>
+              <div className={styles.summary}>
+                <Overview
+                  title={
+                    <TextDrawer
+                      buttonProps={{
+                        size: 'small',
                       }}
+                      buttonStyle={{
+                        fontSize: 'inherit',
+                      }}
+                      drawerProps={{
+                        title: 'Files',
+                      }}
+                      text={
+                        <div style={{ color: 'var(--text-color-secondary)' }}>
+                          <span style={{ marginRight: '5px' }}>
+                            Total Files
+                          </span>
+                          <RightOutlined />
+                        </div>
+                      }
+                    >
+                      <DirectoryTree
+                        defaultExpandAll
+                        selectable={false}
+                        treeData={treeData}
+                        rootStyle={{
+                          minHeight: '800px',
+                          border: '1px solid var(--color-border)',
+                        }}
+                      />
+                    </TextDrawer>
+                  }
+                  description={
+                    <>
+                      <span className={styles.description}>{totalSize}</span>
+                      <span className={styles.unit}>{totalSizeUnit}</span>
+                      <div className={styles.totalNumber}>
+                        <span style={{ marginRight: '7px' }}>
+                          Number of files
+                        </span>
+                        <span style={{ fontWeight: 500 }}>
+                          {summary.all.total.count}
+                        </span>
+                      </div>
+                    </>
+                  }
+                  icon={
+                    <Avatar
+                      style={{ background: '#3874F6' }}
+                      shape="circle"
+                      icon={<FileFilled style={{ fontSize: '18px' }} />}
                     />
-                  </TextDrawer>
-                }
-                description={
-                  <>
-                    <span className={styles.description}>{totalSize}</span>
-                    <span className={styles.unit}>{totalSizeUnit}</span>
-                    <div className={styles.totalNumber}>
-                      <span style={{ marginRight: '7px' }}>
-                        Number of files
-                      </span>
-                      <span style={{ fontWeight: 500 }}>
-                        {summary.all.total.count}
+                  }
+                  style={{
+                    marginBottom: '12px',
+                  }}
+                />
+                <Overview
+                  title={
+                    <div style={{ margin: '4px 0' }}>
+                      <span style={{ marginRight: '5px' }}>
+                        Duplicate Packages
                       </span>
                     </div>
-                  </>
-                }
-                icon={
-                  <Avatar
-                    style={{ background: '#3874F6' }}
-                    shape="circle"
-                    icon={<FileFilled style={{ fontSize: '18px' }} />}
-                  />
-                }
-                style={{
-                  marginBottom: '12px',
-                  minWidth: '210px',
-                }}
-              />
-              <Overview
-                style={{ minWidth: '210px' }}
-                title={
-                  <div style={{ margin: '4px 0' }}>
-                    <span style={{ marginRight: '5px' }}>
-                      Duplicate Packages
-                    </span>
+                  }
+                  description={duplicatePackages.length}
+                  icon={
+                    <Avatar
+                      style={{ background: '#13C2C2' }}
+                      shape="circle"
+                      icon={<GoldenFilled style={{ fontSize: '18px' }} />}
+                    />
+                  }
+                />
+              </div>
+              <div className={styles.chartsContainer}>
+                {arr.map((e, idx) => (
+                  <div key={idx} className={styles.chart}>
+                    {e}
                   </div>
-                }
-                description={duplicatePackages.length}
-                icon={
-                  <Avatar
-                    style={{ background: '#13C2C2' }}
-                    shape="circle"
-                    icon={<GoldenFilled style={{ fontSize: '18px' }} />}
-                  />
-                }
-              />
-            </div>
-            <Divider style={{ height: '200px' }} type="vertical" />
-            <div className={styles.chartsContainer}>
-              {arr.map((e, idx) => (
-                <div key={idx} className={styles.chart}>
-                  {e}
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
           </div>
         );

--- a/packages/client/src/pages/Overall/index.module.scss
+++ b/packages/client/src/pages/Overall/index.module.scss
@@ -20,10 +20,13 @@
 }
 
 .overall {
+  container: overall / inline-size;
   width: 100%;
 }
 
 .columns {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(280px, 1fr);
   width: 100%;
   align-items: flex-start;
   gap: 16px;
@@ -35,12 +38,10 @@
 }
 
 .mainColumn {
-  flex: 3 1 0;
+  container: main-column / inline-size;
 }
 
 .sideColumn {
-  flex: 1 1 0;
-
   :global(.ant-card) {
     background: var(--color-bg-box-subtle);
   }
@@ -52,14 +53,8 @@
   }
 }
 
-@media (max-width: 1200px) {
+@container overall (max-width: 879px) {
   .columns {
-    flex-wrap: wrap;
-  }
-
-  .mainColumn,
-  .sideColumn {
-    flex-basis: 100%;
-    width: 100%;
+    grid-template-columns: minmax(0, 1fr);
   }
 }


### PR DESCRIPTION
## Summary

- Keep bundle summary cards compact across laptop and desktop screens, sizing the layout from the report container to prevent selector overflow and chart overlap.
- Left-align selectors and metrics in a shared column, reduce percentage labels from 20px to 16px, and preserve Size/Gzip/Brotli calculations.
- Preserve alert tab clicks by capturing the pointer only after a drag starts; add browser regression coverage for tab navigation, alignment, and responsive layouts from 1280px to 2560px and within narrow report panels.

Validation on main: client and dependency builds, 34 client tests, focused browser regression, lint, and formatting passed.
- narrow screen
<img width="1100" height="850" alt="image" src="https://github.com/user-attachments/assets/1dc3d860-b9ca-4041-8271-b94706ab98d9" />
- Wide screen or normal
<img width="1920" height="850" alt="image" src="https://github.com/user-attachments/assets/842bbde8-da44-45e9-b107-7afedebfad0a" />


## Related Links

None