### PR TITLE
fix(core): skip binary Lynx bundles in ECMAScript checks

### DIFF
--- a/packages/core/src/rules/rules/ecma-version-check/index.ts
+++ b/packages/core/src/rules/rules/ecma-version-check/index.ts
@@ -49,6 +49,9 @@ export const rule: Linter.RuleData<Config, typeof title> = defineRule<
     },
     async check({ chunkGraph, report, ruleConfig, root, configs }) {
       const assets = chunkGraph.getAssets().filter((asset) => {
+        // Lynx bundles are binary containers, not JavaScript source.
+        if (asset.path.endsWith('.lynx.bundle')) return false;
+
         const extension = path.extname(asset.path);
         return extension === '.js' || extension === '.bundle';
       });

--- a/packages/core/tests/rules/ecma-version-check.test.ts
+++ b/packages/core/tests/rules/ecma-version-check.test.ts
@@ -139,6 +139,31 @@ describe('ecma-version-check rule', () => {
     expect(mocks.options).toHaveLength(0);
   });
 
+  it('skips binary Lynx bundles while checking JavaScript bundles', async () => {
+    const reports = await runRule({ ecmaVersion: 2019 }, [
+      {
+        path: 'main.lynx.bundle',
+        content: Buffer.from([0x9a, 0x7c, 0x01, 0x00]).toString(),
+      },
+      { path: 'main.js', content: 'const main = 1;' },
+      { path: 'async.bundle', content: 'const asyncChunk = 1;' },
+    ]);
+
+    expect(reports).toEqual([]);
+    expect(mocks.check.mock.calls).toEqual([
+      [path.join(outputPath, 'main.js'), 'const main = 1;'],
+      [path.join(outputPath, 'async.bundle'), 'const asyncChunk = 1;'],
+    ]);
+  });
+
+  it('does not initialize the checker for only Lynx bundles', async () => {
+    await runRule({}, [{ path: 'nested/main.lynx.bundle', content: '\u0000' }]);
+
+    expect(mocks.loadConfig).not.toHaveBeenCalled();
+    expect(mocks.options).toHaveLength(0);
+    expect(mocks.check).not.toHaveBeenCalled();
+  });
+
   it('applies output exclusions and forwards error-message exclusions', async () => {
     const excludeErrorMessage = /optional chaining/;
     await runRule({


### PR DESCRIPTION
## Motivation

Rspeedy emits binary `.lynx.bundle` files, which the ECMAScript version rule currently parses as JavaScript and incorrectly reports as E1004.

## Changes

Exclude `.lynx.bundle` assets from syntax checking while preserving checks for `.js` files and ordinary JavaScript `.bundle` files. Add regression coverage for mixed outputs and Lynx-only outputs.

Validation: core build and all 332 core tests passed. Also verified filtering against the demo's actual `main.lynx.bundle` binary.