### PR TITLE
chore(deps): remove unused dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,7 +82,6 @@
     "json-stream-stringify": "3.0.1",
     "string-loader": "0.0.1",
     "ts-loader": "^9.6.2",
-    "tslib": "catalog:",
     "typescript": "catalog:"
   },
   "peerDependencies": {

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@rspress/core": "2.0.21",
     "@rstackjs/doc-ui": "1.14.11",
-    "clsx": "catalog:",
     "react-markdown": "catalog:"
   },
   "devDependencies": {
@@ -38,7 +37,6 @@
     "cross-env": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-render-to-markdown": "^19.1.0",
     "rsbuild-plugin-google-analytics": "^1.0.6",
     "rsbuild-plugin-open-graph": "^1.1.3",
     "rspress-plugin-font-open-sans": "^1.0.4",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -71,9 +71,7 @@
   "devDependencies": {
     "@rspack/core": "catalog:",
     "@types/path-browserify": "catalog:",
-    "@types/react": "catalog:",
     "es-toolkit": "catalog:",
-    "tslib": "catalog:",
     "typescript": "catalog:"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -699,9 +699,6 @@ importers:
       ts-loader:
         specifier: ^9.6.2
         version: 9.6.2(loader-utils@3.3.1)(typescript@7.0.2)(webpack@5.105.4)
-      tslib:
-        specifier: 2.8.1
-        version: 2.8.1
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -714,9 +711,6 @@ importers:
       '@rstackjs/doc-ui':
         specifier: 1.14.11
         version: 1.14.11(@rspress/core@2.0.21(@rspack/core@2.2.2(@swc/helpers@0.5.23))(micromark-util-types@2.0.1)(micromark@4.0.1))
-      clsx:
-        specifier: 'catalog:'
-        version: 2.1.1
       react-markdown:
         specifier: 'catalog:'
         version: 10.1.0(@types/react@19.2.18)(react@19.2.8)
@@ -757,9 +751,6 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.8(react@19.2.8)
-      react-render-to-markdown:
-        specifier: ^19.1.0
-        version: 19.1.0(react@19.2.8)
       rsbuild-plugin-google-analytics:
         specifier: ^1.0.6
         version: 1.0.6(@rsbuild/core@2.2.1)
@@ -806,15 +797,9 @@ importers:
       '@types/path-browserify':
         specifier: 'catalog:'
         version: 1.0.3
-      '@types/react':
-        specifier: 'catalog:'
-        version: 19.2.18
       es-toolkit:
         specifier: 'catalog:'
         version: 1.49.0
-      tslib:
-        specifier: 2.8.1
-        version: 2.8.1
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -849,9 +834,6 @@ importers:
       '@rspack/core':
         specifier: 'catalog:'
         version: 2.1.10(@swc/helpers@0.5.23)
-      '@types/lodash':
-        specifier: ^4.17.25
-        version: 4.17.25
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.3
@@ -3330,9 +3312,6 @@ packages:
 
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
-
-  '@types/lodash@4.17.25':
-    resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -9940,8 +9919,6 @@ snapshots:
   '@types/jsonfile@6.1.4':
     dependencies:
       '@types/node': 24.12.3
-
-  '@types/lodash@4.17.25': {}
 
   '@types/mdast@4.0.4':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,16 +24,13 @@ catalog:
   '@rspack/core': ^2.1.10
   '@rspack/lite-tapable': ^1.1.5
   '@rspack/plugin-react-refresh': ^2.0.2
-  '@rspack/resolver': ^0.2.8
   '@rstest/playwright': 0.11.12
-  '@types/connect': 3.4.38
   '@types/estree': 1.0.5
   '@types/fs-extra': ^11.0.4
   '@types/node': ^24.12.3
   '@types/path-browserify': 1.0.3
   '@types/react': ^19.2.18
   '@types/react-dom': ^19.2.7
-  '@typescript/native-preview': 7.0.0-dev.20260707.2
   antd: 5.19.1
   clsx: ^2.1.1
   cross-env: ^10.1.0
@@ -50,7 +47,6 @@ catalog:
   react-router-dom: 6.30.3
   sirv: 3.0.2
   source-map: ^0.7.6
-  tslib: 2.8.1
   typescript: ^7.0.2
 
 minimumReleaseAge: 1440

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@rsbuild/core": "catalog:",
     "@rspack/core": "catalog:",
-    "@types/lodash": "^4.17.25",
     "@types/node": "catalog:",
     "es-toolkit": "catalog:",
     "memfs": "4.57.8",


### PR DESCRIPTION
## Motivation

Unused direct dependencies and stale catalog entries add maintenance overhead after earlier code and tooling changes.

## Changes

Remove six unused dependency declarations: `tslib` from core and shared, `@types/react` from shared, `@types/lodash` from test-helper, and `clsx` / `react-render-to-markdown` from the documentation package. Rspress provides its own dependencies for the latter two. Remove four unused catalog entries and regenerate the lockfile without upgrading packages.

Validated on the latest main with the workspace build, documentation build, lint, dependency version consistency check, and all 519 unit tests.