### PR TITLE
release: v1.6.4

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/mcp-server",
-  "version": "0.1.3",
+  "version": "1.6.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/cli",
-  "version": "1.6.1",
+  "version": "1.6.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/client",
-  "version": "1.6.1",
+  "version": "1.6.4",
   "main": "dist/index.html",
   "repository": {
     "type": "git",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/components",
-  "version": "1.6.1",
+  "version": "1.6.4",
   "license": "MIT",
   "types": "dist/index.d.ts",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/core",
-  "version": "1.6.1",
+  "version": "1.6.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/docs",
-  "version": "1.6.1",
+  "version": "1.6.4",
   "scripts": {
     "dev": "cross-env RSPRESS_PERSIST_CACHE=false rspress dev",
     "build": "cross-env RSPRESS_PERSIST_CACHE=false rspress build && sh build.sh",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/graph",
-  "version": "1.6.1",
+  "version": "1.6.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/rspack-plugin/package.json
+++ b/packages/rspack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/rspack-plugin",
-  "version": "1.6.1",
+  "version": "1.6.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/sdk",
-  "version": "1.6.1",
+  "version": "1.6.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/types",
-  "version": "1.6.1",
+  "version": "1.6.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/utils",
-  "version": "1.6.1",
+  "version": "1.6.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/webpack-plugin",
-  "version": "1.6.1",
+  "version": "1.6.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",


### PR DESCRIPTION
## Motivation

Prepare the v1.6.4 release.

## Changes

Update the fixed `@rsdoctor/*` package group to `1.6.4`. `@rsdoctor/agent-cli` remains independently versioned.

Release: https://github.com/web-infra-dev/rsdoctor/releases/tag/v1.6.4