### PR TITLE
release: v2.0.0-beta.3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/cli",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/client",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/core",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/docs",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsdoctor/shared",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsdoctor",


### PR DESCRIPTION
## Motivation

Prepare the [v2.0.0-beta.3 release](https://github.com/web-infra-dev/rsdoctor/releases/tag/v2.0.0-beta.3).

## Changes

Bump the fixed-version package group (`cli`, `client`, `core`, `docs`, and `shared`) to `2.0.0-beta.3`. Keep `@rsdoctor/agent-cli` at its independent version `0.1.0`.

Verified package versions and ran `pnpm install --lockfile-only`; no lockfile changes were required.